### PR TITLE
makefile: update setup-envtest install task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,10 @@ test:
 .PHONY: ctrl-test
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 ctrl-test: ctrl-generate ctrl-manifests
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./...
+ifeq (, $(shell which setup-envtest))
+	@go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+endif
+	setup-envtest use
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: ctrl-manifests


### PR DESCRIPTION
**Changes proposed in this PR:**
- Update the Makefile `ctrl-test` task to follow the documentation at https://github.com/kubernetes-sigs/controller-runtime/tree/master/tools/setup-envtest (currently the attempted download path fails with a `404: Not found` from `curl` because this utility was refactored).

**How I've tested this PR:**
Ran `make ctrl-test` locally.

The diff this creates (unexpectedly?) removes `caSecret` from our GatewayClass configs YAML
```
                  caSecret:
                    description: The location of a secret to mount with the Consul
                      root CA.
                    type: string
```

and (not suprisingly) adds a Go 1.7-style build tag 
```
@ pkg/apis/v1alpha1/zz_generated.deepcopy.go:1 @
//go:build !ignore_autogenerated
// +build !ignore_autogenerated
```

**How I expect reviewers to test this PR:**
Offer feedback on if this diff is expected, if any additional changes are needed or if this should be added to CI, and a little background (to add to dev docs) on what these make tasks are expected to do/test.
