### PR TITLE
test/e2e: bump envoyImage to v1.20-latest

### DIFF
--- a/internal/testing/e2e/service.go
+++ b/internal/testing/e2e/service.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	envoyImage                = "envoyproxy/envoy:v1.19-latest"
+	envoyImage                = "envoyproxy/envoy:v1.20-latest"
 	httpBootstrapJSONTemplate = `{
 		"admin": {
 			"access_log_path": "/dev/null",


### PR DESCRIPTION
Followup to #107, missed a spot in e2e tests (this should likely be refactored eventually to just use the default value).