### PR TITLE
Fix up routing resolution behavior

### DIFF
--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -1,5 +1,3 @@
-//+build e2e
-
 package server
 
 import (
@@ -255,7 +253,6 @@ func TestMeshService(t *testing.T) {
 			routeOneName := envconf.RandomName("route", 16)
 			routeTwoName := envconf.RandomName("route", 16)
 			routeThreeName := envconf.RandomName("route", 16)
-			routeFourName := envconf.RandomName("route", 16)
 
 			gatewayNamespace := gateway.Namespace(namespace)
 			resources := cfg.Client().Resources(namespace)
@@ -365,6 +362,8 @@ func TestMeshService(t *testing.T) {
 
 			// route 2
 			port = gateway.PortNumber(serviceTwo.Spec.Ports[0].Port)
+			portFour := gateway.PortNumber(serviceFour.Spec.Ports[0].Port)
+			portFive := gateway.PortNumber(serviceFive.Spec.Ports[0].Port)
 			path = "/v2"
 			route := &gateway.HTTPRoute{
 				ObjectMeta: meta.ObjectMeta{
@@ -389,6 +388,22 @@ func TestMeshService(t *testing.T) {
 								BackendObjectReference: gateway.BackendObjectReference{
 									Name: gateway.ObjectName(serviceTwo.Name),
 									Port: &port,
+								},
+							},
+						}},
+					}, {
+						BackendRefs: []gateway.HTTPBackendRef{{
+							BackendRef: gateway.BackendRef{
+								BackendObjectReference: gateway.BackendObjectReference{
+									Name: gateway.ObjectName(serviceFour.Name),
+									Port: &portFour,
+								},
+							},
+						}, {
+							BackendRef: gateway.BackendRef{
+								BackendObjectReference: gateway.BackendObjectReference{
+									Name: gateway.ObjectName(serviceFive.Name),
+									Port: &portFive,
 								},
 							},
 						}},
@@ -431,42 +446,6 @@ func TestMeshService(t *testing.T) {
 								BackendObjectReference: gateway.BackendObjectReference{
 									Name: gateway.ObjectName(serviceThree.Name),
 									Port: &port,
-								},
-							},
-						}},
-					}},
-				},
-			}
-			err = resources.Create(ctx, route)
-			require.NoError(t, err)
-
-			// route 4 - fallback
-			portFour := gateway.PortNumber(serviceFour.Spec.Ports[0].Port)
-			portFive := gateway.PortNumber(serviceFive.Spec.Ports[0].Port)
-			route = &gateway.HTTPRoute{
-				ObjectMeta: meta.ObjectMeta{
-					Name:      routeFourName,
-					Namespace: namespace,
-				},
-				Spec: gateway.HTTPRouteSpec{
-					CommonRouteSpec: gateway.CommonRouteSpec{
-						ParentRefs: []gateway.ParentRef{{
-							Name: gateway.ObjectName(gatewayName),
-						}},
-					},
-					Rules: []gateway.HTTPRouteRule{{
-						BackendRefs: []gateway.HTTPBackendRef{{
-							BackendRef: gateway.BackendRef{
-								BackendObjectReference: gateway.BackendObjectReference{
-									Name: gateway.ObjectName(serviceFour.Name),
-									Port: &portFour,
-								},
-							},
-						}, {
-							BackendRef: gateway.BackendRef{
-								BackendObjectReference: gateway.BackendObjectReference{
-									Name: gateway.ObjectName(serviceFive.Name),
-									Port: &portFive,
 								},
 							},
 						}},

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -1,3 +1,5 @@
+//+build e2e
+
 package server
 
 import (

--- a/internal/k8s/reconciler/http_route.go
+++ b/internal/k8s/reconciler/http_route.go
@@ -51,11 +51,13 @@ var methodMappings = map[gw.HTTPMethod]core.HTTPMethod{
 
 var pathMappings = map[gw.PathMatchType]core.HTTPPathMatchType{
 	gw.PathMatchExact:             core.HTTPPathMatchExactType,
+	gw.PathMatchPathPrefix:        core.HTTPPathMatchPrefixType,
 	gw.PathMatchRegularExpression: core.HTTPPathMatchRegularExpressionType,
 }
 
 var queryMappings = map[gw.QueryParamMatchType]core.HTTPQueryMatchType{
-	gw.QueryParamMatchExact: core.HTTPQueryMatchExactType,
+	gw.QueryParamMatchExact:             core.HTTPQueryMatchExactType,
+	gw.QueryParamMatchRegularExpression: core.HTTPQueryMatchRegularExpressionType,
 }
 
 var headerMappings = map[gw.HeaderMatchType]core.HTTPHeaderMatchType{

--- a/internal/k8s/reconciler/http_route_test.go
+++ b/internal/k8s/reconciler/http_route_test.go
@@ -99,6 +99,32 @@ func TestConvertHTTPRoute(t *testing.T) {
 			}, {
 				Type: service.HTTPRouteReference,
 			}},
+			service.RouteRule{
+				HTTPRule: &gw.HTTPRouteRule{
+					Matches: []gw.HTTPRouteMatch{{
+						QueryParams: []gw.HTTPQueryParamMatch{{
+							Type:  &queryMatchType,
+							Name:  "c",
+							Value: "d",
+						}},
+					}},
+				},
+			}: []service.ResolvedReference{{
+				Type: service.ConsulServiceReference,
+				Consul: &service.ConsulService{
+					Name:      "other",
+					Namespace: "namespace",
+				},
+				Reference: &service.BackendReference{
+					HTTPRef: &gw.HTTPBackendRef{
+						BackendRef: gw.BackendRef{
+							Weight: &weight,
+						},
+					},
+				},
+			}, {
+				Type: service.HTTPRouteReference,
+			}},
 		},
 		expected: `
 {
@@ -174,6 +200,36 @@ func TestConvertHTTPRoute(t *testing.T) {
 					"Service": {
 						"ConsulNamespace": "namespace",
 						"Service": "name"
+					},
+					"Weight": 10,
+					"Filters": []
+				}
+			]
+		},
+		{
+			"Filters": [],
+			"Matches": [
+				{
+					"Headers": null,
+					"Method": 0,
+					"Path": {
+						"Type": 0,
+						"Value": ""
+					},
+					"Query": [
+						{
+							"Type": 1,
+							"Name": "c",
+							"Value": "d"
+						}
+					]
+				}
+			],
+			"Services": [
+				{
+					"Service": {
+						"ConsulNamespace": "namespace",
+						"Service": "other"
 					},
 					"Weight": 10,
 					"Filters": []

--- a/internal/k8s/reconciler/http_route_test.go
+++ b/internal/k8s/reconciler/http_route_test.go
@@ -99,32 +99,6 @@ func TestConvertHTTPRoute(t *testing.T) {
 			}, {
 				Type: service.HTTPRouteReference,
 			}},
-			service.RouteRule{
-				HTTPRule: &gw.HTTPRouteRule{
-					Matches: []gw.HTTPRouteMatch{{
-						QueryParams: []gw.HTTPQueryParamMatch{{
-							Type:  &queryMatchType,
-							Name:  "c",
-							Value: "d",
-						}},
-					}},
-				},
-			}: []service.ResolvedReference{{
-				Type: service.ConsulServiceReference,
-				Consul: &service.ConsulService{
-					Name:      "other",
-					Namespace: "namespace",
-				},
-				Reference: &service.BackendReference{
-					HTTPRef: &gw.HTTPBackendRef{
-						BackendRef: gw.BackendRef{
-							Weight: &weight,
-						},
-					},
-				},
-			}, {
-				Type: service.HTTPRouteReference,
-			}},
 		},
 		expected: `
 {
@@ -200,36 +174,6 @@ func TestConvertHTTPRoute(t *testing.T) {
 					"Service": {
 						"ConsulNamespace": "namespace",
 						"Service": "name"
-					},
-					"Weight": 10,
-					"Filters": []
-				}
-			]
-		},
-		{
-			"Filters": [],
-			"Matches": [
-				{
-					"Headers": null,
-					"Method": 0,
-					"Path": {
-						"Type": 0,
-						"Value": ""
-					},
-					"Query": [
-						{
-							"Type": 1,
-							"Name": "c",
-							"Value": "d"
-						}
-					]
-				}
-			],
-			"Services": [
-				{
-					"Service": {
-						"ConsulNamespace": "namespace",
-						"Service": "other"
 					},
 					"Weight": 10,
 					"Filters": []

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -337,8 +337,9 @@ func (r *K8sRoute) Validate(ctx context.Context) error {
 	switch route := r.Route.(type) {
 	case *gw.HTTPRoute:
 		for _, rule := range route.Spec.Rules {
-			routeRule := service.NewRouteRule(&rule)
-			for _, ref := range rule.BackendRefs {
+			copiedRule := rule.DeepCopy()
+			routeRule := service.NewRouteRule(copiedRule)
+			for _, ref := range copiedRule.BackendRefs {
 				reference, err := r.resolver.Resolve(ctx, ref.BackendObjectReference)
 				if err != nil {
 					var resolutionError service.ResolutionError

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -336,10 +336,11 @@ func (r *K8sRoute) Parents() []gw.ParentRef {
 func (r *K8sRoute) Validate(ctx context.Context) error {
 	switch route := r.Route.(type) {
 	case *gw.HTTPRoute:
-		for _, rule := range route.Spec.Rules {
-			copiedRule := rule.DeepCopy()
-			routeRule := service.NewRouteRule(copiedRule)
-			for _, ref := range copiedRule.BackendRefs {
+		for _, httpRule := range route.Spec.Rules {
+			rule := httpRule
+			routeRule := service.NewRouteRule(&rule)
+			for _, backendRef := range rule.BackendRefs {
+				ref := backendRef
 				reference, err := r.resolver.Resolve(ctx, ref.BackendObjectReference)
 				if err != nil {
 					var resolutionError service.ResolutionError


### PR DESCRIPTION
This PR adds support for the `PrefixPath` routing that was, unfortunately overlooked during initial development. Additionally, there was a bug with the way we were tracking `HTTPRoute` rules that have multiple rule entries, where the services specified as `backendRefs` across the entire set of `rules` get combined into the final rule specified, and config entries were created solely for this rule.

The fixes:

1. Add a map entry for `PrefixPath` in our `HTTPRoute` --> internal representation code
2. Make a copy of the route rule as we're resolving services -- the iterating loop was taking an address of a value returned via a `range` operation, which was making all of the map keys the same.

How I've tested this PR:

Added unit tests and verified manually.

Checklist:
- [x] Tests added
