### PR TITLE
Add service account management

### DIFF
--- a/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -52,6 +52,10 @@ spec:
                         description: The Kubernetes service account to authenticate
                           as.
                         type: string
+                      managed:
+                        description: Whether deployments should be run with "managed"
+                          service accounts created by the gateway controller.
+                        type: boolean
                       method:
                         description: The Consul auth method used for initial authentication
                           by consul-api-gateway.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,6 +84,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/internal/k8s/controllers/gateway_controller.go
+++ b/internal/k8s/controllers/gateway_controller.go
@@ -82,6 +82,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gateway.Gateway{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
 		Watches(
 			&source.Kind{Type: &corev1.Pod{}},
 			handler.EnqueueRequestsFromMapFunc(podToGatewayRequest),

--- a/internal/k8s/controllers/gateway_controller.go
+++ b/internal/k8s/controllers/gateway_controller.go
@@ -38,6 +38,7 @@ type GatewayReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=list;watch
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;get;create;watch
 //+kubebuilder:rbac:groups=core,resources=services,verbs=list;get;create;watch
+//+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;get;create;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -335,13 +335,14 @@ func (g *gatewayClient) EnsureServiceAccount(ctx context.Context, owner *gateway
 		}
 		return NewK8sError(err)
 	}
-	for key, value := range serviceAccount.Labels {
-		if created.Labels[key] != value {
-			// we found the object, but we're not the owner of it, return an error
-			return errors.New("service account not owned by the gateway")
+	for _, ref := range created.GetOwnerReferences() {
+		if ref.UID == owner.GetUID() && ref.Name == owner.GetName() {
+			// we found proper ownership
+			return nil
 		}
 	}
-	return nil
+	// we found the object, but we're not the owner of it, return an error
+	return errors.New("service account not owned by the gateway")
 }
 
 func (g *gatewayClient) SetControllerOwnership(owner, object client.Object) error {

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -124,6 +124,20 @@ func (mr *MockClientMockRecorder) EnsureFinalizer(ctx, object, finalizer interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureFinalizer", reflect.TypeOf((*MockClient)(nil).EnsureFinalizer), ctx, object, finalizer)
 }
 
+// EnsureServiceAccount mocks base method.
+func (m *MockClient) EnsureServiceAccount(ctx context.Context, owner *v1alpha2.Gateway, serviceAccount *v10.ServiceAccount) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureServiceAccount", ctx, owner, serviceAccount)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureServiceAccount indicates an expected call of EnsureServiceAccount.
+func (mr *MockClientMockRecorder) EnsureServiceAccount(ctx, owner, serviceAccount interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureServiceAccount", reflect.TypeOf((*MockClient)(nil).EnsureServiceAccount), ctx, owner, serviceAccount)
+}
+
 // GatewayClassConfigInUse mocks base method.
 func (m *MockClient) GatewayClassConfigInUse(ctx context.Context, gcc *v1alpha1.GatewayClassConfig) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -364,6 +364,13 @@ func (g *K8sGateway) TrackSync(ctx context.Context, sync func() (bool, error)) e
 }
 
 func (g *K8sGateway) ensureDeploymentExists(ctx context.Context) error {
+	// Create service account for the gateway
+	if serviceAccount := g.config.ServiceAccountFor(g.gateway); serviceAccount != nil {
+		if err := g.client.EnsureServiceAccount(ctx, g.gateway, serviceAccount); err != nil {
+			return err
+		}
+	}
+
 	deployment := g.config.DeploymentFor(g.gateway, g.sdsConfig)
 	mutated := deployment.DeepCopy()
 	if updated, err := g.client.CreateOrUpdateDeployment(ctx, mutated, func() error {


### PR DESCRIPTION
Changes proposed in this PR:

Allow for an option on the `GatewayClassConfig` object to create a service account per-gateway deployment (useful for scoped consul permissions via auth methods)

How I've tested this PR:

```diff
diff --git a/dev/config/k8s/consul-api-gateway.yaml b/dev/config/k8s/consul-api-gateway.yaml
index d952bd1..87599a3 100644
--- a/dev/config/k8s/consul-api-gateway.yaml
+++ b/dev/config/k8s/consul-api-gateway.yaml
@@ -10,6 +10,8 @@ spec:
   consul:
     scheme: https
     caSecret: consul-ca-cert
+    authentication:
+      managed: true
     ports:
       http: 8501
       grpc: 8502
```

Run:

```bash
➜  consul-api-gateway git:(managed-service-account) ✗ kubectl apply -f dev/config/k8s/consul-api-gateway.yaml
...
➜  consul-api-gateway git:(managed-service-account) ✗ kubectl get pod -o json $(kubectl get pods | grep gateway | head -n 1 | cut -d' ' -f1) | grep \"serviceAccount\"
        "serviceAccount": "test-gateway",
➜  consul-api-gateway git:(managed-service-account) ✗ kubectl get serviceaccount test-gateway
NAME           SECRETS   AGE
test-gateway   1         4m30s
➜  consul-api-gateway git:(managed-service-account) ✗ kubectl delete -f dev/config/k8s/consul-api-gateway.yaml
...
➜  consul-api-gateway git:(managed-service-account) ✗ kubectl get serviceaccount test-gateway
Error from server (NotFound): serviceaccounts "test-gateway" not found
```
