### PR TITLE
E2E Routing Test

### DIFF
--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -4,6 +4,9 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -14,6 +17,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
@@ -94,12 +98,12 @@ func TestGatewayBasic(t *testing.T) {
 				return true
 			}, 30*time.Second, 1*time.Second, "no deployment found in the allotted time")
 
+			created := &gateway.Gateway{}
 			require.Eventually(t, func() bool {
-				updated := &gateway.Gateway{}
-				if err := resources.Get(ctx, gatewayName, namespace, updated); err != nil {
+				if err := resources.Get(ctx, gatewayName, namespace, created); err != nil {
 					return false
 				}
-				for _, condition := range updated.Status.Conditions {
+				for _, condition := range created.Status.Conditions {
 					if condition.Type == "Accepted" ||
 						condition.Status == "True" {
 						return true
@@ -122,6 +126,17 @@ func TestGatewayBasic(t *testing.T) {
 				status := service.Checks.AggregatedStatus()
 				return status == "passing"
 			}, 30*time.Second, 1*time.Second, "no healthy consul service found in the allotted time")
+
+			err = resources.Delete(ctx, created)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				services, _, err := client.Catalog().Service(gatewayName, "", nil)
+				if err != nil {
+					return false
+				}
+				return len(services) == 0
+			}, 30*time.Second, 1*time.Second, "consul service not deregistered in the allotted time")
 
 			return ctx
 		})
@@ -207,6 +222,145 @@ func TestServiceListeners(t *testing.T) {
 	testenv.Test(t, feature.Feature())
 }
 
+func TestMeshService(t *testing.T) {
+	feature := features.New("mesh service routing").
+		Assess("basic routing", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			service, err := e2e.DeployMeshService(ctx, cfg)
+			require.NoError(t, err)
+
+			namespace := e2e.Namespace(ctx)
+			configName := envconf.RandomName("gcc", 16)
+			className := envconf.RandomName("gc", 16)
+			gatewayName := envconf.RandomName("gw", 16)
+			routeName := envconf.RandomName("route", 16)
+
+			gatewayNamespace := gateway.Namespace(namespace)
+			resources := cfg.Client().Resources(namespace)
+
+			gcc := &apigwv1alpha1.GatewayClassConfig{
+				ObjectMeta: meta.ObjectMeta{
+					Name: configName,
+				},
+				Spec: apigwv1alpha1.GatewayClassConfigSpec{
+					ImageSpec: apigwv1alpha1.ImageSpec{
+						ConsulAPIGateway: e2e.DockerImage(ctx),
+					},
+					UseHostPorts: true,
+					LogLevel:     "trace",
+					ConsulSpec: apigwv1alpha1.ConsulSpec{
+						Address: "host.docker.internal",
+						Scheme:  "https",
+						PortSpec: apigwv1alpha1.PortSpec{
+							GRPC: e2e.ConsulGRPCPort(ctx),
+							HTTP: e2e.ConsulHTTPPort(ctx),
+						},
+						AuthSpec: apigwv1alpha1.AuthSpec{
+							Method:  "consul-api-gateway",
+							Account: "consul-api-gateway",
+						},
+					},
+				},
+			}
+			err = resources.Create(ctx, gcc)
+			require.NoError(t, err)
+
+			gc := &gateway.GatewayClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: className,
+				},
+				Spec: gateway.GatewayClassSpec{
+					ControllerName: k8s.ControllerName,
+					ParametersRef: &gateway.ParametersReference{
+						Group: apigwv1alpha1.Group,
+						Kind:  apigwv1alpha1.GatewayClassConfigKind,
+						Name:  configName,
+					},
+				},
+			}
+			err = resources.Create(ctx, gc)
+			require.NoError(t, err)
+
+			gw := &gateway.Gateway{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+				Spec: gateway.GatewaySpec{
+					GatewayClassName: gateway.ObjectName(gc.Name),
+					Listeners: []gateway.Listener{{
+						Name:     "https",
+						Port:     gateway.PortNumber(e2e.ExtraPort(ctx)),
+						Protocol: gateway.HTTPSProtocolType,
+						TLS: &gateway.GatewayTLSConfig{
+							CertificateRefs: []*gateway.SecretObjectReference{{
+								Name:      "consul-server-cert",
+								Namespace: &gatewayNamespace,
+							}},
+						},
+					}},
+				},
+			}
+			err = resources.Create(ctx, gw)
+			require.NoError(t, err)
+			require.Eventually(t, gatewayReady(ctx, resources, gatewayName, namespace), 30*time.Second, 1*time.Second, "no gateway found in the allotted time")
+
+			port := gateway.PortNumber(service.Spec.Ports[0].Port)
+			route := &gateway.HTTPRoute{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      routeName,
+					Namespace: namespace,
+				},
+				Spec: gateway.HTTPRouteSpec{
+					CommonRouteSpec: gateway.CommonRouteSpec{
+						ParentRefs: []gateway.ParentRef{{
+							Name: gateway.ObjectName(gatewayName),
+						}},
+					},
+					Rules: []gateway.HTTPRouteRule{{
+						BackendRefs: []gateway.HTTPBackendRef{{
+							BackendRef: gateway.BackendRef{
+								BackendObjectReference: gateway.BackendObjectReference{
+									Name: gateway.ObjectName(service.Name),
+									Port: &port,
+								},
+							},
+						}},
+					}},
+				},
+			}
+			err = resources.Create(ctx, route)
+			require.NoError(t, err)
+
+			require.Eventually(t, func() bool {
+				ok, err := checkRoute(e2e.ExtraPort(ctx))
+				if err != nil || !ok {
+					return false
+				}
+				return true
+			}, 30*time.Second, 1*time.Second, "gateway route not usable in allotted time")
+
+			return ctx
+		})
+
+	testenv.Test(t, feature.Feature())
+}
+
+func gatewayReady(ctx context.Context, resources *resources.Resources, gatewayName, namespace string) func() bool {
+	return func() bool {
+		updated := &gateway.Gateway{}
+		if err := resources.Get(ctx, gatewayName, namespace, updated); err != nil {
+			return false
+		}
+		for _, condition := range updated.Status.Conditions {
+			if condition.Type == "Accepted" ||
+				condition.Status == "True" {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 func createGatewayClass(ctx context.Context, t *testing.T, cfg *envconf.Config) (*apigwv1alpha1.GatewayClassConfig, *gateway.GatewayClass) {
 	t.Helper()
 
@@ -227,7 +381,7 @@ func createGatewayClass(ctx context.Context, t *testing.T, cfg *envconf.Config) 
 			},
 			ServiceType: &serviceType,
 			ConsulSpec: apigwv1alpha1.ConsulSpec{
-				Address: "host.docker.internal", // we're connecting through the kind port mappings
+				Address: "host.docker.internal",
 				Scheme:  "https",
 				PortSpec: apigwv1alpha1.PortSpec{
 					GRPC: e2e.ConsulGRPCPort(ctx),
@@ -260,4 +414,22 @@ func createGatewayClass(ctx context.Context, t *testing.T, cfg *envconf.Config) 
 	require.NoError(t, err)
 
 	return gcc, gc
+}
+
+func checkRoute(port int) (bool, error) {
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://localhost:%d", port), nil)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK, nil
 }

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -41,15 +41,16 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CreateOrUpdateDeployment mocks base method.
-func (m *MockClient) CreateOrUpdateDeployment(ctx context.Context, deployment *v1.Deployment, mutators ...func() error) error {
+func (m *MockClient) CreateOrUpdateDeployment(ctx context.Context, deployment *v1.Deployment, mutators ...func() error) (bool, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, deployment}
 	for _, a := range mutators {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateOrUpdateDeployment", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateOrUpdateDeployment indicates an expected call of CreateOrUpdateDeployment.
@@ -60,15 +61,16 @@ func (mr *MockClientMockRecorder) CreateOrUpdateDeployment(ctx, deployment inter
 }
 
 // CreateOrUpdateService mocks base method.
-func (m *MockClient) CreateOrUpdateService(ctx context.Context, service *v10.Service, mutators ...func() error) error {
+func (m *MockClient) CreateOrUpdateService(ctx context.Context, service *v10.Service, mutators ...func() error) (bool, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, service}
 	for _, a := range mutators {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateOrUpdateService", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateOrUpdateService indicates an expected call of CreateOrUpdateService.

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -322,7 +322,7 @@ func TestGatewayTrackSync(t *testing.T) {
 		Client: client,
 	})
 	gateway.gateway.Status = gateway.Status()
-	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	require.NoError(t, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return false, nil
 	}))
@@ -334,7 +334,7 @@ func TestGatewayTrackSync(t *testing.T) {
 		}),
 		Client: client,
 	})
-	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	client.EXPECT().UpdateStatus(gomock.Any(), gateway.gateway).Return(nil)
 	require.NoError(t, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return false, nil
@@ -349,7 +349,7 @@ func TestGatewayTrackSync(t *testing.T) {
 		}),
 		Client: client,
 	})
-	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(expected)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, expected)
 	require.True(t, errors.Is(gateway.TrackSync(context.Background(), func() (bool, error) {
 		return false, nil
 	}), expected))
