### PR TITLE
Initial TCPRoute Implementation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -168,3 +168,29 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tcproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tcproutes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tcproutes/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/internal/adapters/consul/http.go
+++ b/internal/adapters/consul/http.go
@@ -1,0 +1,262 @@
+package consul
+
+import (
+	"fmt"
+	"hash/crc32"
+	"sort"
+	"strconv"
+
+	"github.com/hashicorp/consul-api-gateway/internal/core"
+	"github.com/hashicorp/consul/api"
+)
+
+// httpRouteToServiceDiscoChain will convert a k8s HTTPRoute to a Consul service-router config entry and 0 or
+// more service-splitter config entries. A prefix can be given to prefix all config entry names with.
+func httpRouteDiscoveryChain(route core.HTTPRoute) (*api.ServiceRouterConfigEntry, []*api.ServiceSplitterConfigEntry) {
+	router := &api.ServiceRouterConfigEntry{
+		Kind:      api.ServiceRouter,
+		Name:      route.GetName(),
+		Meta:      route.GetMeta(),
+		Namespace: route.GetNamespace(),
+	}
+	var splitters []*api.ServiceSplitterConfigEntry
+
+	for idx, rule := range route.Rules {
+		modifier := httpRouteFiltersToServiceRouteHeaderModifier(rule.Filters)
+
+		var destination core.ResolvedService
+		if len(rule.Services) == 1 {
+			destination = rule.Services[0].Service
+			serviceModifier := httpRouteFiltersToServiceRouteHeaderModifier(rule.Services[0].Filters)
+			modifier.Add = mergeMaps(modifier.Add, serviceModifier.Add)
+			modifier.Set = mergeMaps(modifier.Set, serviceModifier.Set)
+			modifier.Remove = append(modifier.Remove, serviceModifier.Remove...)
+		} else {
+			// create a virtual service to split
+			destination = core.ResolvedService{
+				Service:         fmt.Sprintf("%s-%d", route.GetName(), idx),
+				ConsulNamespace: route.GetNamespace(),
+			}
+			splitter := &api.ServiceSplitterConfigEntry{
+				Kind:      api.ServiceSplitter,
+				Name:      destination.Service,
+				Namespace: destination.ConsulNamespace,
+				Splits:    []api.ServiceSplit{},
+				Meta:      route.GetMeta(),
+			}
+
+			totalWeight := int32(0)
+			for _, service := range rule.Services {
+				totalWeight += service.Weight
+			}
+
+			for _, service := range rule.Services {
+				if service.Weight == 0 {
+					continue
+				}
+
+				modifier := httpRouteFiltersToServiceRouteHeaderModifier(service.Filters)
+
+				weightPercentage := float32(service.Weight) / float32(totalWeight)
+				split := api.ServiceSplit{
+					RequestHeaders: modifier,
+					Weight:         weightPercentage * 100,
+				}
+				split.Service = service.Service.Service
+				split.Namespace = service.Service.ConsulNamespace
+				splitter.Splits = append(splitter.Splits, split)
+			}
+			if len(splitter.Splits) > 0 {
+				splitters = append(splitters, splitter)
+			}
+		}
+
+		// for each match rule a ServiceRoute is created for the service-router
+		// if there are no rules a single route with the destination is set
+		if len(rule.Matches) == 0 {
+			router.Routes = append(router.Routes, api.ServiceRoute{
+				Destination: &api.ServiceRouteDestination{
+					Service:        destination.Service,
+					RequestHeaders: modifier,
+					Namespace:      destination.ConsulNamespace,
+				},
+			})
+		}
+		for _, match := range rule.Matches {
+			router.Routes = append(router.Routes, api.ServiceRoute{
+				Match: &api.ServiceRouteMatch{HTTP: httpRouteMatchToServiceRouteHTTPMatch(match)},
+				Destination: &api.ServiceRouteDestination{
+					Service:        destination.Service,
+					RequestHeaders: modifier,
+					Namespace:      destination.ConsulNamespace,
+				},
+			})
+		}
+	}
+
+	return router, splitters
+}
+
+func httpRouteFiltersToServiceRouteHeaderModifier(filters []core.HTTPFilter) *api.HTTPHeaderModifiers {
+	modifier := &api.HTTPHeaderModifiers{
+		Add: make(map[string]string),
+		Set: make(map[string]string),
+	}
+	for _, filter := range filters {
+		switch filter.Type {
+		case core.HTTPHeaderFilterType:
+			// If we have multiple filters specified, then we can potentially clobber
+			// "Add" and "Set" here -- as far as K8S gateway spec is concerned, this
+			// is all implmentation-specific behavior and undefined by the spec.
+			modifier.Add = mergeMaps(modifier.Add, filter.Header.Add)
+			modifier.Set = mergeMaps(modifier.Set, filter.Header.Set)
+			modifier.Remove = append(modifier.Remove, filter.Header.Remove...)
+		}
+	}
+	return modifier
+}
+
+func mergeMaps(a, b map[string]string) map[string]string {
+	for k, v := range b {
+		a[k] = v
+	}
+	return a
+}
+
+func httpRouteMatchToServiceRouteHTTPMatch(match core.HTTPMatch) *api.ServiceRouteHTTPMatch {
+	var consulMatch api.ServiceRouteHTTPMatch
+	switch match.Path.Type {
+	case core.HTTPPathMatchExactType:
+		consulMatch.PathExact = match.Path.Value
+	case core.HTTPPathMatchPrefixType:
+		consulMatch.PathPrefix = match.Path.Value
+	case core.HTTPPathMatchRegularExpressionType:
+		consulMatch.PathRegex = match.Path.Value
+	}
+
+	for _, header := range match.Headers {
+		switch header.Type {
+		case core.HTTPHeaderMatchExactType:
+			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
+				Name:  header.Name,
+				Exact: header.Value,
+			})
+		case core.HTTPHeaderMatchPrefixType:
+			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
+				Name:   header.Name,
+				Prefix: header.Value,
+			})
+		case core.HTTPHeaderMatchSuffixType:
+			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
+				Name:   header.Name,
+				Suffix: header.Value,
+			})
+		case core.HTTPHeaderMatchPresentType:
+			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
+				Name:    header.Name,
+				Present: true,
+			})
+		case core.HTTPHeaderMatchRegularExpressionType:
+			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
+				Name:  header.Name,
+				Regex: header.Value,
+			})
+		}
+	}
+
+	for _, query := range match.Query {
+		switch query.Type {
+		case core.HTTPQueryMatchExactType:
+			consulMatch.QueryParam = append(consulMatch.QueryParam, api.ServiceRouteHTTPMatchQueryParam{
+				Name:  query.Name,
+				Exact: query.Value,
+			})
+		case core.HTTPQueryMatchPresentType:
+			consulMatch.QueryParam = append(consulMatch.QueryParam, api.ServiceRouteHTTPMatchQueryParam{
+				Name:    query.Name,
+				Present: true,
+			})
+		case core.HTTPQueryMatchRegularExpressionType:
+			consulMatch.QueryParam = append(consulMatch.QueryParam, api.ServiceRouteHTTPMatchQueryParam{
+				Name:  query.Name,
+				Regex: query.Value,
+			})
+		}
+	}
+
+	switch match.Method {
+	case core.HTTPMethodConnect:
+		consulMatch.Methods = append(consulMatch.Methods, "CONNECT")
+	case core.HTTPMethodDelete:
+		consulMatch.Methods = append(consulMatch.Methods, "DELETE")
+	case core.HTTPMethodGet:
+		consulMatch.Methods = append(consulMatch.Methods, "GET")
+	case core.HTTPMethodHead:
+		consulMatch.Methods = append(consulMatch.Methods, "HEAD")
+	case core.HTTPMethodOptions:
+		consulMatch.Methods = append(consulMatch.Methods, "OPTIONS")
+	case core.HTTPMethodPatch:
+		consulMatch.Methods = append(consulMatch.Methods, "PATCH")
+	case core.HTTPMethodPost:
+		consulMatch.Methods = append(consulMatch.Methods, "POST")
+	case core.HTTPMethodPut:
+		consulMatch.Methods = append(consulMatch.Methods, "PUT")
+	case core.HTTPMethodTrace:
+		consulMatch.Methods = append(consulMatch.Methods, "TRACE")
+	}
+
+	return &consulMatch
+}
+
+func hostsKey(hosts []string) string {
+	sort.Strings(hosts)
+	hostsHash := crc32.NewIEEE()
+	for _, h := range hosts {
+		if _, err := hostsHash.Write([]byte(h)); err != nil {
+			continue
+		}
+	}
+	return strconv.FormatUint(uint64(hostsHash.Sum32()), 16)
+}
+
+func compareHTTPRules(ruleA, ruleB core.HTTPRouteRule) bool {
+	matchesA := ruleA.Matches
+	matchesB := ruleB.Matches
+
+	// this tries to implement some of the logic specified by the K8S gateway API spec
+
+	// Proxy or Load Balancer routing configuration generated from HTTPRoutes MUST prioritize
+	// rules based on the following criteria, continuing on ties. Precedence must be given
+	// to the the Rule with the largest number of:
+	// Characters in a matching non-wildcard hostname.
+	// Characters in a matching hostname.
+	// Characters in a matching path.
+	// Header matches.
+	// Query param matches.
+
+	var longestPathMatchA int
+	for _, match := range matchesA {
+		pathLength := len(match.Path.Value)
+		if longestPathMatchA < pathLength {
+			longestPathMatchA = pathLength
+		}
+	}
+	var longestPathMatchB int
+	for _, match := range matchesB {
+		pathLength := len(match.Path.Value)
+		if longestPathMatchB < pathLength {
+			longestPathMatchB = pathLength
+		}
+	}
+	return longestPathMatchA > longestPathMatchB
+}
+
+func httpServiceDefault(entry api.ConfigEntry, meta map[string]string) *api.ServiceConfigEntry {
+	return &api.ServiceConfigEntry{
+		Kind:      api.ServiceDefaults,
+		Name:      entry.GetName(),
+		Namespace: entry.GetNamespace(),
+		Protocol:  "http",
+		Meta:      meta,
+	}
+}

