### PR TITLE
Enabling Security-Scan for CRT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: build
 on:
   push:
     branches:    
-      # - 'release/**'
-      - 'enable-security-scan'
+      - 'release/**'
 
 env:
   CGO_ENABLED: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,8 @@ name: build
 on:
   push:
     branches:    
-      - 'release/**'
+      # - 'release/**'
+      - 'enable-security-scan'
 
 env:
   CGO_ENABLED: 0

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,12 +3,12 @@ schema = "1"
 project "consul-api-gateway" {
   team = "consul-api-gateway"
   slack {
-    notification_channel = "C01RWVBQ6GJ"
+    notification_channel = "C01A3A54G0L"
   }
   github {
     organization = "hashicorp"
     repository = "consul-api-gateway"
-    release_branches = ["release/0.1.x"]
+    release_branches = ["enable-security-scan"]
   }
 }
 
@@ -40,8 +40,36 @@ event "upload-dev" {
   }
 }
 
-event "sign" {
+event "security-scan-binaries" {
   depends = ["upload-dev"]
+  action "security-scan-binaries" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-binaries"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "security-scan-containers" {
+  depends = ["security-scan-binaries"]
+  action "security-scan-containers" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-containers"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "sign" {
+  depends = ["security-scan-containers"]
   action "sign" {
     organization = "hashicorp"
     repository = "crt-workflows-common"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,12 +3,12 @@ schema = "1"
 project "consul-api-gateway" {
   team = "consul-api-gateway"
   slack {
-    notification_channel = "C01A3A54G0L"
+    notification_channel = "C01RWVBQ6GJ"
   }
   github {
     organization = "hashicorp"
     repository = "consul-api-gateway"
-    release_branches = ["enable-security-scan"]
+    release_branches = ["release/0.1.x"]
   }
 }
 

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,13 @@
+container {
+	dependencies = true
+	alpine_secdb = true
+	secrets      = true
+}
+
+binary {
+	secrets      = true
+	go_modules   = true
+	osv          = true
+	oss_index    = true
+	nvd          = true
+}


### PR DESCRIPTION
Changes proposed in this PR:

What this PR does is it enables security scanning (owned by the Security team) for this repository. This is a part of the Common Release Tooling (CRT) effort `which enables a consistent workflow for security scanning that can be used across products and services. It provides a single abstraction point to allow us integrate our own scanning capabilities, as well as leverage external tools and APIs from vendors, open source, or free-to-use projects.` Learn more about HashiCorp's security-scanner [here](https://github.com/hashicorp/security-scanner/).

If anyone needs any further clarification or if nothing makes sense, feel free to comment or reach out to me! ❤️

How I've tested this PR:

I ran the tests in crt-workflows-common and the passing tests are as follows: 

- [security-scan-binaries](https://github.com/hashicorp/crt-workflows-common/actions/runs/1588311739)
- [security-scan-containers](https://github.com/hashicorp/crt-workflows-common/actions/runs/1588318571)
- [verify](https://github.com/hashicorp/crt-workflows-common/actions/runs/1588330432) -- this is the very last workflow that is run in workflows common and verifies that everything looks good. 

How I expect reviewers to test this PR:

You can test this PR by creating a new branch by setting your branch name in `release_branches` in `ci.hcl` and changing the `push` event in `build.yml` to your branch name -- this will cause the build workflow to run, once succeeded, the orchestrator will kick off the workflows in [crt-workflows-common](https://github.com/hashicorp/crt-workflows-common/actions).