### PR TITLE
Fix bound gateway deletion

### DIFF
--- a/internal/adapters/consul/sync.go
+++ b/internal/adapters/consul/sync.go
@@ -291,6 +291,12 @@ func (a *ConsulSyncAdapter) Clear(ctx context.Context, id core.GatewayID) error 
 		}
 	}
 
+	// remove the ingress config entry first so that it doesn't throw errors
+	// when the defaults are removed due to protocol mismatches
+	if err := a.deleteConfigEntries(ctx, ingress); err != nil {
+		return fmt.Errorf("error removing ingress config entry: %w", err)
+	}
+
 	if err := a.deleteConfigEntries(ctx, removedRouters...); err != nil {
 		return fmt.Errorf("error removing service router config entries: %w", err)
 	}
@@ -299,10 +305,6 @@ func (a *ConsulSyncAdapter) Clear(ctx context.Context, id core.GatewayID) error 
 	}
 	if err := a.deleteConfigEntries(ctx, removedDefaults...); err != nil {
 		return fmt.Errorf("error removing service defaults config entries: %w", err)
-	}
-
-	if err := a.deleteConfigEntries(ctx, ingress); err != nil {
-		return fmt.Errorf("error removing ingress config entry: %w", err)
 	}
 
 	a.stopIntentionSyncForGateway(id)


### PR DESCRIPTION
Changes proposed in this PR:
- Fix up the deletion order of config entries for gateways with bound routes

Tested manually with the following steps while following the [learn guide](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway).

In the learn guide repo:

```bash
kind create cluster --config=kind/cluster.yaml
```

In the api gateway repo with the fix:

```bash
docker build --build-arg BIN_NAME=consul-api-gateway . -t consul-api-gateway:1
kind load docker-image consul-api-gateway:1 consul-api-gateway:1
```

Updated the `helm` values yaml in the learn tutorial repo with the following diff:

```diff
diff --git a/api-gateway/consul/config.yaml b/api-gateway/consul/config.yaml
index 2d21634..7504511 100644
--- a/api-gateway/consul/config.yaml
+++ b/api-gateway/consul/config.yaml
@@ -16,7 +16,7 @@ controller:
   enabled: true
 apiGateway:
   enabled: true
-  image: "hashicorp/consul-api-gateway:0.1.0-beta"
+  image: "consul-api-gateway:1"
   managedGatewayClass:
     serviceType: NodePort
     useHostPorts: true
\ No newline at end of file
```

In the learn guide repo run:

```bash
kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.1.0-beta"
helm install --values consul/config.yaml consul hashicorp/consul --version "0.40.0"
kubectl apply -f api-gw/consul-api-gateway.yaml
kubectl apply -f two-services
kubectl apply -f api-gw/routes.yaml
curl https://localhost:8443/echo -k --head
```

Stream logs from the deployed controller and then issue:

```bash
kubectl delete gateway example-gateway
```

Make sure that there are no spammed retries and that the gateway is properly deleted.

Fixes: https://github.com/hashicorp/consul-api-gateway/issues/82