### PR TITLE
Assign appropriate IP to Gateway

### DIFF
--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -186,8 +186,9 @@ func (g *K8sGateway) validateGatewayIP(ctx context.Context) error {
 			}
 		}
 	case corev1.ServiceTypeNodePort:
-		// TODO
-		break
+		// TODO NodePorts do not always behave the same. A node in standard k8s
+		//  has a public IP address; however, this is not the case in kind.
+		g.serviceReady = true
 	default:
 		return fmt.Errorf("unsupported service type: %s", service.Spec.Type)
 	}

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -185,6 +185,13 @@ func (g *K8sGateway) validateGatewayIP(ctx context.Context) error {
 			}
 		}
 	case corev1.ServiceTypeNodePort:
+		/* For serviceType: NodePort, there isn't a consistent way to guarantee access to the
+		 * service from outside the k8s cluster. For now, we're putting the IP address of the
+		 * nodes that the gateway pods are running on.
+		 * The practitioner will have to understand that they may need to port forward into the
+		 * cluster (in the case of Kind) or open firewall rules (in the case of GKE) in order to
+		 * access the gateway from outside the cluster.
+		 */
 		pod, err := g.client.PodWithLabels(ctx, utils.LabelsForGateway(g.gateway))
 		if err != nil {
 			return err

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -170,11 +170,8 @@ func (g *K8sGateway) validateGatewayIP(ctx context.Context) error {
 
 	switch service.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer:
-		if len(updated.Status.LoadBalancer.Ingress) > 0 {
-			g.serviceReady = true
-		}
-
 		for _, ingress := range updated.Status.LoadBalancer.Ingress {
+			g.serviceReady = true
 			g.addresses = append(g.addresses, ingress.IP)
 		}
 	case corev1.ServiceTypeClusterIP:

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -189,6 +189,7 @@ func (g *K8sGateway) validateGatewayIP(ctx context.Context) error {
 
 		if pod == nil {
 			g.status.Scheduled.NotReconciled = errors.New("pod not found")
+			return nil
 		}
 
 		if pod.Status.HostIP != "" {

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -384,7 +384,6 @@ func (g *K8sGateway) Status() gw.GatewayStatus {
 		})
 	}
 
-	// TODO: set addresses based off of pod/service lookup (is this our now addressed?)
 	return gw.GatewayStatus{
 		Addresses:  addresses,
 		Conditions: conditions,

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -157,6 +157,9 @@ func (g *K8sGateway) validateListenerConflicts() {
 
 func (g *K8sGateway) validateGatewayIP(ctx context.Context) error {
 	service := g.serviceBuilder.Build()
+	if service == nil {
+		return nil
+	}
 
 	switch service.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeClusterIP:

--- a/internal/k8s/reconciler/manager_test.go
+++ b/internal/k8s/reconciler/manager_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
 	storeMocks "github.com/hashicorp/consul-api-gateway/internal/store/mocks"
 	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/types"
-	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func testNamespaceMapper(namespace string) string {
@@ -89,7 +90,7 @@ func TestUpsertGateway(t *testing.T) {
 	client.EXPECT().PodWithLabels(gomock.Any(), gomock.Any()).Return(nil, expected)
 	require.Equal(t, expected, manager.UpsertGateway(context.Background(), inner))
 
-	client.EXPECT().PodWithLabels(gomock.Any(), gomock.Any()).Return(nil, nil)
+	client.EXPECT().PodWithLabels(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	store.EXPECT().UpsertGateway(gomock.Any(), gomock.Any())
 	require.NoError(t, manager.UpsertGateway(context.Background(), inner))
 }


### PR DESCRIPTION
Fixes #116

### Changes proposed in this PR:
- Assign the external IP of a `Service` to `Gateway` instead of pod IP when service type is `LoadBalancer`
- Wait to mark `Gateway` ready until `Service` is available and has the necessary exposed IP

### How I've tested this PR:

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
