### PR TITLE
makefile: install goimports if not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,8 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,allowDangerousTypes=true"
 goimports:
 ifeq (, $(shell which goimports))
 	@go install golang.org/x/tools/cmd/goimports@latest
-GOIMPORTS=$(GOBIN)/goimports
-else
-GOIMPORTS=$(shell which goimports)
 endif
+GOIMPORTS=$(shell which goimports)
 
 .PHONY: fmt
 fmt: goimports
@@ -69,10 +67,8 @@ ctrl-generate: controller-gen
 controller-gen:
 ifeq (, $(shell which controller-gen))
 	@go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
 endif
+CONTROLLER_GEN=$(shell which controller-gen)
 
 .PHONY: version
 version:


### PR DESCRIPTION
Follows the pattern used by `make controller-gen`, as updated slightly in #49. The current drawback is that the `make fmt` dependency on `goimports` won't wait until install has completed on the first run, so hits `bash: /goimports: No such file or directory` before running successfully when rerun, open to suggestions on how to improve this behavior.

As a separate question, should we add a version check of some sort and/or pin (although staying on latest seems preferable) to ensure consistency? https://pkg.go.dev/golang.org/x/tools/cmd/goimports?tab=versions