### PR TITLE
makefile: go install controller-gen instead of go-get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,14 +57,7 @@ ctrl-generate: controller-gen
 .PHONY: controller-gen
 controller-gen:
 ifeq (, $(shell which controller-gen))
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
+	@go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else
 CONTROLLER_GEN=$(shell which controller-gen)


### PR DESCRIPTION
Using `go get` to install executables is [deprecated](https://golang.org/doc/go-get-install-deprecation) in Go 1.17