### PR TITLE
Fix Consul 1.11 certificate write blocking issues

### DIFF
--- a/internal/consul/certmanager_test.go
+++ b/internal/consul/certmanager_test.go
@@ -50,6 +50,7 @@ func TestManage(t *testing.T) {
 			options.Directory = directory
 
 			manager := NewCertManager(hclog.NewNullLogger(), server.consul, service, options)
+			manager.skipExtraFetch = true
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -108,6 +109,7 @@ func TestManage_Refresh(t *testing.T) {
 
 	options := DefaultCertManagerOptions()
 	manager := NewCertManager(hclog.NewNullLogger(), server.consul, service, options)
+	manager.skipExtraFetch = true
 
 	writes := int32(0)
 	manager.writeCerts = func() error {


### PR DESCRIPTION
The description of the issue is in the comment on the workaround/fix -- we basically force a blocking query timeout prior to kicking off the cert watching goroutines to make sure we successfully retrieve the leaf cert prior to blocking until rotation. Communicated the issue upstream so that we can get a fix in core as well.

How I've tested this PR:

Deployed a gateway talking to Consul 1.11 -- restarted the gateway a few times and made sure it always retrieved the certificates.

Workaround for https://github.com/hashicorp/consul/issues/12048