### PR TITLE
Normalize weight on service splitters

### DIFF
--- a/internal/adapters/consul/sync.go
+++ b/internal/adapters/consul/sync.go
@@ -107,9 +107,10 @@ func httpRouteDiscoveryChain(route core.HTTPRoute) (*api.ServiceRouterConfigEntr
 
 				modifier := httpRouteFiltersToServiceRouteHeaderModifier(service.Filters)
 
+				weightPercentage := float32(service.Weight) / float32(totalWeight)
 				split := api.ServiceSplit{
 					RequestHeaders: modifier,
-					Weight:         float32(service.Weight) / float32(totalWeight),
+					Weight:         weightPercentage * 100,
 				}
 				split.Service = service.Service.Service
 				split.Namespace = service.Service.ConsulNamespace

--- a/internal/adapters/consul/testdata/multiple-rules.golden.json
+++ b/internal/adapters/consul/testdata/multiple-rules.golden.json
@@ -87,7 +87,7 @@
       "Namespace": "k8s",
       "Splits": [
         {
-          "Weight": 0.5,
+          "Weight": 50,
           "Service": "service",
           "Namespace": "namespace",
           "RequestHeaders": {
@@ -103,7 +103,7 @@
           }
         },
         {
-          "Weight": 0.5,
+          "Weight": 50,
           "Service": "another-service",
           "Namespace": "namespace",
           "RequestHeaders": {
@@ -125,7 +125,7 @@
       "Namespace": "k8s",
       "Splits": [
         {
-          "Weight": 0.5,
+          "Weight": 50,
           "Service": "service",
           "Namespace": "namespace",
           "RequestHeaders": {
@@ -141,7 +141,7 @@
           }
         },
         {
-          "Weight": 0.5,
+          "Weight": 50,
           "Service": "another-service",
           "Namespace": "namespace",
           "RequestHeaders": {

--- a/internal/adapters/consul/testdata/multiple-services.golden.json
+++ b/internal/adapters/consul/testdata/multiple-services.golden.json
@@ -39,7 +39,7 @@
       "Namespace": "k8s",
       "Splits": [
         {
-          "Weight": 0.5,
+          "Weight": 50,
           "Service": "service",
           "Namespace": "namespace",
           "RequestHeaders": {
@@ -55,7 +55,7 @@
           }
         },
         {
-          "Weight": 0.5,
+          "Weight": 50,
           "Service": "another-service",
           "Namespace": "namespace",
           "RequestHeaders": {


### PR DESCRIPTION
This is where having a full e2e test for services involving splitters + weights would be nice since the unit tests just check output rather than validating the configurations themselves within Consul.

Was reading through the docs on service splitters again and noticed that [under weight](https://www.consul.io/docs/connect/config-entries/service-splitter#weight) we see:

> A value between 0 and 100 reflecting what portion of traffic should be directed to this split. The smallest representable eight is 1/10000 or .01%

In other words, it's not a percentage in decimal form, but rather a percentage normalized to a float between 0-100, meaning we need to multiply all of our weight percentages by 100 (since the K8s spec and our internal model all assume arbitrary weighting that's calculated relative to the other attached routes).