--- a/internal/adapters/consul/sync.go
+++ b/internal/adapters/consul/sync.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"hash/crc32"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -65,214 +63,6 @@ func (a *ConsulSyncAdapter) deleteConfigEntries(ctx context.Context, entries ...
 	return result
 }
 
-// httpRouteToServiceDiscoChain will convert a k8s HTTPRoute to a Consul service-router config entry and 0 or
-// more service-splitter config entries. A prefix can be given to prefix all config entry names with.
-func httpRouteDiscoveryChain(route core.HTTPRoute) (*api.ServiceRouterConfigEntry, []*api.ServiceSplitterConfigEntry) {
-	router := &api.ServiceRouterConfigEntry{
-		Kind:      api.ServiceRouter,
-		Name:      route.GetName(),
-		Meta:      route.GetMeta(),
-		Namespace: route.GetNamespace(),
-	}
-	var splitters []*api.ServiceSplitterConfigEntry
-
-	for idx, rule := range route.Rules {
-		modifier := httpRouteFiltersToServiceRouteHeaderModifier(rule.Filters)
-
-		var destination core.ResolvedService
-		if len(rule.Services) == 1 {
-			destination = rule.Services[0].Service
-			serviceModifier := httpRouteFiltersToServiceRouteHeaderModifier(rule.Services[0].Filters)
-			modifier.Add = mergeMaps(modifier.Add, serviceModifier.Add)
-			modifier.Set = mergeMaps(modifier.Set, serviceModifier.Set)
-			modifier.Remove = append(modifier.Remove, serviceModifier.Remove...)
-		} else {
-			// create a virtual service to split
-			destination = core.ResolvedService{
-				Service:         fmt.Sprintf("%s-%d", route.GetName(), idx),
-				ConsulNamespace: route.GetNamespace(),
-			}
-			splitter := &api.ServiceSplitterConfigEntry{
-				Kind:      api.ServiceSplitter,
-				Name:      destination.Service,
-				Namespace: destination.ConsulNamespace,
-				Splits:    []api.ServiceSplit{},
-				Meta:      route.GetMeta(),
-			}
-
-			totalWeight := int32(0)
-			for _, service := range rule.Services {
-				totalWeight += service.Weight
-			}
-
-			for _, service := range rule.Services {
-				if service.Weight == 0 {
-					continue
-				}
-
-				modifier := httpRouteFiltersToServiceRouteHeaderModifier(service.Filters)
-
-				weightPercentage := float32(service.Weight) / float32(totalWeight)
-				split := api.ServiceSplit{
-					RequestHeaders: modifier,
-					Weight:         weightPercentage * 100,
-				}
-				split.Service = service.Service.Service
-				split.Namespace = service.Service.ConsulNamespace
-				splitter.Splits = append(splitter.Splits, split)
-			}
-			if len(splitter.Splits) > 0 {
-				splitters = append(splitters, splitter)
-			}
-		}
-
-		// for each match rule a ServiceRoute is created for the service-router
-		// if there are no rules a single route with the destination is set
-		if len(rule.Matches) == 0 {
-			router.Routes = append(router.Routes, api.ServiceRoute{
-				Destination: &api.ServiceRouteDestination{
-					Service:        destination.Service,
-					RequestHeaders: modifier,
-					Namespace:      destination.ConsulNamespace,
-				},
-			})
-		}
-		for _, match := range rule.Matches {
-			router.Routes = append(router.Routes, api.ServiceRoute{
-				Match: &api.ServiceRouteMatch{HTTP: httpRouteMatchToServiceRouteHTTPMatch(match)},
-				Destination: &api.ServiceRouteDestination{
-					Service:        destination.Service,
-					RequestHeaders: modifier,
-					Namespace:      destination.ConsulNamespace,
-				},
-			})
-		}
-	}
-
-	return router, splitters
-}
-
-func httpRouteFiltersToServiceRouteHeaderModifier(filters []core.HTTPFilter) *api.HTTPHeaderModifiers {
-	modifier := &api.HTTPHeaderModifiers{
-		Add: make(map[string]string),
-		Set: make(map[string]string),
-	}
-	for _, filter := range filters {
-		switch filter.Type {
-		case core.HTTPHeaderFilterType:
-			// If we have multiple filters specified, then we can potentially clobber
-			// "Add" and "Set" here -- as far as K8S gateway spec is concerned, this
-			// is all implmentation-specific behavior and undefined by the spec.
-			modifier.Add = mergeMaps(modifier.Add, filter.Header.Add)
-			modifier.Set = mergeMaps(modifier.Set, filter.Header.Set)
-			modifier.Remove = append(modifier.Remove, filter.Header.Remove...)
-		}
-	}
-	return modifier
-}
-
-func mergeMaps(a, b map[string]string) map[string]string {
-	for k, v := range b {
-		a[k] = v
-	}
-	return a
-}
-
-func httpRouteMatchToServiceRouteHTTPMatch(match core.HTTPMatch) *api.ServiceRouteHTTPMatch {
-	var consulMatch api.ServiceRouteHTTPMatch
-	switch match.Path.Type {
-	case core.HTTPPathMatchExactType:
-		consulMatch.PathExact = match.Path.Value
-	case core.HTTPPathMatchPrefixType:
-		consulMatch.PathPrefix = match.Path.Value
-	case core.HTTPPathMatchRegularExpressionType:
-		consulMatch.PathRegex = match.Path.Value
-	}
-
-	for _, header := range match.Headers {
-		switch header.Type {
-		case core.HTTPHeaderMatchExactType:
-			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
-				Name:  header.Name,
-				Exact: header.Value,
-			})
-		case core.HTTPHeaderMatchPrefixType:
-			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
-				Name:   header.Name,
-				Prefix: header.Value,
-			})
-		case core.HTTPHeaderMatchSuffixType:
-			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
-				Name:   header.Name,
-				Suffix: header.Value,
-			})
-		case core.HTTPHeaderMatchPresentType:
-			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
-				Name:    header.Name,
-				Present: true,
-			})
-		case core.HTTPHeaderMatchRegularExpressionType:
-			consulMatch.Header = append(consulMatch.Header, api.ServiceRouteHTTPMatchHeader{
-				Name:  header.Name,
-				Regex: header.Value,
-			})
-		}
-	}
-
-	for _, query := range match.Query {
-		switch query.Type {
-		case core.HTTPQueryMatchExactType:
-			consulMatch.QueryParam = append(consulMatch.QueryParam, api.ServiceRouteHTTPMatchQueryParam{
-				Name:  query.Name,
-				Exact: query.Value,
-			})
-		case core.HTTPQueryMatchPresentType:
-			consulMatch.QueryParam = append(consulMatch.QueryParam, api.ServiceRouteHTTPMatchQueryParam{
-				Name:    query.Name,
-				Present: true,
-			})
-		case core.HTTPQueryMatchRegularExpressionType:
-			consulMatch.QueryParam = append(consulMatch.QueryParam, api.ServiceRouteHTTPMatchQueryParam{
-				Name:  query.Name,
-				Regex: query.Value,
-			})
-		}
-	}
-
-	switch match.Method {
-	case core.HTTPMethodConnect:
-		consulMatch.Methods = append(consulMatch.Methods, "CONNECT")
-	case core.HTTPMethodDelete:
-		consulMatch.Methods = append(consulMatch.Methods, "DELETE")
-	case core.HTTPMethodGet:
-		consulMatch.Methods = append(consulMatch.Methods, "GET")
-	case core.HTTPMethodHead:
-		consulMatch.Methods = append(consulMatch.Methods, "HEAD")
-	case core.HTTPMethodOptions:
-		consulMatch.Methods = append(consulMatch.Methods, "OPTIONS")
-	case core.HTTPMethodPatch:
-		consulMatch.Methods = append(consulMatch.Methods, "PATCH")
-	case core.HTTPMethodPost:
-		consulMatch.Methods = append(consulMatch.Methods, "POST")
-	case core.HTTPMethodPut:
-		consulMatch.Methods = append(consulMatch.Methods, "PUT")
-	case core.HTTPMethodTrace:
-		consulMatch.Methods = append(consulMatch.Methods, "TRACE")
-	}
-
-	return &consulMatch
-}
-
-func httpServiceDefault(entry api.ConfigEntry, meta map[string]string) *api.ServiceConfigEntry {
-	return &api.ServiceConfigEntry{
-		Kind:      api.ServiceDefaults,
-		Name:      entry.GetName(),
-		Namespace: entry.GetNamespace(),
-		Protocol:  "http",
-		Meta:      meta,
-	}
-}
-
 func routeDiscoveryChain(route core.ResolvedRoute) (*api.IngressService, *api.ServiceRouterConfigEntry, *consul.ConfigEntryIndex, *consul.ConfigEntryIndex) {
 	meta := route.GetMeta()
 	splitters := consul.NewConfigEntryIndex(api.ServiceSplitter)
@@ -296,12 +86,18 @@ func routeDiscoveryChain(route core.ResolvedRoute) (*api.IngressService, *api.Se
 			Hosts:     httpRoute.Hostnames,
 			Namespace: httpRoute.GetNamespace(),
 		}, router, splitters, defaults
+	case core.ResolvedTCPRouteType:
+		tcpRoute := route.(core.TCPRoute)
+		return &api.IngressService{
+			Name:      tcpRoute.Service.Service,
+			Namespace: tcpRoute.Service.ConsulNamespace,
+		}, nil, nil, nil
 	default:
 		return nil, nil, nil, nil
 	}
 }
 
