### PR TITLE
Add RefNotPermitted to status listing for HTTPRoute

### DIFF
--- a/dev/docs/supported-features.md
+++ b/dev/docs/supported-features.md
@@ -125,6 +125,7 @@ Supported features are marked with a grey checkbox
         - [x] *ResolvedRefs* indicates that we were able to resolve all route references to things like Kubernetes/Consul services
         - [x] *ServiceNotFound* weren't able to find the referenced Kubernetes service
         - [x] *ConsulServiceNotFound* weren't able to find the referenced Consul mesh service
+        - [x] *RefNotPermitted* weren't able to route across namespaces due to a missing ReferencePolicy
 
 - [x] TCPRoute - we are limited by Consul's ability to only route to a single TCP-based upstream, so TCP-based Gateway listeners only support a single TCPRoute with a single rule with a single backend; otherwise, either the TCPRoute is considered invalid or the Gateway status is set as having conflicting routes.
 - [ ] TLSRoute - TODO


### PR DESCRIPTION
### Changes proposed in this PR:
The `HTTPRoute` can now get `RefNotPermitted` in its status. This error was added in #143.
This PR updates the list of supported features.

### How I've tested this PR:
Read it

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
