### PR TITLE
changelog: add go-changelog templates and tooling

### DIFF
--- a/.changelog/101.txt
+++ b/.changelog/101.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+changelog: add go-changelog templates and tooling
+```

--- a/.changelog/changelog.tmpl
+++ b/.changelog/changelog.tmpl
@@ -1,0 +1,43 @@
+{{- if .NotesByType.note -}}
+NOTES:
+{{range .NotesByType.note -}}
+* {{ template "note" .}}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.deprecation -}}
+DEPRECATIONS:
+{{range .NotesByType.deprecation -}}
+* {{ template "note" .}}
+{{ end -}}
+{{- end -}}
+
+{{- if index .NotesByType "breaking-change" -}}
+BREAKING CHANGES:
+{{range index .NotesByType "breaking-change" -}}
+* {{ template "note" .}}
+{{ end -}}
+{{- end -}}
+
+{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-datasource") (index .NotesByType "new-data-source") -}}
+{{- if $features }}
+FEATURES:
+{{range $features | sort -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- $improvements := combineTypes .NotesByType.improvement .NotesByType.enhancement -}}
+{{- if $improvements }}
+IMPROVEMENTS:
+{{range $improvements | sort -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+
+{{- if .NotesByType.bug }}
+BUG FIXES:
+{{range .NotesByType.bug -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}

--- a/.changelog/release-note.tmpl
+++ b/.changelog/release-note.tmpl
@@ -1,0 +1,3 @@
+{{- define "note" -}}
+{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{ end }}{{.Body}} ([GH-{{- .Issue -}}])
+{{- end -}}


### PR DESCRIPTION
**Changes proposed in this PR:**
- Adds template files used by [go-changelog](https://github.com/hashicorp/go-changelog) to generate a changelog section for a specific release from changelog entry files associated with pull requests.
-

**TODO:**
- [ ] Add `make` tasks for `changelog-build` and `changelog-pr-body-check` commands
- [ ] Remove note from PR template about only HashiCorp engineers adding changelog entries.
- [ ] Add CI check to ensure changelog entries on all PRs and ensure that entries follow valid formatting
- [ ] Add `no-changelog` label to skip CI check

**How I've tested this PR:**

Running
```
go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest

changelog-build -changelog-template .changelog/changelog.tmpl -entries-dir .changelog -last-release v0.1.0-beta -note-template .changelog/release-note.tmpl -this-release $(git rev-parse HEAD)
```
should generate
```
IMPROVEMENTS:
* changelog: add go-changelog templates and tooling ([GH-101])
```

Running
```
go install github.com/hashicorp/go-changelog/cmd/changelog-pr-body-check@latest

changelog-pr-body-check 101
```
looks to currently be missing some config, but should validate the changelog entry for `.changelog/101.txt`

**How I expect reviewers to test this PR:**


Checklist:
- [ ] ~~Tests added~~
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
