### PR TITLE
ReferencePolicy should be breaking change in changelog

### DIFF
--- a/.changelog/143.txt
+++ b/.changelog/143.txt
@@ -1,3 +1,3 @@
-```release-note:feature
+```release-note:breaking-change
 Added support for cross namespace routes with [ReferencePolicy](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1alpha2.ReferencePolicy)
 ```


### PR DESCRIPTION
### Changes proposed in this PR:
-Change release note entry for reference policy from feature to breaking change

### How I've tested this PR:

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
