### PR TITLE
Update to released v1alpha2 from rc1

### DIFF
--- a/dev/getting-started.md
+++ b/dev/getting-started.md
@@ -36,7 +36,7 @@ kind: GatewayClass
 metadata:
   name: test-gateway-class
 spec:
-  controller: "hashicorp.com/consul-api-gateway-controller"
+  controllerName: "hashicorp.com/consul-api-gateway-controller"
   parametersRef:
     group: api-gateway.consul.hashicorp.com
     kind: GatewayClassConfig
@@ -57,8 +57,8 @@ spec:
       namespaces:
         from: Same
     tls:
-      certificateRef:
-        name: consul-server-cert
+      certificateRefs:
+        - name: consul-server-cert
 ---
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults

--- a/go.mod
+++ b/go.mod
@@ -25,5 +25,5 @@ require (
 	k8s.io/client-go v0.22.1
 	k8s.io/klog/v2 v2.10.0
 	sigs.k8s.io/controller-runtime v0.9.6
-	sigs.k8s.io/gateway-api v0.4.0-rc1
+	sigs.k8s.io/gateway-api v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1050,8 +1050,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.19/go.mod h1:LEScyz
 sigs.k8s.io/controller-runtime v0.9.6 h1:EevVMlgUj4fC1NVM4+DB3iPkWkmGRNarA66neqv9Qew=
 sigs.k8s.io/controller-runtime v0.9.6/go.mod h1:q6PpkM5vqQubEKUKOM6qr06oXGzOBcCby1DA9FbyZeA=
 sigs.k8s.io/controller-tools v0.6.2/go.mod h1:oaeGpjXn6+ZSEIQkUe/+3I40PNiDYp9aeawbt3xTgJ8=
-sigs.k8s.io/gateway-api v0.4.0-rc1 h1:62r2bgzU9eZmetVZo3Gpwo6IuDWkzJd6pCS4aMyGtQg=
-sigs.k8s.io/gateway-api v0.4.0-rc1/go.mod h1:r3eiNP+0el+NTLwaTfOrCNXy8TukC+dIM3ggc+fbNWk=
+sigs.k8s.io/gateway-api v0.4.0 h1:07IJkTt21NetZTHtPKJk2I4XIgDN4BAlTIq1wK7V11o=
+sigs.k8s.io/gateway-api v0.4.0/go.mod h1:r3eiNP+0el+NTLwaTfOrCNXy8TukC+dIM3ggc+fbNWk=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/internal/k8s/controllers/gateway_class_controller.go
+++ b/internal/k8s/controllers/gateway_class_controller.go
@@ -47,7 +47,7 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	if string(gc.Spec.Controller) != r.ControllerName {
+	if string(gc.Spec.ControllerName) != r.ControllerName {
 		// no-op if we don't manage this gateway class
 		return ctrl.Result{}, nil
 	}

--- a/internal/k8s/controllers/gateway_class_controller_test.go
+++ b/internal/k8s/controllers/gateway_class_controller_test.go
@@ -55,7 +55,7 @@ func TestGatewayClass(t *testing.T) {
 		expectationCB: func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager) {
 			client.EXPECT().GetGatewayClass(gomock.Any(), className).Return(&gateway.GatewayClass{
 				Spec: gateway.GatewayClassSpec{
-					Controller: gateway.GatewayController("other"),
+					ControllerName: gateway.GatewayController("other"),
 				},
 			}, nil)
 		},
@@ -69,7 +69,7 @@ func TestGatewayClass(t *testing.T) {
 					DeletionTimestamp: &now,
 				},
 				Spec: gateway.GatewayClassSpec{
-					Controller: gateway.GatewayController(mockControllerName),
+					ControllerName: gateway.GatewayController(mockControllerName),
 				},
 			}, nil)
 			client.EXPECT().GatewayClassInUse(gomock.Any(), gomock.Any()).Return(false, errExpected)
@@ -84,7 +84,7 @@ func TestGatewayClass(t *testing.T) {
 					DeletionTimestamp: &now,
 				},
 				Spec: gateway.GatewayClassSpec{
-					Controller: gateway.GatewayController(mockControllerName),
+					ControllerName: gateway.GatewayController(mockControllerName),
 				},
 			}, nil)
 			client.EXPECT().GatewayClassInUse(gomock.Any(), gomock.Any()).Return(true, nil)
