### PR TITLE
Simplify comparison of gateways to use only resource version

### DIFF
--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -388,6 +388,9 @@ func (g *K8sGateway) isEqual(other *K8sGateway) bool {
 	if !reflect.DeepEqual(g.certificates(), other.certificates()) {
 		return false
 	}
+	if !reflect.DeepEqual(g.Listeners(), other.Listeners()) {
+		return false
+	}
 	if !conditionEqual(g.status.Scheduled.Condition(g.gateway.Generation), other.status.Scheduled.Condition(g.gateway.Generation)) {
 		return false
 	}

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -365,7 +365,7 @@ func (g *K8sGateway) ShouldUpdate(other store.Gateway) bool {
 		return false
 	}
 
-	return utils.ResourceVersionLesser(g.gateway.ResourceVersion, otherGateway.gateway.ResourceVersion)
+	return !utils.ResourceVersionGreater(g.gateway.ResourceVersion, otherGateway.gateway.ResourceVersion)
 }
 
 func (g *K8sGateway) ShouldBind(route store.Route) bool {

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -385,6 +385,9 @@ func (g *K8sGateway) isEqual(other *K8sGateway) bool {
 	if !reflect.DeepEqual(g.certificates(), other.certificates()) {
 		return false
 	}
+	if !reflect.DeepEqual(g.Listeners(), other.Listeners()) {
+		return false
+	}
 	if !conditionEqual(g.status.Scheduled.Condition(g.gateway.Generation), other.status.Scheduled.Condition(g.gateway.Generation)) {
 		return false
 	}

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -374,6 +374,9 @@ func (g *K8sGateway) Compare(other store.Gateway) store.CompareResult {
 }
 
 func (g *K8sGateway) isEqual(other *K8sGateway) bool {
+	if !reflect.DeepEqual(g.gateway.Annotations, other.gateway.Annotations) {
+		return false
+	}
 	if !reflect.DeepEqual(g.gateway.Spec, other.gateway.Spec) {
 		return false
 	}
@@ -383,9 +386,6 @@ func (g *K8sGateway) isEqual(other *K8sGateway) bool {
 
 	// check other things that may affect the pending status updates
 	if !reflect.DeepEqual(g.certificates(), other.certificates()) {
-		return false
-	}
-	if !reflect.DeepEqual(g.Listeners(), other.Listeners()) {
 		return false
 	}
 	if !conditionEqual(g.status.Scheduled.Condition(g.gateway.Generation), other.status.Scheduled.Condition(g.gateway.Generation)) {

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -352,59 +351,21 @@ func (g *K8sGateway) Listeners() []store.Listener {
 	return listeners
 }
 
-func (g *K8sGateway) Compare(other store.Gateway) store.CompareResult {
+func (g *K8sGateway) ShouldUpdate(other store.Gateway) bool {
 	if other == nil {
-		return store.CompareResultInvalid
+		return false
 	}
+
 	if g == nil {
-		return store.CompareResultNotEqual
+		return true
 	}
 
-	if otherGateway, ok := other.(*K8sGateway); ok {
-		if utils.ResourceVersionGreater(g.gateway.ResourceVersion, otherGateway.gateway.ResourceVersion) {
-			return store.CompareResultNewer
-		}
-
-		if !g.isEqual(otherGateway) {
-			return store.CompareResultNotEqual
-		}
-		return store.CompareResultEqual
-	}
-	return store.CompareResultInvalid
-}
-
-func (g *K8sGateway) isEqual(other *K8sGateway) bool {
-	if !reflect.DeepEqual(g.gateway.Annotations, other.gateway.Annotations) {
-		return false
-	}
-	if !reflect.DeepEqual(g.gateway.Spec, other.gateway.Spec) {
-		return false
-	}
-	if !gatewayStatusEqual(g.gateway.Status, other.gateway.Status) {
+	otherGateway, ok := other.(*K8sGateway)
+	if !ok {
 		return false
 	}
 
-	// check other things that may affect the pending status updates
-	if !reflect.DeepEqual(g.certificates(), other.certificates()) {
-		return false
-	}
-	if !reflect.DeepEqual(g.Listeners(), other.Listeners()) {
-		return false
-	}
-	if !conditionEqual(g.status.Scheduled.Condition(g.gateway.Generation), other.status.Scheduled.Condition(g.gateway.Generation)) {
-		return false
-	}
-	if g.podReady != other.podReady {
-		return false
-	}
-	if g.serviceReady != other.serviceReady {
-		return false
-	}
-	if !reflect.DeepEqual(g.addresses, other.addresses) {
-		return false
-	}
-
-	return true
+	return utils.ResourceVersionLesser(g.gateway.ResourceVersion, otherGateway.gateway.ResourceVersion)
 }
 
 func (g *K8sGateway) ShouldBind(route store.Route) bool {

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -559,7 +559,7 @@ func TestGatewayShouldUpdate(t *testing.T) {
 	// Have equal resource version
 	gateway.gateway.ObjectMeta.ResourceVersion = `0`
 	other.gateway.ObjectMeta.ResourceVersion = `0`
-	assert.False(t, gateway.ShouldUpdate(other))
+	assert.True(t, gateway.ShouldUpdate(other))
 
 	// Have greater resource version
 	gateway.gateway.ObjectMeta.ResourceVersion = `1`

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -17,7 +17,6 @@ import (
 	internalCore "github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/service"
-	"github.com/hashicorp/consul-api-gateway/internal/store"
 	storeMocks "github.com/hashicorp/consul-api-gateway/internal/store/mocks"
 	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 	"github.com/hashicorp/go-hclog"
@@ -546,78 +545,48 @@ func TestGatewayTrackSync(t *testing.T) {
 	}))
 }
 
-func TestGatewayCompare(t *testing.T) {
+func TestGatewayShouldUpdate(t *testing.T) {
 	t.Parallel()
 
 	gateway := NewK8sGateway(&gw.Gateway{}, K8sGatewayConfig{
 		Logger: hclog.NewNullLogger(),
 	})
+
 	other := NewK8sGateway(&gw.Gateway{}, K8sGatewayConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	require.Equal(t, store.CompareResultEqual, gateway.Compare(other))
-	require.Equal(t, store.CompareResultInvalid, gateway.Compare(nil))
-	require.Equal(t, store.CompareResultInvalid, gateway.Compare(storeMocks.NewMockGateway(nil)))
+
+	// Have equal resource version
+	gateway.gateway.ObjectMeta.ResourceVersion = `0`
+	other.gateway.ObjectMeta.ResourceVersion = `0`
+	assert.False(t, gateway.ShouldUpdate(other))
+
+	// Have greater resource version
+	gateway.gateway.ObjectMeta.ResourceVersion = `1`
+	other.gateway.ObjectMeta.ResourceVersion = `0`
+	assert.False(t, gateway.ShouldUpdate(other))
+
+	// Have lesser resource version
+	gateway.gateway.ObjectMeta.ResourceVersion = `0`
+	other.gateway.ObjectMeta.ResourceVersion = `1`
+	assert.True(t, gateway.ShouldUpdate(other))
+
+	// Have non-numeric resource version
+	gateway.gateway.ObjectMeta.ResourceVersion = `a`
+	other.gateway.ObjectMeta.ResourceVersion = `0`
+	assert.True(t, gateway.ShouldUpdate(other))
+
+	// Other gateway non-numeric resource version
+	gateway.gateway.ObjectMeta.ResourceVersion = `0`
+	other.gateway.ObjectMeta.ResourceVersion = `a`
+	assert.False(t, gateway.ShouldUpdate(other))
+
+	// Other gateway nil
+	assert.False(t, gateway.ShouldUpdate(nil))
+
+	// Have nil gateway
 	gateway = nil
-	require.Equal(t, store.CompareResultNotEqual, gateway.Compare(other))
-
-	gateway = NewK8sGateway(&gw.Gateway{
-		ObjectMeta: meta.ObjectMeta{
-			ResourceVersion: "1",
-		},
-	}, K8sGatewayConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	other = NewK8sGateway(&gw.Gateway{
-		ObjectMeta: meta.ObjectMeta{
-			ResourceVersion: "0",
-		},
-	}, K8sGatewayConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	require.Equal(t, store.CompareResultNewer, gateway.Compare(other))
-
-	gateway.gateway.ObjectMeta.ResourceVersion = "0"
-	gateway.gateway.Spec.GatewayClassName = "other"
-	require.Equal(t, store.CompareResultNotEqual, gateway.Compare(other))
-
-	gateway.gateway.Spec.GatewayClassName = ""
-	gateway.gateway.Status.Conditions = []meta.Condition{{}}
-	require.Equal(t, store.CompareResultNotEqual, gateway.Compare(other))
-
-	gateway = NewK8sGateway(&gw.Gateway{
-		Spec: gw.GatewaySpec{
-			Listeners: []gw.Listener{{
-				Name: gw.SectionName("1"),
-			}},
-		},
-	}, K8sGatewayConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	other = NewK8sGateway(&gw.Gateway{
-		Spec: gw.GatewaySpec{
-			Listeners: []gw.Listener{{
-				Name: gw.SectionName("1"),
-			}},
-		},
-	}, K8sGatewayConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	gateway.listeners["1"].tls.Certificates = []string{"other"}
-	require.Equal(t, store.CompareResultNotEqual, gateway.Compare(other))
-
-	gateway.listeners["1"].tls.Certificates = []string{}
-	gateway.status.Scheduled.Unknown = errors.New("")
-	require.Equal(t, store.CompareResultNotEqual, gateway.Compare(other))
-
-	gateway.status.Scheduled.Unknown = nil
-	gateway.podReady = true
-	other.podReady = false
-	require.Equal(t, store.CompareResultNotEqual, gateway.Compare(other))
-
-	other.podReady = true
-	gateway.addresses = []string{""}
-	require.Equal(t, store.CompareResultNotEqual, gateway.Compare(other))
+	assert.True(t, gateway.ShouldUpdate(other))
 }
 
 func TestGatewayShouldBind(t *testing.T) {

--- a/internal/k8s/utils/versions.go
+++ b/internal/k8s/utils/versions.go
@@ -2,6 +2,20 @@ package utils
 
 import "strconv"
 
+func ResourceVersionLesser(a, b string) bool {
+	aVal, err := strconv.Atoi(a)
+	if err != nil {
+		// a isn't numeric, return that a is lesser
+		return true
+	}
+	bVal, err := strconv.Atoi(b)
+	if err != nil {
+		// b isn't numeric, return that b is lesser
+		return false
+	}
+	return aVal < bVal
+}
+
 func ResourceVersionGreater(a, b string) bool {
 	aVal, err := strconv.Atoi(a)
 	if err != nil {

--- a/internal/k8s/utils/versions.go
+++ b/internal/k8s/utils/versions.go
@@ -2,20 +2,6 @@ package utils
 
 import "strconv"
 
-func ResourceVersionLesser(a, b string) bool {
-	aVal, err := strconv.Atoi(a)
-	if err != nil {
-		// a isn't numeric, return that a is lesser
-		return true
-	}
-	bVal, err := strconv.Atoi(b)
-	if err != nil {
-		// b isn't numeric, return that b is lesser
-		return false
-	}
-	return aVal < bVal
-}
-
 func ResourceVersionGreater(a, b string) bool {
 	aVal, err := strconv.Atoi(a)
 	if err != nil {

--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -33,7 +33,7 @@ type StatusTrackingGateway interface {
 type Gateway interface {
 	ID() core.GatewayID
 	Meta() map[string]string
-	Compare(other Gateway) CompareResult
+	ShouldUpdate(other Gateway) bool
 	Listeners() []Listener
 	ShouldBind(route Route) bool
 }

--- a/internal/store/memory/gateway.go
+++ b/internal/store/memory/gateway.go
@@ -78,15 +78,15 @@ func (g *gatewayState) TryBind(ctx context.Context, route store.Route) {
 	}
 }
 
-func (g *gatewayState) Compare(other store.Gateway) store.CompareResult {
+func (g *gatewayState) ShouldUpdate(other store.Gateway) bool {
 	if other == nil {
-		return store.CompareResultInvalid
+		return false
 	}
 	if g == nil {
-		return store.CompareResultNotEqual
+		return true
 	}
 
-	return g.Gateway.Compare(other)
+	return g.Gateway.ShouldUpdate(other)
 }
 
 func (g *gatewayState) Sync(ctx context.Context) (bool, error) {

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -219,11 +219,7 @@ func (s *Store) UpsertGateway(ctx context.Context, gateway store.Gateway) error 
 
 	current, found := s.gateways[id]
 
-	switch current.Compare(gateway) {
-	case store.CompareResultInvalid, store.CompareResultNewer:
-		// we have an invalid or old route, ignore it
-		return nil
-	case store.CompareResultNotEqual:
+	if current.ShouldUpdate(gateway) {
 		s.logger.Trace("detected gateway state change", "service", id.Service, "namespace", id.ConsulNamespace)
 		updated := newGatewayState(s.logger, gateway, s.adapter)
 

--- a/internal/store/mocks/interfaces.go
+++ b/internal/store/mocks/interfaces.go
@@ -36,20 +36,6 @@ func (m *MockStatusTrackingGateway) EXPECT() *MockStatusTrackingGatewayMockRecor
 	return m.recorder
 }
 
-// Compare mocks base method.
-func (m *MockStatusTrackingGateway) Compare(other store.Gateway) store.CompareResult {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Compare", other)
-	ret0, _ := ret[0].(store.CompareResult)
-	return ret0
-}
-
-// Compare indicates an expected call of Compare.
-func (mr *MockStatusTrackingGatewayMockRecorder) Compare(other interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Compare", reflect.TypeOf((*MockStatusTrackingGateway)(nil).Compare), other)
-}
-
 // ID mocks base method.
 func (m *MockStatusTrackingGateway) ID() core.GatewayID {
 	m.ctrl.T.Helper()
@@ -106,6 +92,20 @@ func (mr *MockStatusTrackingGatewayMockRecorder) ShouldBind(route interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldBind", reflect.TypeOf((*MockStatusTrackingGateway)(nil).ShouldBind), route)
 }
 
+// ShouldUpdate mocks base method.
+func (m *MockStatusTrackingGateway) ShouldUpdate(other store.Gateway) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldUpdate", other)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShouldUpdate indicates an expected call of ShouldUpdate.
+func (mr *MockStatusTrackingGatewayMockRecorder) ShouldUpdate(other interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldUpdate", reflect.TypeOf((*MockStatusTrackingGateway)(nil).ShouldUpdate), other)
+}
+
 // TrackSync mocks base method.
 func (m *MockStatusTrackingGateway) TrackSync(ctx context.Context, sync func() (bool, error)) error {
 	m.ctrl.T.Helper()
@@ -141,20 +141,6 @@ func NewMockGateway(ctrl *gomock.Controller) *MockGateway {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGateway) EXPECT() *MockGatewayMockRecorder {
 	return m.recorder
-}
-
-// Compare mocks base method.
-func (m *MockGateway) Compare(other store.Gateway) store.CompareResult {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Compare", other)
-	ret0, _ := ret[0].(store.CompareResult)
-	return ret0
-}
-
-// Compare indicates an expected call of Compare.
-func (mr *MockGatewayMockRecorder) Compare(other interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Compare", reflect.TypeOf((*MockGateway)(nil).Compare), other)
 }
 
 // ID mocks base method.
@@ -211,6 +197,20 @@ func (m *MockGateway) ShouldBind(route store.Route) bool {
 func (mr *MockGatewayMockRecorder) ShouldBind(route interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldBind", reflect.TypeOf((*MockGateway)(nil).ShouldBind), route)
+}
+
+// ShouldUpdate mocks base method.
+func (m *MockGateway) ShouldUpdate(other store.Gateway) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldUpdate", other)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShouldUpdate indicates an expected call of ShouldUpdate.
+func (mr *MockGatewayMockRecorder) ShouldUpdate(other interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldUpdate", reflect.TypeOf((*MockGateway)(nil).ShouldUpdate), other)
 }
 
 // MockRouteTrackingListener is a mock of RouteTrackingListener interface.


### PR DESCRIPTION
We currently wind up with a stale gateway in memory that can't be written to the store when we want to update it.

```logs
2022-03-15T17:56:05.165Z [ERROR] memory/store.go:110: consul-api-gateway-server.state: error syncing gateways:
  error=
  | 1 error occurred:
  | 	* Operation cannot be fulfilled on gateways.gateway.networking.k8s.io "backend-namespaces": the object has been modified; please apply your changes to the latest version and try again
  | 
```

Due to this, the new route that's being added is unable to bind and thus the conformance tests fail.

After adding some code using [go-test/diff](https://github.com/go-test/deep), I was able to determine the diff between the gateway `Listeners()` during the sync process:

```diff
slice[0].gateway.ObjectMeta.Annotations.map[api-gateway.consul.hashicorp.com/config]:

-{\"serviceType\":\"LoadBalancer\",\"consul\":{\"authentication\":{},\"scheme\":\"https\",\"ports\":{\"http\":8501,\"grpc\":8502}},\"image\":{\"consulAPIGateway\":\"gcr.io/hc-9b66efef4c6f4f9a85bcdbe92a9/consul-api-gateway-oss:16\",\"envoy\":\"envoyproxy/envoy-alpine:v1.20.2\"},\"copyAnnotations\":{},\"logLevel\":\"info\"}
+{\"serviceType\":\"LoadBalancer\",\"consul\":{\"authentication\":{},\"scheme\":\"https\",\"ports\":{\"http\":8501,\"grpc\":8502}},\"image\":{\"consulAPIGateway\":\"gcr.io/hc-9b66efef4c6f4f9a85bcdbe92a9/consul-api-gateway-oss:17\",\"envoy\":\"envoyproxy/envoy-alpine:v1.20.2\"},\"copyAnnotations\":{},\"logLevel\":\"info\"}

slice[0].routeCount:
-1
+0
```

When the sync fails, it retries a couple of times and then goes silent. The gateway then never has the route listed in attached routes. Andrew mentioned that he doesn't think we want to dirty-check the route count, and I think we want the annotation config to be a snapshot of creation time. I'm not sure which of these is preventing the sync; however, including `gateway.Listeners()` in the `isEqual` comparison dirty-checks both implicitly and fixes the issue in my testing.

### Changes proposed in this PR:
When determining if two gateways are equal during the sync process, only compare the resource version. This will prevent the list of things to compare from continually growing and requiring tons of mental overhead to figure out any bugs.

### How I've tested this PR:
Running the upstream conformance tests against `main` will trigger the issue above. The only fix I've found is to delete the controller pod so that the stale gateway is dumped.

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
