### PR TITLE
Apply namespace selector to namespace instead of route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+BUG FIXES:
+
+ * Apply namespace selector for allowed routes to the route's namespace instead of the route itself [[GH-119](https://github.com/hashicorp/consul-api-gateway/pull/119)]
+
 ## 0.1.0 (February 23, 2022)
 
 * Initial release of Consul API Gateway

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -35,6 +35,7 @@ type Client interface {
 	GetHTTPRoute(ctx context.Context, key types.NamespacedName) (*gateway.HTTPRoute, error)
 	GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error)
 	GetMeshService(ctx context.Context, key types.NamespacedName) (*apigwv1alpha1.MeshService, error)
+	GetNamespace(ctx context.Context, key types.NamespacedName) (*core.Namespace, error)
 
 	// finalizer helpers
 
@@ -266,6 +267,17 @@ func (g *gatewayClient) GetMeshService(ctx context.Context, key types.Namespaced
 		return nil, NewK8sError(err)
 	}
 	return service, nil
+}
+
+func (g *gatewayClient) GetNamespace(ctx context.Context, key types.NamespacedName) (*core.Namespace, error) {
+	namespace := &core.Namespace{}
+	if err := g.Client.Get(ctx, key, namespace); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, NewK8sError(err)
+	}
+	return namespace, nil
 }
 
 func (g *gatewayClient) EnsureFinalizer(ctx context.Context, object client.Object, finalizer string) (bool, error) {

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -274,6 +274,21 @@ func (mr *MockClientMockRecorder) GetMeshService(ctx, key interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshService", reflect.TypeOf((*MockClient)(nil).GetMeshService), ctx, key)
 }
 
+// GetNamespace mocks base method.
+func (m *MockClient) GetNamespace(ctx context.Context, key types.NamespacedName) (*v10.Namespace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespace", ctx, key)
+	ret0, _ := ret[0].(*v10.Namespace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNamespace indicates an expected call of GetNamespace.
+func (mr *MockClientMockRecorder) GetNamespace(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockClient)(nil).GetNamespace), ctx, key)
+}
+
 // GetSecret mocks base method.
 func (m *MockClient) GetSecret(ctx context.Context, key types.NamespacedName) (*v10.Secret, error) {
 	m.ctrl.T.Helper()

--- a/internal/k8s/reconciler/listener.go
+++ b/internal/k8s/reconciler/listener.go
@@ -310,7 +310,7 @@ func (l *K8sListener) Config() store.ListenerConfig {
 // on the gateway the return value is nil, if not,
 // an error specifying why the route cannot bind
 // is returned.
-func (l *K8sListener) CanBind(route store.Route) (bool, error) {
+func (l *K8sListener) CanBind(ctx context.Context, route store.Route) (bool, error) {
 	k8sRoute, ok := route.(*K8sRoute)
 	if !ok {
 		l.logger.Error("route is not a known type")
@@ -323,7 +323,7 @@ func (l *K8sListener) CanBind(route store.Route) (bool, error) {
 			expected := utils.NamespacedName(l.gateway)
 			l.logger.Trace("checking gateway match", "expected", expected.String(), "found", namespacedName.String())
 			if expected == namespacedName {
-				canBind, err := l.canBind(ref, k8sRoute)
+				canBind, err := l.canBind(ctx, ref, k8sRoute)
 				if err != nil {
 					return false, err
 				}
@@ -336,7 +336,7 @@ func (l *K8sListener) CanBind(route store.Route) (bool, error) {
 	return false, nil
 }
 
-func (l *K8sListener) canBind(ref gw.ParentRef, route *K8sRoute) (bool, error) {
+func (l *K8sListener) canBind(ctx context.Context, ref gw.ParentRef, route *K8sRoute) (bool, error) {
 	if l.status.Ready.HasError() {
 		l.logger.Trace("listener not ready, unable to bind", "route", route.ID())
 		return false, nil
@@ -356,7 +356,7 @@ func (l *K8sListener) canBind(ref gw.ParentRef, route *K8sRoute) (bool, error) {
 			return false, nil
 		}
 
-		allowed, err := routeAllowedForListenerNamespaces(l.gateway.Namespace, l.listener.AllowedRoutes, route, l.client)
+		allowed, err := routeAllowedForListenerNamespaces(ctx, l.gateway.Namespace, l.listener.AllowedRoutes, route, l.client)
 		if err != nil {
 			return false, fmt.Errorf("error checking listener namespaces: %w", err)
 		}

--- a/internal/k8s/reconciler/listener.go
+++ b/internal/k8s/reconciler/listener.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 	"sync/atomic"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
 	"github.com/hashicorp/consul-api-gateway/internal/common"
 	"github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/utils"
 	"github.com/hashicorp/consul-api-gateway/internal/store"
 	"github.com/hashicorp/go-hclog"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 var (
@@ -354,7 +355,8 @@ func (l *K8sListener) canBind(ref gw.ParentRef, route *K8sRoute) (bool, error) {
 			}
 			return false, nil
 		}
-		allowed, err := routeAllowedForListenerNamespaces(l.gateway.Namespace, l.listener.AllowedRoutes, route)
+
+		allowed, err := routeAllowedForListenerNamespaces(l.gateway.Namespace, l.listener.AllowedRoutes, route, l.client)
 		if err != nil {
 			return false, fmt.Errorf("error checking listener namespaces: %w", err)
 		}

--- a/internal/k8s/reconciler/listener_test.go
+++ b/internal/k8s/reconciler/listener_test.go
@@ -6,16 +6,17 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/hashicorp/consul-api-gateway/internal/core"
-	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
-	"github.com/hashicorp/consul-api-gateway/internal/store"
-	storeMocks "github.com/hashicorp/consul-api-gateway/internal/store/mocks"
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 	k8s "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/hashicorp/consul-api-gateway/internal/core"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
+	"github.com/hashicorp/consul-api-gateway/internal/store"
+	storeMocks "github.com/hashicorp/consul-api-gateway/internal/store/mocks"
+	"github.com/hashicorp/go-hclog"
 )
 
 func TestListenerID(t *testing.T) {
@@ -378,7 +379,7 @@ func TestListenerCanBind(t *testing.T) {
 	listener := NewK8sListener(&gw.Gateway{}, gw.Listener{}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	canBind, err := listener.CanBind(storeMocks.NewMockRoute(nil))
+	canBind, err := listener.CanBind(context.Background(), storeMocks.NewMockRoute(nil))
 	require.NoError(t, err)
 	require.False(t, canBind)
 
@@ -386,7 +387,7 @@ func TestListenerCanBind(t *testing.T) {
 	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	canBind, err = listener.CanBind(NewK8sRoute(&gw.HTTPRoute{}, K8sRouteConfig{
+	canBind, err = listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	}))
 	require.NoError(t, err)
@@ -400,7 +401,7 @@ func TestListenerCanBind(t *testing.T) {
 	}, gw.Listener{}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	canBind, err = listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	canBind, err = listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
 				ParentRefs: []gw.ParentRef{{
@@ -423,7 +424,7 @@ func TestListenerCanBind(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.status.Ready.Invalid = errors.New("invalid")
-	canBind, err = listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	canBind, err = listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
 				ParentRefs: []gw.ParentRef{{
@@ -459,7 +460,7 @@ func TestListenerCanBind_RouteKind(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	require.NoError(t, listener.Validate(context.Background()))
-	canBind, err := listener.CanBind(NewK8sRoute(&gw.UDPRoute{
+	canBind, err := listener.CanBind(context.Background(), NewK8sRoute(&gw.UDPRoute{
 		TypeMeta: routeMeta,
 		Spec: gw.UDPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
@@ -485,7 +486,7 @@ func TestListenerCanBind_RouteKind(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.supportedKinds = supportedProtocols[gw.HTTPProtocolType]
-	_, err = listener.CanBind(NewK8sRoute(&gw.UDPRoute{
+	_, err = listener.CanBind(context.Background(), NewK8sRoute(&gw.UDPRoute{
 		TypeMeta: routeMeta,
 		Spec: gw.UDPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
@@ -532,7 +533,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.supportedKinds = supportedProtocols[gw.HTTPProtocolType]
-	_, err := listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	_, err := listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
@@ -547,7 +548,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	}))
 	require.Error(t, err)
-	canBind, err := listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	canBind, err := listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
@@ -586,7 +587,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.supportedKinds = supportedProtocols[gw.HTTPProtocolType]
-	_, err = listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	_, err = listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
@@ -601,7 +602,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	}))
 	require.Error(t, err)
-	_, err = listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	_, err = listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
@@ -640,7 +641,7 @@ func TestListenerCanBind_HostnameMatch(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.supportedKinds = supportedProtocols[gw.HTTPProtocolType]
-	_, err := listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	_, err := listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
@@ -656,7 +657,7 @@ func TestListenerCanBind_HostnameMatch(t *testing.T) {
 	}))
 	require.Error(t, err)
 
-	canBind, err := listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	canBind, err := listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
@@ -688,7 +689,7 @@ func TestListenerCanBind_NameMatch(t *testing.T) {
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	canBind, err := listener.CanBind(NewK8sRoute(&gw.HTTPRoute{
+	canBind, err := listener.CanBind(context.Background(), NewK8sRoute(&gw.HTTPRoute{
 		Spec: gw.HTTPRouteSpec{
 			CommonRouteSpec: gw.CommonRouteSpec{
 				ParentRefs: []gw.ParentRef{{

--- a/internal/k8s/reconciler/utils.go
+++ b/internal/k8s/reconciler/utils.go
@@ -1,6 +1,7 @@
 package reconciler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -9,7 +10,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
 )
 
 const (
@@ -79,14 +83,16 @@ func routeKindIsAllowedForListener(kinds []gw.RouteGroupKind, route *K8sRoute) b
 	return false
 }
 
-func routeAllowedForListenerNamespaces(gatewayNS string, allowedRoutes *gw.AllowedRoutes, route *K8sRoute) (bool, error) {
+// routeAllowedForListenerNamespaces determines whether the route is allowed
+// to bind to the Gateway based on the AllowedRoutes namespace selectors.
+func routeAllowedForListenerNamespaces(gatewayNS string, allowedRoutes *gw.AllowedRoutes, route *K8sRoute, c gatewayclient.Client) (bool, error) {
 	var namespaceSelector *gw.RouteNamespaces
 	if allowedRoutes != nil {
 		// check gateway namespace
 		namespaceSelector = allowedRoutes.Namespaces
 	}
 
-	// set default is namespace selector is nil
+	// set default if namespace selector is nil
 	from := gw.NamespacesFromSame
 	if namespaceSelector != nil && namespaceSelector.From != nil && *namespaceSelector.From != "" {
 		from = *namespaceSelector.From
@@ -97,12 +103,19 @@ func routeAllowedForListenerNamespaces(gatewayNS string, allowedRoutes *gw.Allow
 	case gw.NamespacesFromSame:
 		return gatewayNS == route.GetNamespace(), nil
 	case gw.NamespacesFromSelector:
-		ns, err := metav1.LabelSelectorAsSelector(namespaceSelector.Selector)
+		namespaceSelector, err := metav1.LabelSelectorAsSelector(namespaceSelector.Selector)
 		if err != nil {
-			return false, fmt.Errorf("error parsing label selector: %v", err)
+			return false, fmt.Errorf("error parsing label selector: %w", err)
 		}
 
-		return ns.Matches(toNamespaceSet(route.GetNamespace(), route.GetLabels())), nil
+		// retrieve the route's namespace and determine whether selector matches
+		// TODO: Pipe context.Context in from the calling function(s)
+		namespace, err := c.GetNamespace(context.TODO(), types.NamespacedName{Name: route.GetNamespace()})
+		if err != nil {
+			return false, fmt.Errorf("error retrieving namespace for route: %w", err)
+		}
+
+		return namespaceSelector.Matches(toNamespaceSet(namespace.GetName(), namespace.GetLabels())), nil
 	}
 	return false, nil
 }

--- a/internal/k8s/reconciler/utils.go
+++ b/internal/k8s/reconciler/utils.go
@@ -85,7 +85,7 @@ func routeKindIsAllowedForListener(kinds []gw.RouteGroupKind, route *K8sRoute) b
 
 // routeAllowedForListenerNamespaces determines whether the route is allowed
 // to bind to the Gateway based on the AllowedRoutes namespace selectors.
-func routeAllowedForListenerNamespaces(gatewayNS string, allowedRoutes *gw.AllowedRoutes, route *K8sRoute, c gatewayclient.Client) (bool, error) {
+func routeAllowedForListenerNamespaces(ctx context.Context, gatewayNS string, allowedRoutes *gw.AllowedRoutes, route *K8sRoute, c gatewayclient.Client) (bool, error) {
 	var namespaceSelector *gw.RouteNamespaces
 	if allowedRoutes != nil {
 		// check gateway namespace
@@ -109,7 +109,6 @@ func routeAllowedForListenerNamespaces(gatewayNS string, allowedRoutes *gw.Allow
 		}
 
 		// retrieve the route's namespace and determine whether selector matches
-		// TODO: Pipe context.Context in from the calling function(s)
 		namespace, err := c.GetNamespace(context.TODO(), types.NamespacedName{Name: route.GetNamespace()})
 		if err != nil {
 			return false, fmt.Errorf("error retrieving namespace for route: %w", err)

--- a/internal/k8s/reconciler/utils.go
+++ b/internal/k8s/reconciler/utils.go
@@ -109,7 +109,7 @@ func routeAllowedForListenerNamespaces(ctx context.Context, gatewayNS string, al
 		}
 
 		// retrieve the route's namespace and determine whether selector matches
-		namespace, err := c.GetNamespace(context.TODO(), types.NamespacedName{Name: route.GetNamespace()})
+		namespace, err := c.GetNamespace(ctx, types.NamespacedName{Name: route.GetNamespace()})
 		if err != nil {
 			return false, fmt.Errorf("error retrieving namespace for route: %w", err)
 		}

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -62,7 +62,7 @@ type RouteTrackingListener interface {
 // listener.
 type Listener interface {
 	ID() string
-	CanBind(route Route) (bool, error)
+	CanBind(ctx context.Context, route Route) (bool, error)
 	Config() ListenerConfig
 	IsValid() bool
 }

--- a/internal/store/memory/gateway.go
+++ b/internal/store/memory/gateway.go
@@ -49,14 +49,14 @@ func (g *gatewayState) Remove(id string) {
 	}
 }
 
-func (g *gatewayState) TryBind(route store.Route) {
+func (g *gatewayState) TryBind(ctx context.Context, route store.Route) {
 	g.logger.Trace("checking if route can bind to gateway", "route", route.ID())
 	if g.ShouldBind(route) {
 		bound := false
 		var bindError error
 		for _, l := range g.listeners {
 			g.logger.Trace("checking if route can bind to listener", "listener", l.name, "route", route.ID())
-			canBind, err := l.CanBind(route)
+			canBind, err := l.CanBind(ctx, route)
 			if err != nil {
 				// consider each route distinct for the purposes of binding
 				g.logger.Debug("error binding route to gateway", "error", err, "route", route.ID())

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -193,7 +193,7 @@ func (s *Store) UpsertRoute(ctx context.Context, route store.Route) error {
 
 		// bind to gateways
 		for _, gateway := range s.gateways {
-			gateway.TryBind(route)
+			gateway.TryBind(ctx, route)
 		}
 	}
 
@@ -231,7 +231,7 @@ func (s *Store) UpsertGateway(ctx context.Context, gateway store.Gateway) error 
 
 		// bind routes to this gateway
 		for _, route := range s.routes {
-			updated.TryBind(route)
+			updated.TryBind(ctx, route)
 		}
 
 		if found && reflect.DeepEqual(current.Resolve(), updated.Resolve()) {

--- a/internal/store/mocks/interfaces.go
+++ b/internal/store/mocks/interfaces.go
@@ -237,18 +237,18 @@ func (m *MockRouteTrackingListener) EXPECT() *MockRouteTrackingListenerMockRecor
 }
 
 // CanBind mocks base method.
-func (m *MockRouteTrackingListener) CanBind(route store.Route) (bool, error) {
+func (m *MockRouteTrackingListener) CanBind(ctx context.Context, route store.Route) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CanBind", route)
+	ret := m.ctrl.Call(m, "CanBind", ctx, route)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CanBind indicates an expected call of CanBind.
-func (mr *MockRouteTrackingListenerMockRecorder) CanBind(route interface{}) *gomock.Call {
+func (mr *MockRouteTrackingListenerMockRecorder) CanBind(ctx, route interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanBind", reflect.TypeOf((*MockRouteTrackingListener)(nil).CanBind), route)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanBind", reflect.TypeOf((*MockRouteTrackingListener)(nil).CanBind), ctx, route)
 }
 
 // Config mocks base method.
@@ -341,18 +341,18 @@ func (m *MockListener) EXPECT() *MockListenerMockRecorder {
 }
 
 // CanBind mocks base method.
-func (m *MockListener) CanBind(route store.Route) (bool, error) {
+func (m *MockListener) CanBind(ctx context.Context, route store.Route) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CanBind", route)
+	ret := m.ctrl.Call(m, "CanBind", ctx, route)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CanBind indicates an expected call of CanBind.
-func (mr *MockListenerMockRecorder) CanBind(route interface{}) *gomock.Call {
+func (mr *MockListenerMockRecorder) CanBind(ctx, route interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanBind", reflect.TypeOf((*MockListener)(nil).CanBind), route)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanBind", reflect.TypeOf((*MockListener)(nil).CanBind), ctx, route)
 }
 
 // Config mocks base method.


### PR DESCRIPTION
Fixes #117 

**Changes proposed in this PR:**
- When a namespace selector is used for `allowedRoutes`, apply selector to route's `Namespace` instead of route itself

**How I've tested this PR:**
`$ kubectl apply -f` [these resources](https://gist.github.com/nathancoleman/2ca0983051287e7d9a3152f526284320).

With this change in the controller, the `HTTPRoute` will successfully attach to the `Gateway`. Without this change, it will not and you will see the log from #117 in the controller pod.

**How I expect reviewers to test this PR:**


**Checklist:**
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use present tense (e.g. Add support for...)
