### PR TITLE
Consume v0.40.0 of Consul Helm chart in dev run script

### DIFF
--- a/dev/run
+++ b/dev/run
@@ -44,7 +44,7 @@ createNginxIngress() {
 
 installConsul() {
   echo "Installing consul helm chart"
-  helm install consul hashicorp/consul --version 0.39.0 -f dev/config/helm/consul.yaml 2>&1 > /dev/null
+  helm install consul hashicorp/consul --version 0.40.0 -f dev/config/helm/consul.yaml 2>&1 > /dev/null
   echo "Waiting for consul to stabilize"
   sleep 10
   kubectl wait --for=condition=ready pod --selector=app=consul,component=server,release=consul --timeout=90s


### PR DESCRIPTION
Changes proposed in this PR:
- Bump to latest version of Consul Helm chart in dev `run` script

How I've tested this PR:
```shell
$ ./dev/run
```

How I expect reviewers to test this PR:
Run the above command on this branch

Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
