### PR TITLE
github: update issue and PR templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,6 +32,10 @@ then it dramatically lowers the chances it'll get fixed.
 * Aim to respond promptly to any questions made by the maintainers on your 
 issue. Stale issues may be closed.
 
+* Please vote on issues by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place.
+
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
+
 ## Developing
 
 If you make any changes to the code, please run `make fmt` to automatically format the code according to Go standards.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,18 +5,6 @@ labels: bug
 
 ---
 
-<!--- Please keep this note for the community --->
-
-### Community Note
-
-* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
-* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
-* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
-
-<!--- Thank you for keeping this note for the community --->
-
----
-
 <!--- When filing a bug, please include the following headings if possible. Any example text in this template can be deleted. --->
 
 ### Overview of the Issue
@@ -39,7 +27,7 @@ kind: Gateway
 ```
 1. View error
 
-  --->
+--->
 
 ### Logs
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,30 +5,20 @@ labels: enhancement
 
 ---
 
-<!--- Please keep this note for the community --->
+<!--- When filing a feature request, please include the following headings if possible. Any example text in this template can be deleted. --->
 
-### Community Note
-
-* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request. Searching for pre-existing feature requests helps us consolidate datapoints for identical requirements into a single place, thank you!
-* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
-* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
-
-<!--- Thank you for keeping this note for the community --->
-
----
-
-#### Is your feature request related to a problem? Please describe.
+### Is your feature request related to a problem? Please describe.
 
 <!--- A clear and concise description of the problem you are facing. Describe what workarounds, if any, that you have tried prior to creating this feature request. --->
 
-#### Feature Description
+### Feature Description
 
 <!--- A description what this feature is and how it addresses the problem you are having. Describe potential UX for the feature if possible. --->
 
-#### Use Case(s)
+### Use Case(s)
 
-<!--- Use cases where this feature is applicable for Consul API Gateway tes (i.e. type of application, type of Consul use case i.e. Service Mesh, Service Discovery). --->
+<!--- Use cases where this feature is applicable for Consul API Gateway (i.e. type of application, type of Consul use case i.e. Service Mesh, Service Discovery). --->
 
-#### Contributions
+### Contributions
 
 <!--- Are you able to contribute the changes to make this feature work? --->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,11 @@
-Changes proposed in this PR:
--
--
+### Changes proposed in this PR:
 
-How I've tested this PR:
+### How I've tested this PR:
 
-How I expect reviewers to test this PR:
+### How I expect reviewers to test this PR:
 
-
-Checklist:
+### Checklist:
 - [ ] Tests added
 - [ ] CHANGELOG entry added 
   > HashiCorp engineers only, community PRs should not add a changelog entry.
-  > Entries should use present tense (e.g. Add support for...)
+  > Entries should use imperative present tense (e.g. Add support for...)


### PR DESCRIPTION
### Changes proposed in this PR:
- Consistify formatting of section headings across templates
- Consolidate "community note" content into [`CONTRIBUTING.md`](https://github.com/hashicorp/consul-api-gateway/blob/gh/update-templates/.github/CONTRIBUTING.md)
- Minor copy fixes

### ~~How I've tested this PR:~~

### ~~How I expect reviewers to test this PR:~~


### Checklist:
- [ ] ~~Tests added~~
- [ ] ~~CHANGELOG entry added~~
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
