### PR TITLE
types: add CertificateAuthoritySecret to ConsulSpec

### DIFF
--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -62,6 +62,8 @@ type ConsulSpec struct {
 	// pod. If not specified, the pod will attempt to use a local agent on
 	// the host on which it is running.
 	Address string `json:"address,omitempty"`
+	// The location of a secret to mount with the Consul root CA.
+	CertificateAuthoritySecret string `json:"caSecret,omitempty"`
 	// The information about Consul's ports
 	PortSpec PortSpec `json:"ports,omitempty"`
 }


### PR DESCRIPTION
**Changes proposed in this PR:**
- Add `caSecret` struct field to source of generated GatewayClassConfig YAML.

**How I've tested this PR:**
- Run `make ctrl-manifests` - prior to this change, the `caSecret` section would be removed from https://github.com/hashicorp/consul-api-gateway/blob/4c6ee19207474ea318a96bf96bce6cbe5b8248b4/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml#L67-L70

**How I expect reviewers to test this PR:**
- Determine if this field is actually used - given that it wasn't in the source struct and the only references to `caSecret` in the codebase appear to be sample YAML config, I'm not sure if this definition should be added, or all the references removed if it's deprecated.
  - https://github.com/hashicorp/consul-api-gateway/blob/4c6ee19207474ea318a96bf96bce6cbe5b8248b4/config/base/gateway-class-config.yaml#L10
  - https://github.com/hashicorp/consul-api-gateway/blob/4c6ee19207474ea318a96bf96bce6cbe5b8248b4/dev/config/k8s/consul-api-gateway.yaml#L12
  - https://github.com/hashicorp/consul-api-gateway/blob/4c6ee19207474ea318a96bf96bce6cbe5b8248b4/internal/k8s/builder/testdata/tls-cert.yaml#L8

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 