### PR TITLE
Add listener binding for 0.0.0.0

### DIFF
--- a/internal/consul/registration.go
+++ b/internal/consul/registration.go
@@ -131,6 +131,15 @@ func (s *ServiceRegistry) register(ctx context.Context) error {
 			Interval:                       serviceCheckInterval,
 			DeregisterCriticalServiceAfter: serviceDeregistrationTime,
 		}},
+		Proxy: &api.AgentServiceConnectProxyConfig{
+			Config: map[string]interface{}{
+				"envoy_gateway_bind_addresses": map[string]interface{}{
+					"__global": map[string]interface{}{
+						"address": "0.0.0.0",
+					},
+				},
+			},
+		},
 	}
 
 	return s.consul.Agent().ServiceRegisterOpts(registration, (&api.ServiceRegisterOpts{}).WithContext(ctx))


### PR DESCRIPTION
So I'm not entirely sure if we want this change or not, but it is potentially useful for kubernetes deployments. Right now when Consul ships the xDS configuration down to our deployed gateways it uses the service registration address (which is set to the pod IP for discovery purposes) as the binding address for all envoy listeners.

Unfortunately, `kubectl port-forward` only allows port-forwarding to pod ports that are listening on the loopback interface (which seems really dumb to me). What this means is that you can't `kubectl port-forward` to a deployed gateway to check out its routing and instead either have to do something like deploy with `serviceType: LoadBalancer` or deploy a container on the same network that you can hop onto to debug network connectivity.

What this change does is leverage https://www.consul.io/docs/connect/proxies/envoy#envoy_gateway_bind_addresses to set up additional binding addresses for listeners. The documentation is a bit confusing as it specifies:

> This map's keys are the name of the listeners to be created and the values are a map with two keys, address and port, that combined make the address to bind the listener to.

However, as far as I can tell the Consul xDS code ignores both the name and port specified in the configuration and really only cares about the `address` value, as seen in the invocation of the [listener construction code](https://github.com/hashicorp/consul/blob/37c7d06b4e5511915814f3f59bc040951f9128b0/agent/xds/listeners.go#L524) and how the address is used in conjunction with listeners from a config entry to actually [build the bound listeners](https://github.com/hashicorp/consul/blob/37c7d06b4e5511915814f3f59bc040951f9128b0/agent/xds/listeners_ingress.go#L82). This seems odd to me, but the change does work. My bigger question is whether or not this is supposed to work this way.

When this configuration is specified with say a gateway listening on port 8443 we wind up with two bound listeners in our deployed gateway:

```json
     "name": "http:0.0.0.0:8443",
...
     "name": "http:10.244.0.39:8443",
```

Both route properly to our configured upstreams.

Tested with out learn tutorial setup and:

```bash
curl https://localhost:8443/echo -k
kubectl port-forward pod/... 9999:8443
curl https://localhost:9999/echo -k
```

Thoughts/any ideas about who from core could clarify this for us?