### PR TITLE
Simplify naming of sync adapter in consideration of pkg name

### DIFF
--- a/internal/adapters/consul/sync_test.go
+++ b/internal/adapters/consul/sync_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul-api-gateway/internal/common"
 	"github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -168,7 +169,7 @@ func TestConsulSyncAdapter_Sync(t *testing.T) {
 	consul, err := api.NewClient(cfg)
 	require.NoError(t, err)
 
-	adapter := NewConsulSyncAdapter(testutil.Logger(t), consul)
+	adapter := NewSyncAdapter(testutil.Logger(t), consul)
 
 	route := core.NewTCPRouteBuilder().
 		WithName("tcp-default/route1").

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -71,7 +71,7 @@ func RunServer(config ServerConfig) int {
 	}
 
 	store := memory.NewStore(memory.StoreConfig{
-		Adapter: consulAdapters.NewConsulSyncAdapter(config.Logger.Named("consul-adapter"), consulClient),
+		Adapter: consulAdapters.NewSyncAdapter(config.Logger.Named("consul-adapter"), consulClient),
 		Logger:  config.Logger.Named("state"),
 	})
 

--- a/internal/testing/e2e/gateway.go
+++ b/internal/testing/e2e/gateway.go
@@ -65,7 +65,7 @@ func (p *gatewayTestEnvironment) run(ctx context.Context, namespace string, cfg 
 	}
 
 	store := memory.NewStore(memory.StoreConfig{
-		Adapter: consulAdapters.NewConsulSyncAdapter(nullLogger, consulClient),
+		Adapter: consulAdapters.NewSyncAdapter(nullLogger, consulClient),
 		Logger:  nullLogger,
 	})
 


### PR DESCRIPTION
### Changes proposed in this PR:
Since the `ConsulSyncAdapter` resides in the `consul` package, we can simplify the name to `SyncAdapter` which makes things less verbose while conveying the same thing.

### How I've tested this PR:
CI

### How I expect reviewers to test this PR:
CI

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
