### PR TITLE
config: remove unused caSecret field

### DIFF
--- a/config/base/gateway-class-config.yaml
+++ b/config/base/gateway-class-config.yaml
@@ -7,7 +7,6 @@ spec:
   serviceType: LoadBalancer
   consul:
     scheme: https
-    caSecret: consul-ca-cert
     ports:
       http: 8501
       grpc: 8502

--- a/dev/config/k8s/consul-api-gateway.yaml
+++ b/dev/config/k8s/consul-api-gateway.yaml
@@ -9,7 +9,6 @@ spec:
     consulAPIGateway: "consul-api-gateway:1"
   consul:
     scheme: https
-    caSecret: consul-ca-cert
     ports:
       http: 8501
       grpc: 8502

--- a/internal/k8s/builder/testdata/tls-cert.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   consul:
     scheme: https
-    caSecret: super-secret
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GatewayClass
@@ -24,7 +23,7 @@ metadata:
   name: tls-cert-test
 spec:
   gatewayClassName: test-gateway-class
-  listeners:  
+  listeners:
   - protocol: HTTP
     port: 80
     name: http


### PR DESCRIPTION
**Changes proposed in this PR:**
- Remove extraneous references to `caSecret` (removed in https://github.com/hashicorp/consul-api-gateway/pull/72) per feedback in https://github.com/hashicorp/consul-api-gateway/pull/89#pullrequestreview-876557387
