### PR TITLE
Fix linter error

### DIFF
--- a/internal/commands/server/command.go
+++ b/internal/commands/server/command.go
@@ -38,7 +38,6 @@ type Command struct {
 	flagCASecretNamespace string // CA Secret namespace for Consul server
 
 	flagConsulAddress string // Consul server address
-	flagConsulHTTPS   bool   // use https for connecting to Consul
 
 	flagSDSServerHost string // SDS server host
 	flagSDSServerPort int    // SDS server port


### PR DESCRIPTION
As part of the changes to https://github.com/hashicorp/consul-api-gateway/pull/72 the use of `flagConsulHTTPS` got dropped, as for auto-encrypt we are going to integrate tightly with `consul-k8s` and leverage their CA injection utilities. This cleans up a linter error that for some reason the PR didn't find but is now failing in main.
