### PR TITLE
Allow API Gateway controller to retrieve namespaces

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -78,6 +78,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - list

--- a/internal/k8s/controllers/gateway_controller.go
+++ b/internal/k8s/controllers/gateway_controller.go
@@ -35,6 +35,7 @@ type GatewayReconciler struct {
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways/finalizers,verbs=update
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=list;watch
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=list;get;create;update;watch
 //+kubebuilder:rbac:groups=core,resources=services,verbs=list;get;create;update;watch


### PR DESCRIPTION
Something I remembered a bit too late for #119 

### Changes proposed in this PR:
- Add RBAC permissions for controller to retrieve namespaces (caching logic also requires `watch`)

### How I've tested this PR:
Ran locally using `./dev/run` and installed `HTTPRoute` in separate namespace from gateway w/ selector for allowed routes

### How I expect reviewers to test this PR:

### Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