@@ -361,7 +361,7 @@ func TestGatewayTrackSync(t *testing.T) {
 		}),
 		Client: client,
 	})
-	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	client.EXPECT().UpdateStatus(gomock.Any(), gateway.gateway).Return(expected)
 	require.Equal(t, expected, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return false, nil
@@ -374,7 +374,7 @@ func TestGatewayTrackSync(t *testing.T) {
 		}),
 		Client: client,
 	})
-	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	client.EXPECT().UpdateStatus(gomock.Any(), gateway.gateway).Return(nil)
 	require.NoError(t, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return true, nil
@@ -387,7 +387,7 @@ func TestGatewayTrackSync(t *testing.T) {
 		}),
 		Client: client,
 	})
-	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 	client.EXPECT().UpdateStatus(gomock.Any(), gateway.gateway).Return(nil)
 	require.NoError(t, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return false, expected

--- a/internal/k8s/reconciler/http_route.go
+++ b/internal/k8s/reconciler/http_route.go
@@ -17,6 +17,9 @@ func convertHTTPRoute(namespace, hostname, prefix string, meta map[string]string
 		hostnames = append(hostnames, string(hostname))
 	}
 	if len(hostnames) == 0 {
+		if hostname == "" {
+			hostname = "*"
+		}
 		hostnames = append(hostnames, hostname)
 	}
 	name := prefix + route.Name

--- a/internal/k8s/reconciler/http_route_test.go
+++ b/internal/k8s/reconciler/http_route_test.go
@@ -106,7 +106,7 @@ func TestConvertHTTPRoute(t *testing.T) {
 	"Name": "kitchen-sink",
 	"Namespace": "",
 	"Hostnames": [
-		""
+		"*"
 	],
 	"Rules": [
 		{

--- a/internal/testing/certificates.go
+++ b/internal/testing/certificates.go
@@ -93,12 +93,18 @@ type GenerateCertificateOptions struct {
 	SPIFFEHostOverride string
 	SPIFFEPathOverride string
 	ExtraSANs          []string
+	ExtraIPs           []net.IP
 	Expiration         time.Time
+	Bits               int
 }
 
 // GenerateSignedCertificate generates a certificate with the given options
 func GenerateSignedCertificate(options GenerateCertificateOptions) (*CertificateInfo, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	bits := options.Bits
+	if bits == 0 {
+		bits = 1024
+	}
+	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +134,7 @@ func GenerateSignedCertificate(options GenerateCertificateOptions) (*Certificate
 			PostalCode:    []string{"11111"},
 		},
 		IsCA:                  options.IsCA,
-		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		IPAddresses:           append(options.ExtraIPs, net.IPv4(127, 0, 0, 1), net.IPv6loopback),
 		NotBefore:             time.Now().Add(-10 * time.Minute),
 		NotAfter:              expiration,
 		SubjectKeyId:          []byte{1, 2, 3, 4, 6},

--- a/internal/testing/e2e/gateway.go
+++ b/internal/testing/e2e/gateway.go
@@ -53,7 +53,7 @@ func (p *gatewayTestEnvironment) run(ctx context.Context, namespace string, cfg 
 	controller, err := k8s.New(nullLogger, &k8s.Config{
 		CACertSecretNamespace: namespace,
 		CACertSecret:          "consul-ca-cert",
-		SDSServerHost:         "gateway-controller.default.svc.cluster.local",
+		SDSServerHost:         "host.docker.internal",
 		SDSServerPort:         9090,
 		RestConfig:            cfg.Client().RESTConfig(),
 	})

--- a/internal/testing/e2e/kind.go
+++ b/internal/testing/e2e/kind.go
@@ -40,6 +40,9 @@ nodes:
   - containerPort: {{ .GRPCPort }}
     hostPort: {{ .GRPCPort }}
     protocol: TCP
+  - containerPort: {{ .ExtraPort }}
+    hostPort: {{ .ExtraPort }}
+    protocol: TCP
 `
 )
 
@@ -56,12 +59,13 @@ type kindCluster struct {
 	kubecfgFile string
 	config      string
 	httpsPort   int
+	extraPort   int
 	grpcPort    int
 }
 
 func newKindCluster(name string) *kindCluster {
-	ports := freeport.MustTake(2)
-	return &kindCluster{name: name, e: gexe.New(), httpsPort: ports[0], grpcPort: ports[1]}
+	ports := freeport.MustTake(3)
+	return &kindCluster{name: name, e: gexe.New(), httpsPort: ports[0], grpcPort: ports[1], extraPort: ports[2]}
 }
 
 func (k *kindCluster) Create() (string, error) {
@@ -71,9 +75,11 @@ func (k *kindCluster) Create() (string, error) {
 	err := kindTemplate.Execute(&kindConfig, &struct {
 		HTTPSPort int
 		GRPCPort  int
+		ExtraPort int
 	}{
 		HTTPSPort: k.httpsPort,
 		GRPCPort:  k.grpcPort,
+		ExtraPort: k.extraPort,
 	})
 	if err != nil {
 		return "", err

--- a/internal/testing/e2e/kubernetes.go
+++ b/internal/testing/e2e/kubernetes.go
@@ -47,6 +47,8 @@ func InstallGatewayCRDs(ctx context.Context, cfg *envconf.Config) (context.Conte
 		&gateway.GatewayClassList{},
 		&gateway.Gateway{},
 		&gateway.GatewayList{},
+		&gateway.HTTPRoute{},
+		&gateway.HTTPRouteList{},
 	)
 	meta.AddToGroupVersion(scheme.Scheme, gateway.SchemeGroupVersion)
 

--- a/internal/testing/e2e/service.go
+++ b/internal/testing/e2e/service.go
@@ -1,0 +1,371 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"html/template"
+
+	"github.com/cenkalti/backoff"
+	"github.com/hashicorp/consul-api-gateway/internal/common"
+	serviceResolver "github.com/hashicorp/consul-api-gateway/internal/k8s/service"
+	"github.com/hashicorp/consul/api"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+const (
+	envoyImage            = "envoyproxy/envoy:v1.19-latest"
+	bootstrapJSONTemplate = `{
+		"admin": {
+			"access_log_path": "/dev/null",
+			"address": {
+				"socket_address": {
+					"address": "127.0.0.1",
+					"port_value": 19000
+				}
+			}
+		},
+		"node": {
+			"cluster": "{{ .ID }}",
+			"id": "{{ .ID }}"
+		},
+		"static_resources": {
+			"clusters": [
+				{
+					"name": "self_admin",
+					"ignore_health_on_host_removal": false,
+					"connect_timeout": "5s",
+					"type": "STATIC",
+					"http_protocol_options": {},
+					"loadAssignment": {
+						"clusterName": "self_admin",
+						"endpoints": [
+							{
+								"lbEndpoints": [
+									{
+										"endpoint": {
+											"address": {
+												"socket_address": {
+													"address": "127.0.0.1",
+													"port_value": 19000
+												}
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				},
+				{
+					"name": "consul-server",
+					"ignore_health_on_host_removal": false,
+					"connect_timeout": "1s",
+					"type": "{{ .AddressType }}",
+					"transport_socket": {
+						"name": "tls",
+						"typed_config": {
+							"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+							"common_tls_context": {
+								"validation_context": {
+									"trusted_ca": {
+										"filename": "/ca/tls.crt"
+									}
+								}
+							}
+						}
+					},
+					"http2_protocol_options": {},
+					"loadAssignment": {
+						"clusterName": "consul-server",
+						"endpoints": [
+							{
+								"lbEndpoints": [
+									{
+										"endpoint": {
+											"address": {
+												"socket_address": {
+													"address": "{{ .ConsulAddress }}",
+													"port_value": {{ .ConsulXDSPort }}
+												}
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		},
+		"dynamic_resources": {
+			"lds_config": {
+				"ads": {},
+				"resource_api_version": "V3"
+			},
+			"cds_config": {
+				"ads": {},
+				"resource_api_version": "V3"
+			},
+			"ads_config": {
+				"api_type": "DELTA_GRPC",
+				"transport_api_version": "V3",
+				"grpc_services": {
+					"initial_metadata": [
+						{
+							"key": "x-consul-token",
+							"value": "{{ .Token }}"
+						}
+					],
+					"envoy_grpc": {
+						"cluster_name": "consul-server"
+					}
+				}
+			}
+		}
+	}
+	`
+)
+
+var (
+	bootstrapTemplate *template.Template
+)
+
+func init() {
+	bootstrapTemplate = template.Must(template.New("bootstrap").Parse(bootstrapJSONTemplate))
+}
+
+type bootstrapArgs struct {
+	ID            string
+	AddressType   string
+	ConsulAddress string
+	Token         string
+	ConsulXDSPort int
+}
+
+// DeployMeshService deploys an envoy proxy with roughly the same logic that consul-k8s uses
+// in its connect-inject registration
+func DeployMeshService(ctx context.Context, cfg *envconf.Config) (*core.Service, error) {
+	servicePort := 8080
+	namespace := Namespace(ctx)
+	name := envconf.RandomName("mesh", 16)
+	client := ConsulClient(ctx)
+	consulPort := ConsulGRPCPort(ctx)
+	token := ConsulMasterToken(ctx)
+	consulAddress := "host.docker.internal"
+	proxyServiceName := name + "-proxy"
+
+	resourcesClient := cfg.Client().Resources(namespace)
+
+	configMap, err := meshServiceConfigMap(name, namespace, proxyServiceName, token, consulAddress, consulPort)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := resourcesClient.Create(ctx, configMap); err != nil {
+		return nil, err
+	}
+
+	deployment := meshDeployment(name, namespace, servicePort)
+	if err := resourcesClient.Create(ctx, deployment); err != nil {
+		return nil, err
+	}
+
+	service := meshService(deployment, servicePort)
+	if err := resourcesClient.Create(ctx, service); err != nil {
+		return nil, err
+	}
+
+	pod := &core.Pod{}
+	err = backoff.Retry(func() error {
+		list := &core.PodList{}
+		if err := resourcesClient.List(ctx, list, resources.WithLabelSelector(meta.FormatLabelSelector(&meta.LabelSelector{
+			MatchLabels: deployment.Labels,
+		}))); err != nil {
+			return err
+		}
+
+		if len(list.Items) == 0 {
+			return errors.New("no pod created yet")
+		}
+		pod = &list.Items[0]
+
+		if pod.Status.PodIP == "" {
+			return errors.New("no assigned ip yet")
+		}
+		return nil
+	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 20), ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	registration := &api.AgentServiceRegistration{
+		ID:   name,
+		Name: name,
+		Port: 19000,
+		Meta: map[string]string{
+			serviceResolver.MetaKeyKubeServiceName: name,
+			serviceResolver.MetaKeyKubeNS:          namespace,
+		},
+		Address: pod.Status.PodIP,
+	}
+
+	if err := client.Agent().ServiceRegisterOpts(registration, (&api.ServiceRegisterOpts{}).WithContext(ctx)); err != nil {
+		return nil, err
+	}
+
+	_, _, err = client.ConfigEntries().Set(&api.ServiceConfigEntry{
+		Kind:     api.ServiceDefaults,
+		Name:     name,
+		Protocol: "http",
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyRegistration := &api.AgentServiceRegistration{
+		Kind: api.ServiceKind(api.ServiceKindConnectProxy),
+		ID:   proxyServiceName,
+		Name: proxyServiceName,
+		Port: servicePort,
+		Meta: map[string]string{
+			serviceResolver.MetaKeyKubeServiceName: name,
+			serviceResolver.MetaKeyKubeNS:          namespace,
+		},
+		Proxy: &api.AgentServiceConnectProxyConfig{
+			DestinationServiceName: name,
+			LocalServiceAddress:    "127.0.0.1",
+			LocalServicePort:       19000,
+		},
+		Address: pod.Status.PodIP,
+	}
+
+	if err := client.Agent().ServiceRegisterOpts(proxyRegistration, (&api.ServiceRegisterOpts{}).WithContext(ctx)); err != nil {
+		return nil, err
+	}
+	return service, nil
+}
+
+func meshServiceConfigMap(name, namespace, proxyServiceName, token, consulAddress string, consulPort int) (*core.ConfigMap, error) {
+	config, err := meshServiceConfig(proxyServiceName, token, consulAddress, consulPort)
+	if err != nil {
+		return nil, err
+	}
+
+	return &core.ConfigMap{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"bootstrap.json": config,
+		},
+	}, nil
+}
+
+func meshServiceConfig(name, token, consulAddress string, consulPort int) (string, error) {
+	var template bytes.Buffer
+	if err := bootstrapTemplate.Execute(&template, &bootstrapArgs{
+		ID:            name,
+		AddressType:   common.AddressTypeForAddress(consulAddress),
+		Token:         token,
+		ConsulAddress: consulAddress,
+		ConsulXDSPort: consulPort,
+	}); err != nil {
+		return "", err
+	}
+	return template.String(), nil
+}
+
+func meshService(deployment *apps.Deployment, port int) *core.Service {
+	return &core.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      deployment.Name,
+			Namespace: deployment.Namespace,
+			Labels:    deployment.Labels,
+		},
+		Spec: core.ServiceSpec{
+			Selector: deployment.Labels,
+			Ports: []core.ServicePort{{
+				Name:     "port",
+				Protocol: core.ProtocolTCP,
+				Port:     int32(port),
+			}},
+		},
+	}
+}
+
+func meshDeployment(name, namespace string, port int) *apps.Deployment {
+	labels := map[string]string{
+		"deployment": name,
+		"type":       "mesh-service",
+	}
+	return &apps.Deployment{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: apps.DeploymentSpec{
+			Selector: &meta.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: core.PodTemplateSpec{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    labels,
+				},
+				Spec: core.PodSpec{
+					Volumes: []core.Volume{{
+						Name: "ca",
+						VolumeSource: core.VolumeSource{
+							Secret: &core.SecretVolumeSource{
+								SecretName: "consul-ca-cert",
+							},
+						},
+					}, {
+						Name: "config",
+						VolumeSource: core.VolumeSource{
+							ConfigMap: &core.ConfigMapVolumeSource{
+								LocalObjectReference: core.LocalObjectReference{
+									Name: name,
+								},
+							},
+						},
+					}},
+					Containers: []core.Container{
+						{
+							Name:  "envoy",
+							Image: envoyImage,
+							Ports: []core.ContainerPort{{
+								Name:          "port",
+								Protocol:      "TCP",
+								ContainerPort: int32(port),
+							}},
+							VolumeMounts: []core.VolumeMount{{
+								Name:      "config",
+								MountPath: "/config",
+							}, {
+								Name:      "ca",
+								MountPath: "/ca",
+								ReadOnly:  true,
+							}},
+							Command: []string{
+								"envoy",
+								"-c",
+								"/config/bootstrap.json",
+								"-l",
+								"trace",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This adds a full end-to-end routing test that actually checks that a deployed gateway proxies properly to a service on the mesh. Rather than using the `consul-k8s` helm chart, it just registers an envoy connect proxy that proxies to its local admin interface registered as another consul service. In registering both the proxy and the service, the same metadata that we'd expect to be in Consul via a connect-inject annotation is created so we can properly resolve the K8s --> Consul mappings.

When the gateway routes to this K8s service/container we should be able to see the gateway proxy properly to the connect proxy and the connect proxy forward requests to the local admin interface. Since I forwarded an additional port from the `kind` cluster, the net result is being able to check the connection from development machine --> gateway (in kind) --> connect (in kind) --> container localhost service. 

---

This PR also fixes a bug introduced in https://github.com/hashicorp/consul-api-gateway/pull/44 -- turns out that K8s does a bunch of "default" additions to our Gateway Deployment/Service definitions, so the `Merge` code I introduced was always causing the CreateOrUpdate dirty checking to fail. I wrapped the merging code in a manual equality check on the fields that can get updated currently based off of a Gateway definition being updated. The way I found the bug was turning on trace logging in the running inline server in the tests and seeing the spam generated from continuous deployment/service updates -- which leads me to believe that once we get this running in CI, we might want to pass a flag that allows us to do trace-level logging in CI as well.