### PR TITLE
Use ErrorOrNil for asserting no errors in multierror group

### DIFF
--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -106,7 +106,7 @@ func (s *Store) syncGateways(ctx context.Context, gateways ...*gatewayState) err
 			return s.syncGateway(ctx, gateway)
 		})
 	}
-	if err := syncGroup.Wait(); err != nil {
+	if err := syncGroup.Wait().ErrorOrNil(); err != nil {
 		s.logger.Error("error syncing gateways", "error", err)
 		return err
 	}
@@ -124,7 +124,7 @@ func (s *Store) syncRouteStatuses(ctx context.Context) error {
 			})
 		}
 	}
-	if err := syncGroup.Wait(); err != nil {
+	if err := syncGroup.Wait().ErrorOrNil(); err != nil {
 		s.logger.Error("error syncing route statuses", "error", err)
 		return err
 	}
@@ -152,7 +152,7 @@ func (s *Store) sync(ctx context.Context, gateways ...*gatewayState) error {
 	syncGroup.Go(func() error {
 		return s.syncRouteStatuses(ctx)
 	})
-	if err := syncGroup.Wait(); err != nil {
+	if err := syncGroup.Wait().ErrorOrNil(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Something unexpected that I discovered while using the go-multierror library in a personal project:

### Changes proposed in this PR:
Use `ErrorOrNil()` when asserting no errors from `multierror.Group`.

See docstring for `ErrorOrNil()` [here](https://github.com/hashicorp/go-multierror/blob/9974e9ec57696378079ecc3accd3d6f29401b3a0/multierror.go#L24-L28).

### How I've tested this PR:
This test fails every time
```go
func TestMultierrorGroupWait(t *testing.T) {
    var g multierror.Group
    g.Go(func() error { return nil })
    require.NoError(t, g.Wait())
}
```

This one behaves as you'd expect
```go
func TestMultierrorGroupWait(t *testing.T) {
    var g multierror.Group
    g.Go(func() error { return nil })
    require.NoError(t, g.Wait().ErrorOrNil())
}
```

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
