### PR TITLE
Fix kubernetes-sigs/gateway-api/config version v0.4.0 to v0.5.0-dev

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.1
+- github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.5.0-dev
 - bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
 - bases/api-gateway.consul.hashicorp.com_meshservices.yaml


### PR DESCRIPTION
Changes proposed in this PR:
Fix kubernetes-sigs/gateway-api/config version v0.4.0 to v0.5.0-dev as version v0.4.0 is no longer available so updated to current stable version

