### PR TITLE
Use updated "initial management token" terminology

### DIFF
--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -398,7 +398,7 @@ func ConsulCA(ctx context.Context) []byte {
 
 }
 
-func ConsulMasterToken(ctx context.Context) string {
+func ConsulInitialManagementToken(ctx context.Context) string {
 	consulEnvironment := ctx.Value(consulTestContextKey)
 	if consulEnvironment == nil {
 		panic("must run this with an integration test that has called CreateTestConsul")
@@ -474,7 +474,7 @@ func CreateConsulACLPolicy(ctx context.Context, cfg *envconf.Config) (context.Co
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Consul master token: %s", token.SecretID)
+	log.Printf("Consul initial management token: %s", token.SecretID)
 	policy, _, err := env.consulClient.ACL().PolicyCreate(adminPolicy(), &api.WriteOptions{
 		Token: token.SecretID,
 	})

--- a/internal/testing/e2e/gateway.go
+++ b/internal/testing/e2e/gateway.go
@@ -38,7 +38,7 @@ func (p *gatewayTestEnvironment) run(ctx context.Context, namespace string, cfg 
 	consulClient := ConsulClient(ctx)
 
 	// this should go away once we implement auth in the server bootup
-	consulClient.AddHeader("x-consul-token", ConsulMasterToken(ctx))
+	consulClient.AddHeader("x-consul-token", ConsulInitialManagementToken(ctx))
 
 	nullLogger := hclog.Default()
 	nullLogger.SetLevel(hclog.Trace)

--- a/internal/testing/e2e/service.go
+++ b/internal/testing/e2e/service.go
@@ -283,7 +283,7 @@ func deployMeshService(ctx context.Context, cfg *envconf.Config, protocol string
 	name := envconf.RandomName("mesh", 16)
 	client := ConsulClient(ctx)
 	consulPort := ConsulGRPCPort(ctx)
-	token := ConsulMasterToken(ctx)
+	token := ConsulInitialManagementToken(ctx)
 	consulAddress := HostRoute(ctx)
 	proxyServiceName := name + "-proxy"
 


### PR DESCRIPTION
Changes proposed in this PR:
- Use updated terminology from [Consul docs](https://www.consul.io/docs/security/acl/acl-system#builtin-tokens):
    > In Consul 1.4 - 1.10, this was called the master token. It was renamed to initial_management token in Consul 1.11.

How I've tested this PR:

How I expect reviewers to test this PR:


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
