### PR TITLE
Remove now-unused func

### DIFF
--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -80,14 +80,6 @@ func NewK8sGateway(gateway *gw.Gateway, config K8sGatewayConfig) *K8sGateway {
 	}
 }
 
-func (g *K8sGateway) certificates() []string {
-	certificates := []string{}
-	for _, listener := range g.listeners {
-		certificates = append(certificates, listener.Config().TLS.Certificates...)
-	}
-	return certificates
-}
-
 func (g *K8sGateway) Validate(ctx context.Context) error {
 	g.status = GatewayStatus{}
 	g.validateListenerConflicts()


### PR DESCRIPTION
### Changes proposed in this PR:
Remove unused func causing linting to fail on `main` [here](https://github.com/hashicorp/consul-api-gateway/runs/5606501755?check_suite_focus=true)

### How I've tested this PR:
linting passes on this PR

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
