### PR TITLE
Spin up a kind cluster and configure metallb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,42 @@ jobs:
         --jsonfile $TEST_RESULTS_DIR/json/go-test-race.log \
         --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
         -tags e2e ./internal/commands/server
+  conformance:
+    name: conformance tests (consul-image=${{ matrix.consul-image }})
+    strategy:
+      matrix:
+        consul-image: ['hashicorp/consul:1.11.4', 'hashicorp/consul-enterprise:1.11.4-ent']
+    runs-on: ubuntu-latest
+    env:
+      TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: |
+        curl -L https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 -o ./kind
+        chmod +x ./kind
+        mv ./kind /usr/local/bin/kind
+        curl -L https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl -o ./kubectl
+        chmod +x ./kubectl
+        mv ./kubectl /usr/local/bin/kubectl
+        curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.4.0/kustomize_v4.4.0_linux_amd64.tar.gz -o kustomize_v4.4.0_linux_amd64.tar.gz
+        tar xvzf kustomize_v4.4.0_linux_amd64.tar.gz
+        mv kustomize /usr/local/bin/kustomize
+        rm kustomize_v4.4.0_linux_amd64.tar.gz
+    - uses: ./.github/actions/goenv
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Test
+      env:
+        DOCKER_HOST_ROUTE: 172.17.0.1
+        E2E_APIGW_CONSUL_IMAGE: ${{ matrix.consul-image }}
+      run: |
+        mkdir -p $TEST_RESULTS_DIR/json
+        gotestsum \
+        --format=short-verbose \
+        --jsonfile $TEST_RESULTS_DIR/json/go-test-race.log \
+        --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
+        -tags conformance ./testing/conformance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,4 +151,4 @@ jobs:
         --format=short-verbose \
         --jsonfile $TEST_RESULTS_DIR/json/go-test-race.log \
         --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
-        -tags conformance ./testing/conformance
+        -tags conformance ./internal/testing/conformance

--- a/internal/testing/conformance/run_conformance_test.go
+++ b/internal/testing/conformance/run_conformance_test.go
@@ -1,0 +1,48 @@
+//go:build conformance
+// +build conformance
+
+package conformance
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul-api-gateway/internal/testing/e2e"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+)
+
+//This file is intended to help faciliate an easy and local way of running the
+//conformance tests defined here https://github.com/kubernetes-sigs/gateway-api/blob/master/conformance/conformance_test.go
+
+//This is a work in progress
+
+var (
+	testenv   env.Environment
+	hostRoute string
+)
+
+func TestMain(m *testing.M) {
+	//set up test env
+	hostRoute := os.Getenv("DOCKER_HOST_ROUTE")
+	if hostRoute == "" {
+		hostRoute = "host.docker.internal"
+	}
+
+	testenv = env.New()
+	testenv.Setup(
+		SetUpStack(hostRoute),
+	)
+
+	testenv.Finish(
+		e2e.TearDownStack,
+	)
+
+	testenv.Run(m)
+}
+
+func TestRunConformanceTestSuite(t *testing.T) {
+	//TODO wait for gateway to be ready
+
+	//TODO invoke conformance tests
+
+}

--- a/internal/testing/conformance/run_conformance_test.go
+++ b/internal/testing/conformance/run_conformance_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 )
 
-//This file is intended to help faciliate an easy and local way of running the
+//This file is intended to help facilitate an easy and local way of running the
 //conformance tests defined here https://github.com/kubernetes-sigs/gateway-api/blob/master/conformance/conformance_test.go
 
 //This is a work in progress

--- a/internal/testing/conformance/stack.go
+++ b/internal/testing/conformance/stack.go
@@ -1,0 +1,47 @@
+package conformance
+
+import (
+	"context"
+	"os/exec"
+	"time"
+
+	"github.com/hashicorp/consul-api-gateway/internal/testing/e2e"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+//set up conformance test stack
+
+var (
+	metalLBManifests = []string{
+		"https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml",
+		"https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml",
+	}
+)
+
+func kubectlApply(ctx context.Context, path string) error {
+	timeoutContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(timeoutContext, "kubectl", "apply", "-f", path)
+	return cmd.Run()
+}
+
+func SetUpStack(hostRoute string) env.Func {
+	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		var err error
+		//invoke e2e stack
+		ctx, err = e2e.SetUpStack(hostRoute)(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		//install metallb on newly spun up kind cluster
+		for _, url := range metalLBManifests {
+			err = kubectlApply(ctx, url)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return ctx, nil
+	}
+}


### PR DESCRIPTION
### Changes proposed in this PR:

- Empty test runner added to testing/conformance that can be invoked with go test ./... -tags conformance
- Set up a conformance test stack intesting/conformanc that installs metallb in addition to the dependencies required for the e2e test (though potentially they don't need all the same dependencies installed? Feedback needed there.) 
- Added a github action config that invokes go test ./... -tags conformance 


### How I've tested this PR:
go test ./... -tags conformance

### How I expect reviewers to test this PR:
go test ./... -tags conformance

### Checklist:
- [ X ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
