### PR TITLE
Allow API Gateway controller to update k8s Deployments + Services

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - coordination.k8s.io
@@ -98,6 +99,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - gateway.networking.k8s.io

--- a/internal/k8s/controllers/gateway_controller.go
+++ b/internal/k8s/controllers/gateway_controller.go
@@ -36,8 +36,8 @@ type GatewayReconciler struct {
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=list;watch
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;get;create;watch
-//+kubebuilder:rbac:groups=core,resources=services,verbs=list;get;create;watch
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;get;create;update;watch
+//+kubebuilder:rbac:groups=core,resources=services,verbs=list;get;create;update;watch
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;get;create;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 


### PR DESCRIPTION
The k8s client abstraction in consul-api-gateway [expects](https://github.com/hashicorp/consul-api-gateway/blob/c82e707fb30bebf1a88980568e0f67e318f65496/internal/k8s/gatewayclient/gatewayclient.go#L67-L68) to be able to create **or update** k8s `Deployments` and `Services`; however, the `ClusterRole` as defined today does not allow for updates to these resources. This prevents the Consul API Gateway controller from successfully installing a new gateway to the cluster.

Changes proposed in this PR:
- Modify `ClusterRole` to allow controller to update k8s `Deployment`
- Modify `ClusterRole` to allow controller to update k8s `Service`

How I've tested this PR:
Applied changes to deployment on GKE

How I expect reviewers to test this PR:
Follow the [Learn tutorial](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway) for Consul API Gateway; however, the Consul Helm chart install needs to use the branch in this PR.

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)