### PR TITLE
Add missed leader election rbac rules

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,6 +31,42 @@ rules:
   - list
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - ""
   resources:
   - pods

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -24,6 +24,12 @@ import (
 	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 )
 
+// The following RBAC rules are for leader election
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;update;list;watch;create;patch;delete
+//+kubebuilder:rbac:groups=core,resources=configmaps/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;get;list;update
+
 var (
 	scheme = runtime.NewScheme()
 )


### PR DESCRIPTION
Since we're generating the RBAC rules required for the controller to function, these should ideally wind up in the generated policy as well, as you can't run the controller without them.