### PR TITLE
Prevent stale GatewayClassConfig

### DIFF
--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -141,8 +141,9 @@ func (k *Kubernetes) Start(ctx context.Context) error {
 	})
 
 	err := (&controllers.GatewayClassConfigReconciler{
-		Client: gwClient,
-		Log:    k.logger.Named("GatewayClassConfig"),
+		Client:  gwClient,
+		Log:     k.logger.Named("GatewayClassConfig"),
+		Manager: reconcileManager,
 	}).SetupWithManager(k.k8sManager)
 	if err != nil {
 		return fmt.Errorf("failed to create gateway class config controller: %w", err)

--- a/internal/k8s/controllers/gateway_class_config_controller.go
+++ b/internal/k8s/controllers/gateway_class_config_controller.go
@@ -7,6 +7,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler"
 	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 	"github.com/hashicorp/go-hclog"
 )
@@ -17,8 +18,9 @@ const (
 
 // GatewayClassConfigReconciler reconciles a GatewayClassConfig object
 type GatewayClassConfigReconciler struct {
-	Client gatewayclient.Client
-	Log    hclog.Logger
+	Client  gatewayclient.Client
+	Log     hclog.Logger
+	Manager reconciler.ReconcileManager
 }
 
 //+kubebuilder:rbac:groups=api-gateway.consul.hashicorp.com,resources=gatewayclassconfigs,verbs=get;update;list;watch

--- a/internal/k8s/controllers/gateway_class_config_controller_test.go
+++ b/internal/k8s/controllers/gateway_class_config_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gateway "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/hashicorp/go-hclog"
 
@@ -105,12 +106,14 @@ func TestGatewayClassConfig(t *testing.T) {
 		err:  errExpected,
 		expectationCB: func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager) {
 			client.EXPECT().GetGatewayClassConfig(gomock.Any(), classConfigName).Return(&apigwv1alpha1.GatewayClassConfig{}, nil)
+			client.EXPECT().GatewayClassesUsingConfig(gomock.Any(), gomock.Any()).Return(&gateway.GatewayClassList{}, nil)
 			client.EXPECT().EnsureFinalizer(gomock.Any(), gomock.Any(), gatewayClassConfigFinalizer).Return(false, errExpected)
 		},
 	}, {
 		name: "create",
 		expectationCB: func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager) {
 			client.EXPECT().GetGatewayClassConfig(gomock.Any(), classConfigName).Return(&apigwv1alpha1.GatewayClassConfig{}, nil)
+			client.EXPECT().GatewayClassesUsingConfig(gomock.Any(), gomock.Any()).Return(&gateway.GatewayClassList{}, nil)
 			client.EXPECT().EnsureFinalizer(gomock.Any(), gomock.Any(), gatewayClassConfigFinalizer).Return(true, nil)
 		},
 	}} {

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -85,17 +85,19 @@ func New(client client.Client, scheme *runtime.Scheme, controllerName string) Cl
 	}
 }
 
+// gatewayClassUsesConfig determines whether a given GatewayClass references a
+// given GatewayClassConfig. Since these resources are scoped to the cluster,
+// namespace is not considered.
 func gatewayClassUsesConfig(gc gateway.GatewayClass, gcc *apigwv1alpha1.GatewayClassConfig) bool {
 	paramaterRef := gc.Spec.ParametersRef
-
-	// TODO Move this to docstring
-	// no need to check on namespaces since we're cluster-scoped
 	return paramaterRef != nil &&
 		paramaterRef.Group == apigwv1alpha1.Group &&
 		paramaterRef.Kind == apigwv1alpha1.GatewayClassConfigKind &&
 		paramaterRef.Name == gcc.Name
 }
 
+// GatewayClassConfigInUse determines whether any GatewayClass in the cluster
+// references the provided GatewayClassConfig.
 func (g *gatewayClient) GatewayClassConfigInUse(ctx context.Context, gcc *apigwv1alpha1.GatewayClassConfig) (bool, error) {
 	list := &gateway.GatewayClassList{}
 	if err := g.List(ctx, list); err != nil {
@@ -111,6 +113,8 @@ func (g *gatewayClient) GatewayClassConfigInUse(ctx context.Context, gcc *apigwv
 	return false, nil
 }
 
+// GatewayClassesUsingConfig returns the list of all GatewayClasses in the
+// cluster that reference the provided GatewayClassConfig.
 func (g *gatewayClient) GatewayClassesUsingConfig(ctx context.Context, gcc *apigwv1alpha1.GatewayClassConfig) (*gateway.GatewayClassList, error) {
 	list, filteredList := &gateway.GatewayClassList{}, &gateway.GatewayClassList{}
 	if err := g.List(ctx, list); err != nil {
@@ -126,6 +130,8 @@ func (g *gatewayClient) GatewayClassesUsingConfig(ctx context.Context, gcc *apig
 	return filteredList, nil
 }
 
+// GatewayClassInUse determines whether any Gateway in the cluster
+// references the provided GatewayClass.
 func (g *gatewayClient) GatewayClassInUse(ctx context.Context, gc *gateway.GatewayClass) (bool, error) {
 	list := &gateway.GatewayList{}
 	if err := g.List(ctx, list); err != nil {

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -168,6 +168,21 @@ func (mr *MockClientMockRecorder) GatewayClassInUse(ctx, gc interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GatewayClassInUse", reflect.TypeOf((*MockClient)(nil).GatewayClassInUse), ctx, gc)
 }
 
+// GatewayClassesUsingConfig mocks base method.
+func (m *MockClient) GatewayClassesUsingConfig(ctx context.Context, gcc *v1alpha1.GatewayClassConfig) (*v1alpha2.GatewayClassList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GatewayClassesUsingConfig", ctx, gcc)
+	ret0, _ := ret[0].(*v1alpha2.GatewayClassList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GatewayClassesUsingConfig indicates an expected call of GatewayClassesUsingConfig.
+func (mr *MockClientMockRecorder) GatewayClassesUsingConfig(ctx, gcc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GatewayClassesUsingConfig", reflect.TypeOf((*MockClient)(nil).GatewayClassesUsingConfig), ctx, gcc)
+}
+
 // GetConfigForGatewayClassName mocks base method.
 func (m *MockClient) GetConfigForGatewayClassName(ctx context.Context, name string) (v1alpha1.GatewayClassConfig, bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Fixes #88 

Changes proposed in this PR:
- When a `GatewayClassConfig` changes, evict all `GatewayClasses` that reference it from the cache

How I've tested this PR:
See instructions in #88 

How I expect reviewers to test this PR:
Do the following on both main and this branch, observing that the config annotation on the `Gateway` is correct on this branch:
```shell
$ ./dev/run

# In a separate terminal
$ kubectl apply -f ./dev/config/k8s/

# Observe config in Gateway annotation
$ kubectl get gateway test-gateway -o yaml

# Add serviceType to GatewayClassConfig
$ kubectl edit gatewayclassconfig test-gateway-class-config

# Delete the gateway and recreate it, expecting that it will pick up the new serviceType in the config annotation
$ kubectl delete gateway test-gateway
$ kubectl apply -f ./dev/config/k8s/

# Observe config in Gateway annotation
# On main, the added serviceType will not be included at this stage.
# On this branch, the serviceType will be included.
$ kubectl get gateway test-gateway -o yaml

# Quit the ./dev/run process, switch branches, and then
$ ./dev/run -r

# Start back at the first command
```

Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
