### PR TITLE
Consume Consul 1.11.4 in tests and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     name: unit test (consul-version=${{ matrix.consul-version }})
     strategy:
       matrix:
-        consul-version: [1.11.3, 1.11.3+ent]
+        consul-version: [1.11.4, 1.11.4+ent]
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/consul@${{ matrix.consul-version }}
@@ -78,7 +78,7 @@ jobs:
     name: e2e tests (consul-image=${{ matrix.consul-image }})
     strategy:
       matrix:
-        consul-image: ['hashicorp/consul:1.11.3', 'hashicorp/consul-enterprise:1.11.3-ent']
+        consul-image: ['hashicorp/consul:1.11.4', 'hashicorp/consul-enterprise:1.11.4-ent']
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}

--- a/dev/docs/example-setup.md
+++ b/dev/docs/example-setup.md
@@ -51,7 +51,7 @@ helm repo add hashicorp https://helm.releases.hashicorp.com
 cat <<EOF | helm install consul hashicorp/consul --version 0.41.1 -f -
 global:
   name: consul
-  image: "hashicorp/consul:1.11.3"
+  image: "hashicorp/consul:1.11.4"
   tls:
     enabled: true
 connectInject:
@@ -111,7 +111,7 @@ with the following commands:
 
 ```bash
 mkdir -p demo-deployment/example
-cat <<EOF > demo-deployment/example/kustomization.yaml 
+cat <<EOF > demo-deployment/example/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	defaultConsulImage            = "hashicorp/consul:1.11.3"
+	defaultConsulImage            = "hashicorp/consul:1.11.4"
 	envvarConsulImage             = envvarPrefix + "CONSUL_IMAGE"
 	envvarConsulEnterpriseLicense = "CONSUL_LICENSE"
 	configTemplateString          = `


### PR DESCRIPTION
Changes proposed in this PR:
- Consume Consul 1.11.4 for tests and examples


How I've tested this PR:
- CI pipeline
- Ran through this tutorial https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway with the consul version pointed at 1.11.4 and saw no errors

How I expect reviewers to test this PR:
Confirm CI is pasing


Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