-func mergeRoutes(gateway core.ResolvedGateway, routes []core.ResolvedRoute) []core.ResolvedRoute {
+func mergeHTTPRoutes(gateway core.ResolvedGateway, routes []core.ResolvedRoute) []core.ResolvedRoute {
 	merged := map[string]core.HTTPRoute{}
 	unmerged := []core.ResolvedRoute{}
 	for _, route := range routes {
@@ -332,47 +128,29 @@ func mergeRoutes(gateway core.ResolvedGateway, routes []core.ResolvedRoute) []co
 	return unmerged
 }
 
-func hostsKey(hosts []string) string {
-	sort.Strings(hosts)
-	hostsHash := crc32.NewIEEE()
-	for _, h := range hosts {
-		if _, err := hostsHash.Write([]byte(h)); err != nil {
-			continue
+// filterTCPRoutes makes sure we only have a single TCPRoute for a given listener
+func filterTCPRoutes(routes []core.ResolvedRoute) []core.ResolvedRoute {
+	filtered := []core.ResolvedRoute{}
+
+	found := false
+	for _, route := range routes {
+		switch route.GetType() {
+		case core.ResolvedTCPRouteType:
+			if !found {
+				found = true
+				filtered = append(filtered, route)
+			}
+		default:
+			filtered = append(filtered, route)
 		}
 	}
-	return strconv.FormatUint(uint64(hostsHash.Sum32()), 16)
+
+	return filtered
 }
 
-func compareHTTPRules(ruleA, ruleB core.HTTPRouteRule) bool {
-	matchesA := ruleA.Matches
-	matchesB := ruleB.Matches
-
-	// this tries to implement some of the logic specified by the K8S gateway API spec
-
-	// Proxy or Load Balancer routing configuration generated from HTTPRoutes MUST prioritize
-	// rules based on the following criteria, continuing on ties. Precedence must be given
-	// to the the Rule with the largest number of:
-	// Characters in a matching non-wildcard hostname.
-	// Characters in a matching hostname.
-	// Characters in a matching path.
-	// Header matches.
-	// Query param matches.
-
-	var longestPathMatchA int
-	for _, match := range matchesA {
-		pathLength := len(match.Path.Value)
-		if longestPathMatchA < pathLength {
-			longestPathMatchA = pathLength
-		}
-	}
-	var longestPathMatchB int
-	for _, match := range matchesB {
-		pathLength := len(match.Path.Value)
-		if longestPathMatchB < pathLength {
-			longestPathMatchB = pathLength
-		}
-	}
-	return longestPathMatchA > longestPathMatchB
+func mergeRoutes(gateway core.ResolvedGateway, routes []core.ResolvedRoute) []core.ResolvedRoute {
+	routes = mergeHTTPRoutes(gateway, routes)
+	return filterTCPRoutes(routes)
 }
 
 func discoveryChain(gateway core.ResolvedGateway) (*api.IngressGatewayConfigEntry, *consul.ConfigEntryIndex, *consul.ConfigEntryIndex, *consul.ConfigEntryIndex) {
@@ -394,7 +172,9 @@ func discoveryChain(gateway core.ResolvedGateway) (*api.IngressGatewayConfigEntr
 			service, router, splits, serviceDefaults := routeDiscoveryChain(route)
 			if service != nil {
 				services = append(services, *service)
-				routers.Add(router)
+				if router != nil {
+					routers.Add(router)
+				}
 				splitters.Merge(splits)
 				defaults.Merge(serviceDefaults)
 			}

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -458,42 +458,6 @@ func TestHTTPMeshService(t *testing.T) {
 			err = resources.Create(ctx, route)
 			require.NoError(t, err)
 
-			// route 4 - fallback
-			portFour := gateway.PortNumber(serviceFour.Spec.Ports[0].Port)
-			portFive := gateway.PortNumber(serviceFive.Spec.Ports[0].Port)
-			route = &gateway.HTTPRoute{
-				ObjectMeta: meta.ObjectMeta{
-					Name:      routeFourName,
-					Namespace: namespace,
-				},
-				Spec: gateway.HTTPRouteSpec{
-					CommonRouteSpec: gateway.CommonRouteSpec{
-						ParentRefs: []gateway.ParentRef{{
-							Name: gateway.ObjectName(gatewayName),
-						}},
-					},
-					Rules: []gateway.HTTPRouteRule{{
-						BackendRefs: []gateway.HTTPBackendRef{{
-							BackendRef: gateway.BackendRef{
-								BackendObjectReference: gateway.BackendObjectReference{
-									Name: gateway.ObjectName(serviceFour.Name),
-									Port: &portFour,
-								},
-							},
-						}, {
-							BackendRef: gateway.BackendRef{
-								BackendObjectReference: gateway.BackendObjectReference{
-									Name: gateway.ObjectName(serviceFive.Name),
-									Port: &portFive,
-								},
-							},
-						}},
-					}},
-				},
-			}
-			err = resources.Create(ctx, route)
-			require.NoError(t, err)
-
 			checkPort := e2e.HTTPPort(ctx)
 			checkRoute(t, checkPort, "/v1", serviceOne.Name, nil, "service one not routable in allotted time")
 			checkRoute(t, checkPort, "/v2", serviceTwo.Name, nil, "service two not routable in allotted time")

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -234,18 +235,18 @@ func TestServiceListeners(t *testing.T) {
 	testenv.Test(t, feature.Feature())
 }
 
-func TestMeshService(t *testing.T) {
+func TestHTTPMeshService(t *testing.T) {
 	feature := features.New("mesh service routing").
 		Assess("basic routing", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			serviceOne, err := e2e.DeployMeshService(ctx, cfg)
+			serviceOne, err := e2e.DeployHTTPMeshService(ctx, cfg)
 			require.NoError(t, err)
-			serviceTwo, err := e2e.DeployMeshService(ctx, cfg)
+			serviceTwo, err := e2e.DeployHTTPMeshService(ctx, cfg)
 			require.NoError(t, err)
-			serviceThree, err := e2e.DeployMeshService(ctx, cfg)
+			serviceThree, err := e2e.DeployHTTPMeshService(ctx, cfg)
 			require.NoError(t, err)
-			serviceFour, err := e2e.DeployMeshService(ctx, cfg)
+			serviceFour, err := e2e.DeployHTTPMeshService(ctx, cfg)
 			require.NoError(t, err)
-			serviceFive, err := e2e.DeployMeshService(ctx, cfg)
+			serviceFive, err := e2e.DeployHTTPMeshService(ctx, cfg)
 			require.NoError(t, err)
 
 			namespace := e2e.Namespace(ctx)
@@ -312,7 +313,7 @@ func TestMeshService(t *testing.T) {
 					GatewayClassName: gateway.ObjectName(gc.Name),
 					Listeners: []gateway.Listener{{
 						Name:     "https",
-						Port:     gateway.PortNumber(e2e.ExtraPort(ctx)),
+						Port:     gateway.PortNumber(e2e.HTTPPort(ctx)),
 						Protocol: gateway.HTTPSProtocolType,
 						TLS: &gateway.GatewayTLSConfig{
 							CertificateRefs: []*gateway.SecretObjectReference{{
@@ -476,7 +477,7 @@ func TestMeshService(t *testing.T) {
 			err = resources.Create(ctx, route)
 			require.NoError(t, err)
 
-			checkPort := e2e.ExtraPort(ctx)
+			checkPort := e2e.HTTPPort(ctx)
 			checkRoute(t, checkPort, "/v1", serviceOne.Name, nil, "service one not routable in allotted time")
 			checkRoute(t, checkPort, "/v2", serviceTwo.Name, nil, "service two not routable in allotted time")
 			checkRoute(t, checkPort, "/v3", serviceThree.Name, map[string]string{
@@ -499,6 +500,168 @@ func TestMeshService(t *testing.T) {
 	testenv.Test(t, feature.Feature())
 }
 
+func TestTCPMeshService(t *testing.T) {
+	feature := features.New("mesh service routing").
+		Assess("basic routing", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			serviceOne, err := e2e.DeployTCPMeshService(ctx, cfg)
+			require.NoError(t, err)
+			serviceTwo, err := e2e.DeployTCPMeshService(ctx, cfg)
+			require.NoError(t, err)
+			serviceThree, err := e2e.DeployTCPMeshService(ctx, cfg)
+			require.NoError(t, err)
+			serviceFour, err := e2e.DeployTCPMeshService(ctx, cfg)
+			require.NoError(t, err)
+
+			namespace := e2e.Namespace(ctx)
+			configName := envconf.RandomName("gcc", 16)
+			className := envconf.RandomName("gc", 16)
+			gatewayName := envconf.RandomName("gw", 16)
+			routeOneName := envconf.RandomName("route", 16)
+			routeTwoName := envconf.RandomName("route", 16)
+
+			resources := cfg.Client().Resources(namespace)
+
+			gcc := &apigwv1alpha1.GatewayClassConfig{
+				ObjectMeta: meta.ObjectMeta{
+					Name: configName,
+				},
+				Spec: apigwv1alpha1.GatewayClassConfigSpec{
+					ImageSpec: apigwv1alpha1.ImageSpec{
+						ConsulAPIGateway: e2e.DockerImage(ctx),
+					},
+					UseHostPorts: true,
+					LogLevel:     "trace",
+					ConsulSpec: apigwv1alpha1.ConsulSpec{
+						Address: hostRoute,
+						Scheme:  "https",
+						PortSpec: apigwv1alpha1.PortSpec{
+							GRPC: e2e.ConsulGRPCPort(ctx),
+							HTTP: e2e.ConsulHTTPPort(ctx),
+						},
+						AuthSpec: apigwv1alpha1.AuthSpec{
+							Method:  "consul-api-gateway",
+							Account: "consul-api-gateway",
+						},
+					},
+				},
+			}
+			err = resources.Create(ctx, gcc)
+			require.NoError(t, err)
+
+			gc := &gateway.GatewayClass{
+				ObjectMeta: meta.ObjectMeta{
+					Name: className,
+				},
+				Spec: gateway.GatewayClassSpec{
+					ControllerName: k8s.ControllerName,
+					ParametersRef: &gateway.ParametersReference{
+						Group: apigwv1alpha1.Group,
+						Kind:  apigwv1alpha1.GatewayClassConfigKind,
+						Name:  configName,
+					},
+				},
+			}
+			err = resources.Create(ctx, gc)
+			require.NoError(t, err)
+
+			gw := &gateway.Gateway{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      gatewayName,
+					Namespace: namespace,
+				},
+				Spec: gateway.GatewaySpec{
+					GatewayClassName: gateway.ObjectName(gc.Name),
+					Listeners: []gateway.Listener{{
+						Name:     "tcp",
+						Port:     gateway.PortNumber(e2e.TCPPort(ctx)),
+						Protocol: gateway.TCPProtocolType,
+					}},
+				},
+			}
+			err = resources.Create(ctx, gw)
+			require.NoError(t, err)
+			require.Eventually(t, gatewayStatusCheck(ctx, resources, gatewayName, namespace, gatewayReady), 30*time.Second, 1*time.Second, "no gateway found in the allotted time")
+
+			// route 1
+			portOne := gateway.PortNumber(serviceOne.Spec.Ports[0].Port)
+			portTwo := gateway.PortNumber(serviceTwo.Spec.Ports[0].Port)
+			portThree := gateway.PortNumber(serviceThree.Spec.Ports[0].Port)
+			routeOne := &gateway.TCPRoute{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      routeOneName,
+					Namespace: namespace,
+				},
+				Spec: gateway.TCPRouteSpec{
+					CommonRouteSpec: gateway.CommonRouteSpec{
+						ParentRefs: []gateway.ParentRef{{
+							Name: gateway.ObjectName(gatewayName),
+						}},
+					},
+					Rules: []gateway.TCPRouteRule{{
+						BackendRefs: []gateway.BackendRef{{
+							BackendObjectReference: gateway.BackendObjectReference{
+								Name: gateway.ObjectName(serviceOne.Name),
+								Port: &portOne,
+							},
+						}, {
+							BackendObjectReference: gateway.BackendObjectReference{
+								Name: gateway.ObjectName(serviceTwo.Name),
+								Port: &portTwo,
+							},
+						}},
+					}, {
+						BackendRefs: []gateway.BackendRef{{
+							BackendObjectReference: gateway.BackendObjectReference{
+								Name: gateway.ObjectName(serviceThree.Name),
+								Port: &portThree,
+							},
+						}},
+					}},
+				},
+			}
+			err = resources.Create(ctx, routeOne)
+			require.NoError(t, err)
+
+			require.Eventually(t, tcpRouteStatusCheck(ctx, resources, gatewayName, routeOneName, namespace, routeRefErrors), 30*time.Second, 1*time.Second, "route status not set in allotted time")
+
+			// route 2
+			portFour := gateway.PortNumber(serviceFour.Spec.Ports[0].Port)
+			route := &gateway.TCPRoute{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      routeTwoName,
+					Namespace: namespace,
+				},
+				Spec: gateway.TCPRouteSpec{
+					CommonRouteSpec: gateway.CommonRouteSpec{
+						ParentRefs: []gateway.ParentRef{{
+							Name: gateway.ObjectName(gatewayName),
+						}},
+					},
+					Rules: []gateway.TCPRouteRule{{
+						BackendRefs: []gateway.BackendRef{{
+							BackendObjectReference: gateway.BackendObjectReference{
+								Name: gateway.ObjectName(serviceFour.Name),
+								Port: &portFour,
+							},
+						}},
+					}},
+				},
+			}
+			err = resources.Create(ctx, route)
+			require.NoError(t, err)
+
+			checkPort := e2e.TCPPort(ctx)
+
+			// only service 4 should be routable as we don't support routes with multiple rules or backend refs for TCP
+			checkTCPRoute(t, checkPort, serviceFour.Name, "service four not routable in allotted time")
+
+			require.Eventually(t, gatewayStatusCheck(ctx, resources, gatewayName, namespace, gatewayInSync), 30*time.Second, 1*time.Second, "gateway not synced in the allotted time")
+			return ctx
+		})
+
+	testenv.Test(t, feature.Feature())
+}
+
 func gatewayStatusCheck(ctx context.Context, resources *resources.Resources, gatewayName, namespace string, checkFn func([]meta.Condition) bool) func() bool {
 	return func() bool {
 		updated := &gateway.Gateway{}
@@ -509,9 +672,35 @@ func gatewayStatusCheck(ctx context.Context, resources *resources.Resources, gat
 	}
 }
 
+func tcpRouteStatusCheck(ctx context.Context, resources *resources.Resources, gatewayName, routeName, namespace string, checkFn func([]meta.Condition) bool) func() bool {
+	return func() bool {
+		updated := &gateway.TCPRoute{}
+		if err := resources.Get(ctx, routeName, namespace, updated); err != nil {
+			return false
+		}
+		for _, status := range updated.Status.Parents {
+			if string(status.ParentRef.Name) == gatewayName {
+				return checkFn(status.Conditions)
+			}
+		}
+		return false
+	}
+}
+
+func routeRefErrors(conditions []meta.Condition) bool {
+	for _, condition := range conditions {
+		if condition.Type == "ResolvedRefs" &&
+			condition.Status == "False" &&
+			condition.Reason == "Errors" {
+			return true
+		}
+	}
+	return false
+}
+
 func gatewayReady(conditions []meta.Condition) bool {
 	for _, condition := range conditions {
-		if condition.Type == "Accepted" ||
+		if condition.Type == "Ready" &&
 			condition.Status == "True" {
 			return true
 		}
@@ -521,7 +710,7 @@ func gatewayReady(conditions []meta.Condition) bool {
 
 func gatewayInSync(conditions []meta.Condition) bool {
 	for _, condition := range conditions {
-		if condition.Type == "InSync" ||
+		if condition.Type == "InSync" &&
 			condition.Status == "True" {
 			return true
 		}
@@ -619,6 +808,25 @@ func checkRoute(t *testing.T, port int, path, expected string, headers map[strin
 			return false
 		}
 
+		return strings.HasPrefix(string(data), expected)
+	}, 30*time.Second, 1*time.Second, message)
+}
+
+func checkTCPRoute(t *testing.T, port int, expected string, message string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTCP("tcp", nil, &net.TCPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: port,
+		})
+		if err != nil {
+			return false
+		}
+		data, err := io.ReadAll(conn)
+		if err != nil {
+			return false
+		}
 		return strings.HasPrefix(string(data), expected)
 	}, 30*time.Second, 1*time.Second, message)
 }

--- a/internal/consul/config_entries.go
+++ b/internal/consul/config_entries.go
@@ -17,6 +17,9 @@ func NewConfigEntryIndex(kind string) *ConfigEntryIndex {
 }
 
 func (i *ConfigEntryIndex) Add(entry api.ConfigEntry) {
+	if entry == nil {
+		return
+	}
 	if entry.GetKind() != i.kind {
 		return
 	}
@@ -24,6 +27,9 @@ func (i *ConfigEntryIndex) Add(entry api.ConfigEntry) {
 }
 
 func (i *ConfigEntryIndex) Merge(other *ConfigEntryIndex) {
+	if other == nil {
+		return
+	}
 	if i.kind != other.kind {
 		return
 	}

--- a/internal/core/tcp.go
+++ b/internal/core/tcp.go
@@ -1,0 +1,52 @@
+package core
+
+type TCPRoute struct {
+	CommonRoute
+	Service ResolvedService
+}
+
+func (r TCPRoute) GetType() ResolvedRouteType {
+	return ResolvedTCPRouteType
+}
+
+type TCPRouteBuilder struct {
+	meta      map[string]string
+	name      string
+	namespace string
+	service   ResolvedService
+}
+
+func (b *TCPRouteBuilder) WithMeta(meta map[string]string) *TCPRouteBuilder {
+	b.meta = meta
+	return b
+}
+
+func (b *TCPRouteBuilder) WithName(name string) *TCPRouteBuilder {
+	b.name = name
+	return b
+}
+
+func (b *TCPRouteBuilder) WithNamespace(namespace string) *TCPRouteBuilder {
+	b.namespace = namespace
+	return b
+}
+
+func (b *TCPRouteBuilder) WithService(service ResolvedService) *TCPRouteBuilder {
+	b.service = service
+	return b
+}
+
+func (b *TCPRouteBuilder) Build() ResolvedRoute {
+	return TCPRoute{
+		CommonRoute: CommonRoute{
+			Meta:      b.meta,
+			Name:      b.name,
+			Namespace: b.namespace,
+		},
+		Service: b.service,
+	}
+}
+
+func NewTCPRouteBuilder() *TCPRouteBuilder {
+	return &TCPRouteBuilder{}
+}

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -192,5 +192,15 @@ func (k *Kubernetes) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to create http route controller: %w", err)
 	}
 
+	err = (&controllers.TCPRouteReconciler{
+		Client:         gwClient,
+		Log:            k.logger.Named("TCPRoute"),
+		Manager:        reconcileManager,
+		ControllerName: ControllerName,
+	}).SetupWithManager(k.k8sManager)
+	if err != nil {
+		return fmt.Errorf("failed to create tcp route controller: %w", err)
+	}
+
 	return k.k8sManager.Start(ctx)
 }

--- a/internal/k8s/controllers/tcp_route_controller.go
+++ b/internal/k8s/controllers/tcp_route_controller.go
@@ -11,47 +11,47 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-// HTTPRouteReconciler reconciles a HTTPRoute object
-type HTTPRouteReconciler struct {
+// TCPRouteReconciler reconciles a HTTPRoute object
+type TCPRouteReconciler struct {
 	Client         gatewayclient.Client
 	Log            hclog.Logger
 	ControllerName string
 	Manager        reconciler.ReconcileManager
 }
 
-//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes/finalizers,verbs=update
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tcproutes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tcproutes/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tcproutes/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
-func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := r.Log.With("http-route", req.NamespacedName)
+func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := r.Log.With("tcp-route", req.NamespacedName)
 
-	route, err := r.Client.GetHTTPRoute(ctx, req.NamespacedName)
+	route, err := r.Client.GetTCPRoute(ctx, req.NamespacedName)
 	if err != nil {
-		logger.Error("failed to get http route", "error", err)
+		logger.Error("failed to get tcp route", "error", err)
 		return ctrl.Result{}, err
 	}
 
 	if route == nil {
 		// clean up cached resources
-		err := r.Manager.DeleteHTTPRoute(ctx, req.NamespacedName)
+		err := r.Manager.DeleteTCPRoute(ctx, req.NamespacedName)
 		return ctrl.Result{}, err
 	}
 
 	// let the route get upserted so long as there's a single gateway we control
 	// that it's managed by -- the underlying reconciliation code will handle the
 	// validation of gateway attachment
-	err = r.Manager.UpsertHTTPRoute(ctx, route)
+	err = r.Manager.UpsertTCPRoute(ctx, route)
 	return ctrl.Result{}, err
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&gateway.HTTPRoute{}).
+		For(&gateway.TCPRoute{}).
 		Complete(gatewayclient.NewRequeueingMiddleware(r.Log, r))
 }

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -32,6 +32,7 @@ type Client interface {
 	GetSecret(ctx context.Context, key types.NamespacedName) (*core.Secret, error)
 	GetService(ctx context.Context, key types.NamespacedName) (*core.Service, error)
 	GetHTTPRoute(ctx context.Context, key types.NamespacedName) (*gateway.HTTPRoute, error)
+	GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error)
 
 	// finalizer helpers
 
@@ -204,6 +205,17 @@ func (g *gatewayClient) GetSecret(ctx context.Context, key types.NamespacedName)
 
 func (g *gatewayClient) GetHTTPRoute(ctx context.Context, key types.NamespacedName) (*gateway.HTTPRoute, error) {
 	route := &gateway.HTTPRoute{}
+	if err := g.Client.Get(ctx, key, route); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, NewK8sError(err)
+	}
+	return route, nil
+}
+
+func (g *gatewayClient) GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error) {
+	route := &gateway.TCPRoute{}
 	if err := g.Client.Get(ctx, key, route); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, nil

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -260,6 +260,21 @@ func (mr *MockClientMockRecorder) GetService(ctx, key interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockClient)(nil).GetService), ctx, key)
 }
 
+// GetTCPRoute mocks base method.
+func (m *MockClient) GetTCPRoute(ctx context.Context, key types.NamespacedName) (*v1alpha2.TCPRoute, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTCPRoute", ctx, key)
+	ret0, _ := ret[0].(*v1alpha2.TCPRoute)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTCPRoute indicates an expected call of GetTCPRoute.
+func (mr *MockClientMockRecorder) GetTCPRoute(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTCPRoute", reflect.TypeOf((*MockClient)(nil).GetTCPRoute), ctx, key)
+}
+
 // HasManagedDeployment mocks base method.
 func (m *MockClient) HasManagedDeployment(ctx context.Context, gw *v1alpha2.Gateway) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/k8s/reconciler/config/errors.yaml
+++ b/internal/k8s/reconciler/config/errors.yaml
@@ -1,4 +1,4 @@
 - name: CertificateResolution
   types: ["NotFound","Unsupported"]
 - name: Bind
-  types: ["RouteKind","ListenerNamespacePolicy","HostnameMismatch"]
+  types: ["RouteKind","ListenerNamespacePolicy","HostnameMismatch","RouteInvalid"]

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -274,11 +274,6 @@ func (g *K8sGateway) ShouldBind(route store.Route) bool {
 		return false
 	}
 
-	if !k8sRoute.IsValid() {
-		g.logger.Trace("route is invalid, should not bind", "route", route.ID())
-		return false
-	}
-
 	for _, ref := range k8sRoute.CommonRouteSpec().ParentRefs {
 		if namespacedName, isGateway := utils.ReferencesGateway(k8sRoute.GetNamespace(), ref); isGateway {
 			if utils.NamespacedName(g.gateway) == namespacedName {
@@ -286,7 +281,6 @@ func (g *K8sGateway) ShouldBind(route store.Route) bool {
 			}
 		}
 	}
-	g.logger.Trace("route does not reference gateway, should not bind", "route", route.ID())
 	return false
 }
 

--- a/internal/k8s/reconciler/tcp_route.go
+++ b/internal/k8s/reconciler/tcp_route.go
@@ -1,7 +1,46 @@
 package reconciler
 
-import "k8s.io/apimachinery/pkg/types"
+import (
+	"github.com/hashicorp/consul-api-gateway/internal/core"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/service"
+	"k8s.io/apimachinery/pkg/types"
+	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
 
 func TCPRouteID(namespacedName types.NamespacedName) string {
 	return "tcp-" + namespacedName.String()
+}
+
+func convertTCPRoute(namespace, prefix string, meta map[string]string, route *gw.TCPRoute, k8sRoute *K8sRoute) *core.ResolvedRoute {
+	name := prefix + route.Name
+
+	resolved := core.NewTCPRouteBuilder().
+		WithName(name).
+		// we always use the listener namespace for the routes
+		// themselves, while the services they route to might
+		// be in different namespaces
+		WithNamespace(namespace).
+		WithMeta(meta).
+		WithService(tcpReferencesToService(k8sRoute.references)).
+		Build()
+	return &resolved
+}
+
+func tcpReferencesToService(referenceMap service.RouteRuleReferenceMap) core.ResolvedService {
+	for _, references := range referenceMap {
+		for _, reference := range references {
+			switch reference.Type {
+			case service.ConsulServiceReference:
+				// at this point there should only be a single resolved service in the reference map
+				return core.ResolvedService{
+					ConsulNamespace: reference.Consul.Namespace,
+					Service:         reference.Consul.Name,
+				}
+			default:
+				// TODO: support other reference types
+				continue
+			}
+		}
+	}
+	return core.ResolvedService{}
 }

--- a/internal/k8s/reconciler/zz_generated_errors.go
+++ b/internal/k8s/reconciler/zz_generated_errors.go
@@ -35,6 +35,7 @@ const (
 	BindErrorTypeRouteKind BindErrorType = iota
 	BindErrorTypeListenerNamespacePolicy
 	BindErrorTypeHostnameMismatch
+	BindErrorTypeRouteInvalid
 )
 
 type BindError struct {
@@ -50,6 +51,9 @@ func NewBindErrorListenerNamespacePolicy(inner string) BindError {
 }
 func NewBindErrorHostnameMismatch(inner string) BindError {
 	return BindError{inner, BindErrorTypeHostnameMismatch}
+}
+func NewBindErrorRouteInvalid(inner string) BindError {
+	return BindError{inner, BindErrorTypeRouteInvalid}
 }
 
 func (r BindError) Error() string {

--- a/internal/k8s/reconciler/zz_generated_errors_test.go
+++ b/internal/k8s/reconciler/zz_generated_errors_test.go
@@ -30,4 +30,6 @@ func TestBindErrorType(t *testing.T) {
 	require.Equal(t, BindErrorTypeListenerNamespacePolicy, NewBindErrorListenerNamespacePolicy(expected).Kind())
 	require.Equal(t, expected, NewBindErrorHostnameMismatch(expected).Error())
 	require.Equal(t, BindErrorTypeHostnameMismatch, NewBindErrorHostnameMismatch(expected).Kind())
+	require.Equal(t, expected, NewBindErrorRouteInvalid(expected).Error())
+	require.Equal(t, BindErrorTypeRouteInvalid, NewBindErrorRouteInvalid(expected).Kind())
 }

--- a/internal/k8s/service/resolver.go
+++ b/internal/k8s/service/resolver.go
@@ -97,7 +97,7 @@ func (r *ResolutionErrors) String() string {
 	}
 
 	if len(r.genericErrors) > 0 {
-		genericErrs := "k8s: "
+		genericErrs := ""
 		for i, err := range r.genericErrors {
 			if i != 0 {
 				genericErrs += ", "

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -65,6 +65,7 @@ type Listener interface {
 	CanBind(route Route) (bool, error)
 	Certificates() []string
 	Config() ListenerConfig
+	IsValid() bool
 }
 
 // StatusTrackingRoute is an optional extension

--- a/internal/store/memory/gateway.go
+++ b/internal/store/memory/gateway.go
@@ -116,7 +116,9 @@ func (g *gatewayState) sync(ctx context.Context) error {
 func (g *gatewayState) Resolve() core.ResolvedGateway {
 	listeners := []core.ResolvedListener{}
 	for _, listener := range g.listeners {
-		listeners = append(listeners, listener.Resolve())
+		if listener.Listener.IsValid() {
+			listeners = append(listeners, listener.Resolve())
+		}
 	}
 	return core.ResolvedGateway{
 		ID:        g.ID(),

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -70,15 +70,16 @@ func init() {
 }
 
 type consulTestEnvironment struct {
-	ca            []byte
-	consulClient  *api.Client
-	token         string
-	policy        *api.ACLPolicy
-	httpPort      int
-	grpcPort      int
-	extraHTTPPort int
-	extraTCPPort  int
-	ip            string
+	ca              []byte
+	consulClient    *api.Client
+	token           string
+	policy          *api.ACLPolicy
+	httpPort        int
+	grpcPort        int
+	extraHTTPPort   int
+	extraTCPPort    int
+	extraTCPTLSPort int
+	ip              string
 }
 
 func CreateTestConsulContainer(name, namespace string) env.Func {
@@ -93,6 +94,7 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 		httpsPort := cluster.httpsPort
 		grpcPort := cluster.grpcPort
 		extraTCPPort := cluster.extraTCPPort
+		extraTCPTLSPort := cluster.extraTCPTLSPort
 		extraHTTPPort := cluster.extraHTTPPort
 
 		rootCA, err := testing.GenerateSignedCertificate(testing.GenerateCertificateOptions{
@@ -177,13 +179,14 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 		}
 
 		env := &consulTestEnvironment{
-			ca:            rootCA.CertBytes,
-			consulClient:  consulClient,
-			httpPort:      httpsPort,
-			grpcPort:      grpcPort,
-			extraHTTPPort: extraHTTPPort,
-			extraTCPPort:  extraTCPPort,
-			ip:            ip,
+			ca:              rootCA.CertBytes,
+			consulClient:    consulClient,
+			httpPort:        httpsPort,
+			grpcPort:        grpcPort,
+			extraHTTPPort:   extraHTTPPort,
+			extraTCPPort:    extraTCPPort,
+			extraTCPTLSPort: extraTCPTLSPort,
+			ip:              ip,
 		}
 
 		return context.WithValue(ctx, consulTestContextKey, env), nil
@@ -413,6 +416,14 @@ func TCPPort(ctx context.Context) int {
 		panic("must run this with an integration test that has called CreateTestConsul")
 	}
 	return consulEnvironment.(*consulTestEnvironment).extraTCPPort
+}
+
+func TCPTLSPort(ctx context.Context) int {
+	consulEnvironment := ctx.Value(consulTestContextKey)
+	if consulEnvironment == nil {
+		panic("must run this with an integration test that has called CreateTestConsul")
+	}
+	return consulEnvironment.(*consulTestEnvironment).extraTCPTLSPort
 }
 
 func HTTPPort(ctx context.Context) int {

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -70,14 +70,15 @@ func init() {
 }
 
 type consulTestEnvironment struct {
-	ca           []byte
-	consulClient *api.Client
-	token        string
-	policy       *api.ACLPolicy
-	httpPort     int
-	grpcPort     int
-	extraPort    int
-	ip           string
+	ca            []byte
+	consulClient  *api.Client
+	token         string
+	policy        *api.ACLPolicy
+	httpPort      int
+	grpcPort      int
+	extraHTTPPort int
+	extraTCPPort  int
+	ip            string
 }
 
 func CreateTestConsulContainer(name, namespace string) env.Func {
@@ -91,7 +92,8 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 		cluster := clusterVal.(*kindCluster)
 		httpsPort := cluster.httpsPort
 		grpcPort := cluster.grpcPort
-		extraPort := cluster.extraPort
+		extraTCPPort := cluster.extraTCPPort
+		extraHTTPPort := cluster.extraHTTPPort
 
 		rootCA, err := testing.GenerateSignedCertificate(testing.GenerateCertificateOptions{
 			IsCA: true,
@@ -175,12 +177,13 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 		}
 
 		env := &consulTestEnvironment{
-			ca:           rootCA.CertBytes,
-			consulClient: consulClient,
-			httpPort:     httpsPort,
-			grpcPort:     grpcPort,
-			extraPort:    extraPort,
-			ip:           ip,
+			ca:            rootCA.CertBytes,
+			consulClient:  consulClient,
+			httpPort:      httpsPort,
+			grpcPort:      grpcPort,
+			extraHTTPPort: extraHTTPPort,
+			extraTCPPort:  extraTCPPort,
+			ip:            ip,
 		}
 
 		return context.WithValue(ctx, consulTestContextKey, env), nil
@@ -404,12 +407,20 @@ func ConsulGRPCPort(ctx context.Context) int {
 	return consulEnvironment.(*consulTestEnvironment).grpcPort
 }
 
-func ExtraPort(ctx context.Context) int {
+func TCPPort(ctx context.Context) int {
 	consulEnvironment := ctx.Value(consulTestContextKey)
 	if consulEnvironment == nil {
 		panic("must run this with an integration test that has called CreateTestConsul")
 	}
-	return consulEnvironment.(*consulTestEnvironment).extraPort
+	return consulEnvironment.(*consulTestEnvironment).extraTCPPort
+}
+
+func HTTPPort(ctx context.Context) int {
+	consulEnvironment := ctx.Value(consulTestContextKey)
+	if consulEnvironment == nil {
+		panic("must run this with an integration test that has called CreateTestConsul")
+	}
+	return consulEnvironment.(*consulTestEnvironment).extraHTTPPort
 }
 
 func ConsulHTTPPort(ctx context.Context) int {

--- a/internal/testing/e2e/kind.go
+++ b/internal/testing/e2e/kind.go
@@ -46,6 +46,9 @@ nodes:
   - containerPort: {{ .ExtraHTTPPort }}
     hostPort: {{ .ExtraHTTPPort }}
     protocol: TCP
+  - containerPort: {{ .ExtraTCPTLSPort }}
+    hostPort: {{ .ExtraTCPTLSPort }}
+    protocol: TCP
 `
 )
 
@@ -57,19 +60,28 @@ func init() {
 
 // based off github.com/kubernetes-sigs/e2e-framework/support/kind
 type kindCluster struct {
-	name          string
-	e             *gexe.Echo
-	kubecfgFile   string
-	config        string
-	httpsPort     int
-	grpcPort      int
-	extraHTTPPort int
-	extraTCPPort  int
+	name            string
+	e               *gexe.Echo
+	kubecfgFile     string
+	config          string
+	httpsPort       int
+	grpcPort        int
+	extraHTTPPort   int
+	extraTCPPort    int
+	extraTCPTLSPort int
 }
 
 func newKindCluster(name string) *kindCluster {
-	ports := freeport.MustTake(4)
-	return &kindCluster{name: name, e: gexe.New(), httpsPort: ports[0], grpcPort: ports[1], extraHTTPPort: ports[2], extraTCPPort: ports[3]}
+	ports := freeport.MustTake(5)
+	return &kindCluster{
+		name:            name,
+		e:               gexe.New(),
+		httpsPort:       ports[0],
+		grpcPort:        ports[1],
+		extraHTTPPort:   ports[2],
+		extraTCPPort:    ports[3],
+		extraTCPTLSPort: ports[4],
+	}
 }
 
 func (k *kindCluster) Create() (string, error) {
@@ -77,15 +89,17 @@ func (k *kindCluster) Create() (string, error) {
 
 	var kindConfig bytes.Buffer
 	err := kindTemplate.Execute(&kindConfig, &struct {
-		HTTPSPort     int
-		GRPCPort      int
-		ExtraTCPPort  int
-		ExtraHTTPPort int
+		HTTPSPort       int
+		GRPCPort        int
+		ExtraTCPPort    int
+		ExtraTCPTLSPort int
+		ExtraHTTPPort   int
 	}{
-		HTTPSPort:     k.httpsPort,
-		GRPCPort:      k.grpcPort,
-		ExtraTCPPort:  k.extraTCPPort,
-		ExtraHTTPPort: k.extraHTTPPort,
+		HTTPSPort:       k.httpsPort,
+		GRPCPort:        k.grpcPort,
+		ExtraTCPPort:    k.extraTCPPort,
+		ExtraTCPTLSPort: k.extraTCPTLSPort,
+		ExtraHTTPPort:   k.extraHTTPPort,
 	})
 	if err != nil {
 		return "", err

--- a/internal/testing/e2e/kubernetes.go
+++ b/internal/testing/e2e/kubernetes.go
@@ -49,6 +49,8 @@ func InstallGatewayCRDs(ctx context.Context, cfg *envconf.Config) (context.Conte
 		&gateway.GatewayList{},
 		&gateway.HTTPRoute{},
 		&gateway.HTTPRouteList{},
+		&gateway.TCPRoute{},
+		&gateway.TCPRouteList{},
 	)
 	meta.AddToGroupVersion(scheme.Scheme, gateway.SchemeGroupVersion)
 


### PR DESCRIPTION
This PR introduces the Gateway API's `TCPRoute`s -- in the process of implementation I also found a bug in how we were setting binding/resolution errors in our route statuses and went ahead and fixed that.

There are two implementation-specific constraints for `TCPRoute`s that I added. Due to the way Consul `IngressGateway` config entries only support single services when they leverage the TCP protocol:

1. `TCPRoute`s may only have a single backend service, which means
  a. Only a single routing rule can be defined on a `TCPRoute`
  b. The single routing rule can only have a single entry in `backendRefs`
2. The spec doesn't specify what to do with multiple `TCPRoute`s that reference the same Gateway listener, because of the need for only a single backend, we mark the listener status with `Conflicted` condition of `RouteConflict`, which essentially keeps the listener from being bound on the gateway until its resolved.

Checklist:
- [x] Tests added

Still adding more tests and cleaning stuff up, so going to mark this as a draft for the time being.