@@ -99,7 +99,7 @@ func TestGatewayClass(t *testing.T) {
 					DeletionTimestamp: &now,
 				},
 				Spec: gateway.GatewayClassSpec{
-					Controller: gateway.GatewayController(mockControllerName),
+					ControllerName: gateway.GatewayController(mockControllerName),
 				},
 			}, nil)
 			client.EXPECT().GatewayClassInUse(gomock.Any(), gomock.Any()).Return(false, nil)
@@ -114,7 +114,7 @@ func TestGatewayClass(t *testing.T) {
 					DeletionTimestamp: &now,
 				},
 				Spec: gateway.GatewayClassSpec{
-					Controller: gateway.GatewayController(mockControllerName),
+					ControllerName: gateway.GatewayController(mockControllerName),
 				},
 			}, nil)
 			client.EXPECT().GatewayClassInUse(gomock.Any(), gomock.Any()).Return(false, nil)
@@ -126,7 +126,7 @@ func TestGatewayClass(t *testing.T) {
 		expectationCB: func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager) {
 			client.EXPECT().GetGatewayClass(gomock.Any(), className).Return(&gateway.GatewayClass{
 				Spec: gateway.GatewayClassSpec{
-					Controller: gateway.GatewayController(mockControllerName),
+					ControllerName: gateway.GatewayController(mockControllerName),
 				},
 			}, nil)
 			client.EXPECT().EnsureFinalizer(gomock.Any(), gomock.Any(), gatewayClassFinalizer).Return(false, errExpected)
@@ -136,7 +136,7 @@ func TestGatewayClass(t *testing.T) {
 		expectationCB: func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager) {
 			client.EXPECT().GetGatewayClass(gomock.Any(), className).Return(&gateway.GatewayClass{
 				Spec: gateway.GatewayClassSpec{
-					Controller: gateway.GatewayController(mockControllerName),
+					ControllerName: gateway.GatewayController(mockControllerName),
 				},
 			}, nil)
 			client.EXPECT().EnsureFinalizer(gomock.Any(), gomock.Any(), gatewayClassFinalizer).Return(true, nil)
@@ -147,7 +147,7 @@ func TestGatewayClass(t *testing.T) {
 		expectationCB: func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager) {
 			client.EXPECT().GetGatewayClass(gomock.Any(), className).Return(&gateway.GatewayClass{
 				Spec: gateway.GatewayClassSpec{
-					Controller: gateway.GatewayController(mockControllerName),
+					ControllerName: gateway.GatewayController(mockControllerName),
 				},
 			}, nil)
 			client.EXPECT().EnsureFinalizer(gomock.Any(), gomock.Any(), gatewayClassFinalizer).Return(false, nil)

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -102,7 +102,7 @@ func (g *gatewayClient) GatewayClassInUse(ctx context.Context, gc *gateway.Gatew
 		return false, NewK8sError(err)
 	}
 	for _, g := range list.Items {
-		if g.Spec.GatewayClassName == gc.Name {
+		if string(g.Spec.GatewayClassName) == gc.Name {
 			return true, nil
 		}
 	}
@@ -307,7 +307,7 @@ func (g *gatewayClient) GetConfigForGatewayClassName(ctx context.Context, name s
 	if err != nil {
 		return apigwv1alpha1.GatewayClassConfig{}, false, NewK8sError(err)
 	}
-	if class.Spec.Controller != gateway.GatewayController(g.controllerName) {
+	if class.Spec.ControllerName != gateway.GatewayController(g.controllerName) {
 		// we're not owned by this controller, so pretend we don't exist
 		return apigwv1alpha1.GatewayClassConfig{}, false, NewK8sError(err)
 	}

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -35,7 +35,7 @@ func TestGatewayValidate(t *testing.T) {
 				Hostname: &hostname,
 				Protocol: gw.HTTPSProtocolType,
 				TLS: &gw.GatewayTLSConfig{
-					CertificateRef: &gw.SecretObjectReference{},
+					CertificateRefs: []*gw.SecretObjectReference{{}},
 				},
 			}},
 		},

--- a/internal/k8s/reconciler/http_route.go
+++ b/internal/k8s/reconciler/http_route.go
@@ -160,8 +160,8 @@ func convertHTTPRouteFilters(routeFilters []gw.HTTPRouteFilter) []core.HTTPFilte
 			})
 		case gw.HTTPRouteFilterRequestRedirect:
 			scheme := ""
-			if filter.RequestRedirect.Protocol != nil {
-				scheme = *filter.RequestRedirect.Protocol
+			if filter.RequestRedirect.Scheme != nil {
+				scheme = *filter.RequestRedirect.Scheme
 			}
 			hostname := ""
 			if filter.RequestRedirect.Hostname != nil {

--- a/internal/k8s/reconciler/http_route_test.go
+++ b/internal/k8s/reconciler/http_route_test.go
@@ -62,8 +62,8 @@ func TestConvertHTTPRoute(t *testing.T) {
 					}},
 					Filters: []gw.HTTPRouteFilter{{
 						Type: gw.HTTPRouteFilterRequestRedirect,
-						RequestRedirect: &gw.HTTPRequestRedirect{
-							Protocol:   &protocol,
+						RequestRedirect: &gw.HTTPRequestRedirectFilter{
+							Scheme:     &protocol,
 							Hostname:   &hostname,
 							Port:       &port,
 							StatusCode: &statusCode,

--- a/internal/k8s/reconciler/listener.go
+++ b/internal/k8s/reconciler/listener.go
@@ -104,12 +104,13 @@ func (l *K8sListener) validateTLS(ctx context.Context) error {
 		return nil
 	}
 
-	if l.listener.TLS.CertificateRef == nil {
+	if len(l.listener.TLS.CertificateRefs) == 0 {
 		l.status.ResolvedRefs.InvalidCertificateRef = errors.New("certificate reference must be set")
 		return nil
 	}
 
-	ref := *l.listener.TLS.CertificateRef
+	// we only support a single certificate for now
+	ref := *l.listener.TLS.CertificateRefs[0]
 	resource, err := l.resolveCertificateReference(ctx, ref)
 	if err != nil {
 		var certificateErr CertificateResolutionError
@@ -189,14 +190,14 @@ func (l *K8sListener) resolveCertificateReference(ctx context.Context, ref gw.Se
 
 	switch {
 	case kind == "Secret" && group == corev1.GroupName:
-		cert, err := l.client.GetSecret(ctx, types.NamespacedName{Name: ref.Name, Namespace: namespace})
+		cert, err := l.client.GetSecret(ctx, types.NamespacedName{Name: string(ref.Name), Namespace: namespace})
 		if err != nil {
 			return "", fmt.Errorf("error fetching secret: %w", err)
 		}
 		if cert == nil {
 			return "", NewCertificateResolutionErrorNotFound("certificate not found")
 		}
-		return utils.NewK8sSecret(namespace, ref.Name).String(), nil
+		return utils.NewK8sSecret(namespace, string(ref.Name)).String(), nil
 	// add more supported types here
 	default:
 		return "", NewCertificateResolutionErrorUnsupported(fmt.Sprintf("unsupported certificate type - group: %s, kind: %s", group, kind))

--- a/internal/k8s/reconciler/listener_test.go
+++ b/internal/k8s/reconciler/listener_test.go
@@ -112,9 +112,9 @@ func TestListenerValidate(t *testing.T) {
 	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
 		Protocol: gw.HTTPSProtocolType,
 		TLS: &gw.GatewayTLSConfig{
-			CertificateRef: &gw.SecretObjectReference{
+			CertificateRefs: []*gw.SecretObjectReference{{
 				Name: "secret",
-			},
+			}},
 		},
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
@@ -126,9 +126,9 @@ func TestListenerValidate(t *testing.T) {
 	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
 		Protocol: gw.HTTPSProtocolType,
 		TLS: &gw.GatewayTLSConfig{
-			CertificateRef: &gw.SecretObjectReference{
+			CertificateRefs: []*gw.SecretObjectReference{{
 				Name: "secret",
-			},
+			}},
 		},
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
@@ -142,9 +142,9 @@ func TestListenerValidate(t *testing.T) {
 	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
 		Protocol: gw.HTTPSProtocolType,
 		TLS: &gw.GatewayTLSConfig{
-			CertificateRef: &gw.SecretObjectReference{
+			CertificateRefs: []*gw.SecretObjectReference{{
 				Name: "secret",
-			},
+			}},
 		},
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
@@ -165,12 +165,12 @@ func TestListenerValidate(t *testing.T) {
 	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
 		Protocol: gw.HTTPSProtocolType,
 		TLS: &gw.GatewayTLSConfig{
-			CertificateRef: &gw.SecretObjectReference{
+			CertificateRefs: []*gw.SecretObjectReference{{
 				Namespace: &namespace,
 				Group:     &group,
 				Kind:      &kind,
 				Name:      "secret",
-			},
+			}},
 		},
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),

--- a/internal/k8s/reconciler/manager.go
+++ b/internal/k8s/reconciler/manager.go
@@ -93,8 +93,10 @@ func (m *GatewayReconcileManager) UpsertGateway(ctx context.Context, g *gw.Gatew
 
 	var err error
 
+	gatewayClassName := string(g.Spec.GatewayClassName)
+
 	// first check our cache to see if we have a known configuration
-	config, managed := m.gatewayClasses.GetConfig(g.Spec.GatewayClassName)
+	config, managed := m.gatewayClasses.GetConfig(gatewayClassName)
 	if !managed {
 		// next check to see if we have an existing deployment, if we do, we manage the gateway
 		// and can just use an empty config since we won't re-deploy
@@ -104,7 +106,7 @@ func (m *GatewayReconcileManager) UpsertGateway(ctx context.Context, g *gw.Gatew
 		}
 		if !managed {
 			// finally, see if we can run through all of the relationships and retrieve the config
-			config, managed, err = m.client.GetConfigForGatewayClassName(ctx, g.Spec.GatewayClassName)
+			config, managed, err = m.client.GetConfigForGatewayClassName(ctx, gatewayClassName)
 			if err != nil {
 				return err
 			}

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -139,9 +139,9 @@ func (r *K8sRoute) ParentStatuses() []gw.RouteParentStatus {
 	statuses := []gw.RouteParentStatus{}
 	for ref, status := range r.parentStatuses {
 		statuses = append(statuses, gw.RouteParentStatus{
-			ParentRef:  parseParent(ref),
-			Controller: gw.GatewayController(r.controllerName),
-			Conditions: status.Conditions(r.GetGeneration()),
+			ParentRef:      parseParent(ref),
+			ControllerName: gw.GatewayController(r.controllerName),
+			Conditions:     status.Conditions(r.GetGeneration()),
 		})
 	}
 	return statuses
@@ -150,7 +150,7 @@ func (r *K8sRoute) ParentStatuses() []gw.RouteParentStatus {
 func (r *K8sRoute) FilterParentStatuses() []gw.RouteParentStatus {
 	filtered := []gw.RouteParentStatus{}
 	for _, status := range r.routeStatus().Parents {
-		if status.Controller != gw.GatewayController(r.controllerName) {
+		if status.ControllerName != gw.GatewayController(r.controllerName) {
 			filtered = append(filtered, status)
 			continue
 		}

--- a/internal/k8s/reconciler/route_test.go
+++ b/internal/k8s/reconciler/route_test.go
@@ -103,17 +103,17 @@ func TestRouteFilterParentStatuses(t *testing.T) {
 					ParentRef: gw.ParentRef{
 						Name: "expected",
 					},
-					Controller: "expected",
+					ControllerName: "expected",
 				}, {
 					ParentRef: gw.ParentRef{
 						Name: "expected",
 					},
-					Controller: "other",
+					ControllerName: "other",
 				}, {
 					ParentRef: gw.ParentRef{
 						Name: "other",
 					},
-					Controller: "other",
+					ControllerName: "other",
 				}},
 			},
 		},
@@ -132,10 +132,10 @@ func TestRouteFilterParentStatuses(t *testing.T) {
 
 	statuses := route.FilterParentStatuses()
 	require.Len(t, statuses, 2)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "other", string(statuses[0].Controller))
-	require.Equal(t, "other", statuses[1].ParentRef.Name)
-	require.Equal(t, "other", string(statuses[1].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "other", string(statuses[0].ControllerName))
+	require.Equal(t, "other", string(statuses[1].ParentRef.Name))
+	require.Equal(t, "other", string(statuses[1].ControllerName))
 }
 
 func TestRouteMergedStatusAndBinding(t *testing.T) {
@@ -164,17 +164,17 @@ func TestRouteMergedStatusAndBinding(t *testing.T) {
 					ParentRef: gw.ParentRef{
 						Name: "expected",
 					},
-					Controller: "expected",
+					ControllerName: "expected",
 				}, {
 					ParentRef: gw.ParentRef{
 						Name: "expected",
 					},
-					Controller: "other",
+					ControllerName: "other",
 				}, {
 					ParentRef: gw.ParentRef{
 						Name: "other",
 					},
-					Controller: "other",
+					ControllerName: "other",
 				}},
 			},
 		},
@@ -188,21 +188,21 @@ func TestRouteMergedStatusAndBinding(t *testing.T) {
 
 	statuses := route.MergedStatus().Parents
 	require.Len(t, statuses, 3)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "expected", string(statuses[0].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "expected", string(statuses[0].ControllerName))
 	require.Len(t, statuses[0].Conditions, 2)
 	require.Equal(t, "Route accepted.", statuses[0].Conditions[0].Message)
-	require.Equal(t, "expected", statuses[1].ParentRef.Name)
-	require.Equal(t, "other", string(statuses[1].Controller))
-	require.Equal(t, "other", statuses[2].ParentRef.Name)
-	require.Equal(t, "other", string(statuses[2].Controller))
+	require.Equal(t, "expected", string(statuses[1].ParentRef.Name))
+	require.Equal(t, "other", string(statuses[1].ControllerName))
+	require.Equal(t, "other", string(statuses[2].ParentRef.Name))
+	require.Equal(t, "other", string(statuses[2].ControllerName))
 
 	route.OnBindFailed(errors.New("expected"), gateway)
 
 	statuses = route.MergedStatus().Parents
 	require.Len(t, statuses, 3)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "expected", string(statuses[0].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "expected", string(statuses[0].ControllerName))
 	require.Equal(t, "expected", statuses[0].Conditions[0].Message)
 	require.Equal(t, RouteConditionReasonBindError, statuses[0].Conditions[0].Reason)
 
@@ -210,8 +210,8 @@ func TestRouteMergedStatusAndBinding(t *testing.T) {
 
 	statuses = route.MergedStatus().Parents
 	require.Len(t, statuses, 3)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "expected", string(statuses[0].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "expected", string(statuses[0].ControllerName))
 	require.Equal(t, "expected", statuses[0].Conditions[0].Message)
 	require.Equal(t, RouteConditionReasonListenerHostnameMismatch, statuses[0].Conditions[0].Reason)
 
@@ -219,8 +219,8 @@ func TestRouteMergedStatusAndBinding(t *testing.T) {
 
 	statuses = route.MergedStatus().Parents
 	require.Len(t, statuses, 3)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "expected", string(statuses[0].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "expected", string(statuses[0].ControllerName))
 	require.Equal(t, "expected", statuses[0].Conditions[0].Message)
 	require.Equal(t, RouteConditionReasonListenerNamespacePolicy, statuses[0].Conditions[0].Reason)
 
@@ -228,8 +228,8 @@ func TestRouteMergedStatusAndBinding(t *testing.T) {
 
 	statuses = route.MergedStatus().Parents
 	require.Len(t, statuses, 3)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "expected", string(statuses[0].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "expected", string(statuses[0].ControllerName))
 	require.Equal(t, "expected", statuses[0].Conditions[0].Message)
 	require.Equal(t, RouteConditionReasonInvalidRouteKind, statuses[0].Conditions[0].Reason)
 
@@ -237,18 +237,18 @@ func TestRouteMergedStatusAndBinding(t *testing.T) {
 
 	statuses = route.MergedStatus().Parents
 	require.Len(t, statuses, 3)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "expected", string(statuses[0].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "expected", string(statuses[0].ControllerName))
 	require.Equal(t, "Route accepted.", statuses[0].Conditions[0].Message)
 
 	route.OnGatewayRemoved(gateway)
 
 	statuses = route.MergedStatus().Parents
 	require.Len(t, statuses, 2)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "other", string(statuses[0].Controller))
-	require.Equal(t, "other", statuses[1].ParentRef.Name)
-	require.Equal(t, "other", string(statuses[1].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "other", string(statuses[0].ControllerName))
+	require.Equal(t, "other", string(statuses[1].ParentRef.Name))
+	require.Equal(t, "other", string(statuses[1].ControllerName))
 
 	// check creating a status on bind failure when it's not there
 	route = NewK8sRoute(inner, K8sRouteConfig{
@@ -260,8 +260,8 @@ func TestRouteMergedStatusAndBinding(t *testing.T) {
 
 	statuses = route.MergedStatus().Parents
 	require.Len(t, statuses, 3)
-	require.Equal(t, "expected", statuses[0].ParentRef.Name)
-	require.Equal(t, "expected", string(statuses[0].Controller))
+	require.Equal(t, "expected", string(statuses[0].ParentRef.Name))
+	require.Equal(t, "expected", string(statuses[0].ControllerName))
 	require.Equal(t, "expected", statuses[0].Conditions[0].Message)
 	require.Equal(t, RouteConditionReasonBindError, statuses[0].Conditions[0].Reason)
 
@@ -302,17 +302,17 @@ func TestRouteNeedsStatusUpdate(t *testing.T) {
 					ParentRef: gw.ParentRef{
 						Name: "expected",
 					},
-					Controller: "expected",
+					ControllerName: "expected",
 				}, {
 					ParentRef: gw.ParentRef{
 						Name: "expected",
 					},
-					Controller: "other",
+					ControllerName: "other",
 				}, {
 					ParentRef: gw.ParentRef{
 						Name: "other",
 					},
-					Controller: "other",
+					ControllerName: "other",
 				}},
 			},
 		},
@@ -629,17 +629,17 @@ func TestRouteSyncStatus(t *testing.T) {
 					ParentRef: gw.ParentRef{
 						Name: "expected",
 					},
-					Controller: "expected",
+					ControllerName: "expected",
 				}, {
 					ParentRef: gw.ParentRef{
 						Name: "expected",
 					},
-					Controller: "other",
+					ControllerName: "other",
 				}, {
 					ParentRef: gw.ParentRef{
 						Name: "other",
 					},
-					Controller: "other",
+					ControllerName: "other",
 				}},
 			},
 		},

--- a/internal/k8s/reconciler/utils.go
+++ b/internal/k8s/reconciler/utils.go
@@ -210,7 +210,7 @@ func listenerStatusesEqual(a, b []gw.ListenerStatus) bool {
 }
 
 func parentStatusEqual(a, b gw.RouteParentStatus) bool {
-	if a.Controller != b.Controller {
+	if a.ControllerName != b.ControllerName {
 		return false
 	}
 	if asJSON(a.ParentRef) != asJSON(b.ParentRef) {

--- a/internal/k8s/reconciler/utils_test.go
+++ b/internal/k8s/reconciler/utils_test.go
@@ -342,7 +342,7 @@ func TestParentStatusEqual(t *testing.T) {
 
 	require.True(t, parentStatusEqual(gw.RouteParentStatus{}, gw.RouteParentStatus{}))
 	require.False(t, parentStatusEqual(gw.RouteParentStatus{}, gw.RouteParentStatus{
-		Controller: "other",
+		ControllerName: "other",
 	}))
 	require.False(t, parentStatusEqual(gw.RouteParentStatus{}, gw.RouteParentStatus{
 		ParentRef: gw.ParentRef{

--- a/internal/k8s/service/resolver.go
+++ b/internal/k8s/service/resolver.go
@@ -207,7 +207,7 @@ func (r *backendResolver) Resolve(ctx context.Context, ref gw.BackendObjectRefer
 	if ref.Namespace != nil {
 		namespace = string(*ref.Namespace)
 	}
-	namespacedName := types.NamespacedName{Name: ref.Name, Namespace: namespace}
+	namespacedName := types.NamespacedName{Name: string(ref.Name), Namespace: namespace}
 
 	switch {
 	case group == corev1.GroupName && kind == "Service":

--- a/internal/k8s/utils/reference.go
+++ b/internal/k8s/utils/reference.go
@@ -21,5 +21,5 @@ func ReferencesGateway(namespace string, ref gw.ParentRef) (types.NamespacedName
 	if ref.Namespace != nil {
 		namespace = string(*ref.Namespace)
 	}
-	return types.NamespacedName{Name: ref.Name, Namespace: namespace}, true
+	return types.NamespacedName{Name: string(ref.Name), Namespace: namespace}, true
 }

--- a/scripts/develop
+++ b/scripts/develop
@@ -49,7 +49,7 @@ EOF
 
 installGatewayCRDs() {
   echo "Installing Gateway CRDs"
-  kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0-rc1" | kubectl apply -f -  2>&1 > /dev/null
+  kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -  2>&1 > /dev/null
 }
 
 createServiceAccountForRBAC() {


### PR DESCRIPTION
A surprising number of things changed between rc1 and the release:

1. The `GatewayClass` spec field `controller` was renamed to `controllerName`
2. The route parent status `controller` field was renamed to `controllerName`
3. Listeners can reference multiple certificates (we only support a single Kubernetes Secret reference, since that has core spec support)
4. Redirect filters' `protocol` field was renamed to `scheme`
5. Some structure names (i.e. `HTTPRequestRedirect`) were changed and a number of fields are now typed as the string type-alias `ObjectName` (so even more casting! 😬)

This updates the go dependency to reference the stable `v0.4.0` release, updates the development script to install the same version of the CRDs, and updates our `getting-started.md` to reference the changed fields accordingly.