### PR TITLE
run e2e against enterprise consul binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["main", "release/**"]
 env:
-  GO_VERSION: '1.16'
+  GO_VERSION: '1.17'
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
 jobs:
   lint:
@@ -66,10 +66,13 @@ jobs:
         path: ${{ env.TEST_RESULTS_DIR }}
 
   e2e:
-    name: e2e tests
+    name: e2e tests (consul-image=${{ matrix.consul-image }})
+    strategy:
+      matrix:
+        consul-image: ['hashicorp/consul:1.11.2', 'hashicorp/consul-enterprise:1.11.2-ent']
     runs-on: ubuntu-latest
     env:
-      TEST_RESULTS_DIR: /tmp/test-results/e2e
+      TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -93,6 +96,7 @@ jobs:
     - name: Test
       env:
         DOCKER_HOST_ROUTE: 172.17.0.1
+        E2E_APIGW_CONSUL_IMAGE: ${{ matrix.consul-image }}
       run: |
         mkdir -p $TEST_RESULTS_DIR/json
         gotestsum \

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"log"
 	"net"
+	"os"
 
 	"github.com/cenkalti/backoff"
 	apps "k8s.io/api/apps/v1"
@@ -24,8 +25,10 @@ import (
 )
 
 const (
-	consulImage          = "hashicorp/consul:1.11.2"
-	configTemplateString = `
+	defaultConsulImage            = "hashicorp/consul:1.11.2"
+	envvarConsulImage             = envvarPrefix + "CONSUL_IMAGE"
+	envvarConsulEnterpriseLicense = "CONSUL_LICENSE"
+	configTemplateString          = `
 {
 	"log_level": "trace",
   "acl": {
@@ -62,7 +65,9 @@ type consulTestContext struct{}
 var (
 	consulTestContextKey = consulTestContext{}
 
-	configTemplate *template.Template
+	configTemplate   *template.Template
+	consulImage      = getEnvDefault(envvarConsulImage, defaultConsulImage)
+	consulEntLicense = os.Getenv(envvarConsulEnterpriseLicense)
 )
 
 func init() {
@@ -287,6 +292,13 @@ func consulDeployment(namespace string, httpsPort, grpcPort int) *apps.Deploymen
 	labels := map[string]string{
 		"deployment": "consul-test-server",
 	}
+	var env []core.EnvVar
+	if consulEntLicense != "" {
+		env = append(env, core.EnvVar{
+			Name:  envvarConsulEnterpriseLicense,
+			Value: consulEntLicense,
+		})
+	}
 	return &apps.Deployment{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "consul",
@@ -338,6 +350,7 @@ func consulDeployment(namespace string, httpsPort, grpcPort int) *apps.Deploymen
 						{
 							Name:  "consul",
 							Image: consulImage,
+							Env:   env,
 							Ports: []core.ContainerPort{{
 								Name:          "https",
 								Protocol:      "TCP",

--- a/internal/testing/e2e/stack.go
+++ b/internal/testing/e2e/stack.go
@@ -2,10 +2,15 @@ package e2e
 
 import (
 	"context"
+	"os"
 
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+)
+
+const (
+	envvarPrefix = "E2E_APIGW_"
 )
 
 func SetUpStack(hostRoute string) env.Func {
@@ -68,4 +73,11 @@ func SetHostRoute(ctx context.Context, hostRoute string) context.Context {
 
 func HostRoute(ctx context.Context) string {
 	return ctx.Value(hostRouteContextKey).(string)
+}
+
+func getEnvDefault(envvar, defaultVal string) string {
+	if val := os.Getenv(envvar); val != "" {
+		return val
+	}
+	return defaultVal
 }


### PR DESCRIPTION
This PR adds a matrix build to the e2e ci step and plumbs the necessary information into the e2e environment to boot an enterprise consul cluster.