### PR TITLE
envoy: bump default image to v1.20-latest

### DIFF
--- a/internal/k8s/builder/builder.go
+++ b/internal/k8s/builder/builder.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 const (
-	defaultEnvoyImage     = "envoyproxy/envoy:v1.19-latest"
+	defaultEnvoyImage     = "envoyproxy/envoy:v1.20-latest"
 	defaultLogLevel       = "info"
 	defaultConsulAddress  = "$(HOST_IP)"
 	defaultConsulHTTPPort = "8500"

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -52,7 +52,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: envoyproxy/envoy:v1.19-latest
+        image: envoyproxy/envoy:v1.20-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -52,7 +52,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: envoyproxy/envoy:v1.19-latest
+        image: envoyproxy/envoy:v1.20-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: envoyproxy/envoy:v1.19-latest
+        image: envoyproxy/envoy:v1.20-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -56,7 +56,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: envoyproxy/envoy:v1.19-latest
+        image: envoyproxy/envoy:v1.20-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000


### PR DESCRIPTION
I don't particularly like how this default is buried a few directories deep, but reorganizing that feels out of scope for now.

**Changes proposed in this PR:**
- Bumps the default Envoy image used to `envoyproxy/envoy:v1.20-latest`

**How I've tested this PR:** 

**How I expect reviewers to test this PR:**

**Checklist:**
- [ ] Tests added
- [ ] CHANGELOG entry added
