### PR TITLE
Include service namespace and name in resolution errors

### DIFF
--- a/internal/k8s/service/resolver.go
+++ b/internal/k8s/service/resolver.go
@@ -234,7 +234,7 @@ func (r *backendResolver) consulServiceForK8SService(ctx context.Context, namesp
 	}
 	if service == nil {
 		r.logger.Warn("kubernetes service not found")
-		return nil, NewK8sResolutionError(fmt.Sprintf("service (%q, %q) not found", namespacedName.Namespace, namespacedName.Name))
+		return nil, NewK8sResolutionError(fmt.Sprintf("service %s not found", namespacedName))
 	}
 
 	// we do an inner retry since consul may take some time to sync
@@ -246,7 +246,7 @@ func (r *backendResolver) consulServiceForK8SService(ctx context.Context, namesp
 			return err
 		}
 		if resolved == nil {
-			return NewConsulResolutionError(fmt.Sprintf("consul service (%q, %q) not found", service.Namespace, service.Name))
+			return NewConsulResolutionError(fmt.Sprintf("consul service %s not found", namespacedName))
 		}
 		return nil
 	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 30), ctx))

--- a/internal/k8s/service/resolver.go
+++ b/internal/k8s/service/resolver.go
@@ -234,7 +234,7 @@ func (r *backendResolver) consulServiceForK8SService(ctx context.Context, namesp
 	}
 	if service == nil {
 		r.logger.Warn("kubernetes service not found")
-		return nil, NewK8sResolutionError("service not found")
+		return nil, NewK8sResolutionError(fmt.Sprintf("service %s not found", namespacedName))
 	}
 
 	// we do an inner retry since consul may take some time to sync
@@ -246,7 +246,7 @@ func (r *backendResolver) consulServiceForK8SService(ctx context.Context, namesp
 			return err
 		}
 		if resolved == nil {
-			return NewConsulResolutionError("consul service not found")
+			return NewConsulResolutionError(fmt.Sprintf("consul service %s not found", namespacedName))
 		}
 		return nil
 	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 30), ctx))

--- a/internal/k8s/service/resolver.go
+++ b/internal/k8s/service/resolver.go
@@ -234,7 +234,7 @@ func (r *backendResolver) consulServiceForK8SService(ctx context.Context, namesp
 	}
 	if service == nil {
 		r.logger.Warn("kubernetes service not found")
-		return nil, NewK8sResolutionError(fmt.Sprintf("service %s not found", namespacedName))
+		return nil, NewK8sResolutionError(fmt.Sprintf("service (%q, %q) not found", namespacedName.Namespace, namespacedName.Name))
 	}
 
 	// we do an inner retry since consul may take some time to sync
@@ -246,7 +246,7 @@ func (r *backendResolver) consulServiceForK8SService(ctx context.Context, namesp
 			return err
 		}
 		if resolved == nil {
-			return NewConsulResolutionError(fmt.Sprintf("consul service %s not found", namespacedName))
+			return NewConsulResolutionError(fmt.Sprintf("consul service (%q, %q) not found", service.Namespace, service.Name))
 		}
 		return nil
 	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 30), ctx))


### PR DESCRIPTION
Fixes #87

Changes proposed in this PR:
- Include the namespace and name of the service for which resolution failed

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
