### PR TITLE
Add header manipulation for service splits

### DIFF
--- a/internal/adapters/consul/sync.go
+++ b/internal/adapters/consul/sync.go
@@ -96,8 +96,12 @@ func httpRouteDiscoveryChain(route core.HTTPRoute) (*api.ServiceRouterConfigEntr
 				if service.Weight == 0 {
 					continue
 				}
+
+				modifier := httpRouteFiltersToServiceRouteHeaderModifier(service.Filters)
+
 				split := api.ServiceSplit{
-					Weight: float32(service.Weight) / float32(totalWeight),
+					RequestHeaders: modifier,
+					Weight:         float32(service.Weight) / float32(totalWeight),
 				}
 				split.Service = service.Service.Service
 				splitter.Splits = append(splitter.Splits, split)


### PR DESCRIPTION
Quick addition to https://github.com/hashicorp/consul-api-gateway/pull/27 -- forgot the addition of header modification for backendrefs (i.e. header modification in our splitters). This adds it.