### PR TITLE
Fix how http routes are merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 
  * Apply namespace selector for allowed routes to the route's namespace instead of the route itself [[GH-119](https://github.com/hashicorp/consul-api-gateway/pull/119)]
+ * Fix http route merging to make sure we merge routes that reference the same hostname [[GH-126](https://github.com/hashicorp/consul-api-gateway/pull/126)]
 
 ## 0.1.0 (February 23, 2022)
 

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -88,6 +88,7 @@ type consulTestEnvironment struct {
 	token              string
 	policy             *api.ACLPolicy
 	httpPort           int
+	httpFlattenedPort  int
 	grpcPort           int
 	extraHTTPPort      int
 	extraTCPPort       int
@@ -107,6 +108,7 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 		}
 		cluster := clusterVal.(*kindCluster)
 		httpsPort := cluster.httpsPort
+		httpFlattenedPort := cluster.httpsFlattenedPort
 		grpcPort := cluster.grpcPort
 		extraTCPPort := cluster.extraTCPPort
 		extraTCPTLSPort := cluster.extraTCPTLSPort
@@ -198,6 +200,7 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 			ca:                 rootCA.CertBytes,
 			consulClient:       consulClient,
 			httpPort:           httpsPort,
+			httpFlattenedPort:  httpFlattenedPort,
 			grpcPort:           grpcPort,
 			extraHTTPPort:      extraHTTPPort,
 			extraTCPPort:       extraTCPPort,
@@ -474,6 +477,14 @@ func HTTPPort(ctx context.Context) int {
 		panic("must run this with an integration test that has called CreateTestConsul")
 	}
 	return consulEnvironment.(*consulTestEnvironment).extraHTTPPort
+}
+
+func HTTPFlattenedPort(ctx context.Context) int {
+	consulEnvironment := ctx.Value(consulTestContextKey)
+	if consulEnvironment == nil {
+		panic("must run this with an integration test that has called CreateTestConsul")
+	}
+	return consulEnvironment.(*consulTestEnvironment).httpFlattenedPort
 }
 
 func ConsulHTTPPort(ctx context.Context) int {

--- a/internal/testing/e2e/kind.go
+++ b/internal/testing/e2e/kind.go
@@ -37,6 +37,9 @@ nodes:
   - containerPort: {{ .HTTPSPort }}
     hostPort: {{ .HTTPSPort }}
     protocol: TCP
+  - containerPort: {{ .HTTPSFlattenedPort }}
+    hostPort: {{ .HTTPSFlattenedPort }}
+    protocol: TCP
   - containerPort: {{ .GRPCPort }}
     hostPort: {{ .GRPCPort }}
     protocol: TCP
@@ -68,6 +71,7 @@ type kindCluster struct {
 	kubecfgFile        string
 	config             string
 	httpsPort          int
+	httpsFlattenedPort int
 	grpcPort           int
 	extraHTTPPort      int
 	extraTCPPort       int
@@ -76,16 +80,17 @@ type kindCluster struct {
 }
 
 func newKindCluster(name string) *kindCluster {
-	ports := freeport.MustTake(6)
+	ports := freeport.MustTake(7)
 	return &kindCluster{
 		name:               name,
 		e:                  gexe.New(),
 		httpsPort:          ports[0],
-		grpcPort:           ports[1],
-		extraHTTPPort:      ports[2],
-		extraTCPPort:       ports[3],
-		extraTCPTLSPort:    ports[4],
-		extraTCPTLSPortTwo: ports[5],
+		httpsFlattenedPort: ports[1],
+		grpcPort:           ports[2],
+		extraHTTPPort:      ports[3],
+		extraTCPPort:       ports[4],
+		extraTCPTLSPort:    ports[5],
+		extraTCPTLSPortTwo: ports[6],
 	}
 }
 
@@ -95,6 +100,7 @@ func (k *kindCluster) Create() (string, error) {
 	var kindConfig bytes.Buffer
 	err := kindTemplate.Execute(&kindConfig, &struct {
 		HTTPSPort          int
+		HTTPSFlattenedPort int
 		GRPCPort           int
 		ExtraTCPPort       int
 		ExtraTCPTLSPort    int
@@ -102,6 +108,7 @@ func (k *kindCluster) Create() (string, error) {
 		ExtraHTTPPort      int
 	}{
 		HTTPSPort:          k.httpsPort,
+		HTTPSFlattenedPort: k.httpsFlattenedPort,
 		GRPCPort:           k.grpcPort,
 		ExtraTCPPort:       k.extraTCPPort,
 		ExtraTCPTLSPort:    k.extraTCPTLSPort,


### PR DESCRIPTION
### Changes proposed in this PR:

This PR changes the way that HTTP routes are merged. Specifically, rather than looking at the totality of the hostnames used in a particular route, it attempts to merge all routes that reference a given hostname before prioritizing the individual rules on a route. A good, stripped-down example of how this should work is found in the [conformance tests](https://github.com/kubernetes-sigs/gateway-api/blob/master/conformance/tests/httproute-matching-across-routes.yaml):

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
...
spec:
  hostnames:
  - example.com
  - example.net
...
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
...
    backendRefs:
    - name: infra-backend-v1
...
---
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
...
spec:
  hostnames:
  - example.com
...
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /v2
    - headers:
      - name: version
        value: two
    backendRefs:
    - name: infra-backend-v2
...
```

Basically, the rules for a hostname matching `example.com` should be merged in this case and should:

1. Prioritize the `/v2` path prefix match first
2. Priortize the `version: two` header match over the `/` path prefix match
3. fallback to the `/` path prefix match

Previously we were just merging routes based on the overall hash of the `hostnames` values specified. In this case the two routes have different `hostnames` values, yet we still need to merge the rules for `example.com`.

### How I've tested this PR:

I added an e2e test that leverages the behavior expected in the conformance test.

### How I expect reviewers to test this PR:

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
