### PR TITLE
Stop using fork of gateway-api for conformance testing

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -41,8 +41,7 @@ jobs:
       - name: Clone gateway-api
         uses: actions/checkout@v2
         with:
-          repository: "nathancoleman/gateway-api"
-          ref: "eventually-consistent-conformance"
+          repository: "kubernetes-sigs/gateway-api"
           path: "gateway-api"
 
       - name: Setup Goenv


### PR DESCRIPTION
### Changes proposed in this PR:
Stop using my fork of gateway-api for conformance testing since https://github.com/kubernetes-sigs/gateway-api/pull/1080 merged

### How I've tested this PR:
:robot: tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
