### PR TITLE
Rev CI versions for consul 1.11 and add 1.12 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
     name: unit test (consul-version=${{ matrix.consul-version }})
     strategy:
       matrix:
-        consul-version: [1.11.4, 1.11.4+ent]
+        consul-version: 
+        - 1.11.5
+        - 1.12.0-beta1
+        - 1.11.5+ent
+        - 1.12.0-beta1+ent
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/consul@${{ matrix.consul-version }}
@@ -82,7 +86,11 @@ jobs:
     name: e2e tests (consul-image=${{ matrix.consul-image }})
     strategy:
       matrix:
-        consul-image: ['hashicorp/consul:1.11.4', 'hashicorp/consul-enterprise:1.11.4-ent']
+        consul-image: 
+        - 'hashicorp/consul:1.11.5'
+        - 'hashicorp/consul-enterprise:1.11.5-ent'
+        - 'hashicorp/consul:1.12.0-beta1'
+        - 'hashicorp/consul-enterprise:1.12.0-beta1-ent'
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}


### PR DESCRIPTION
### Changes proposed in this PR:

This adds some CI targets for Consul 1.12.0-beta1 and has us testing on the latest 1.11 patch release. Once the 1.12 release goes out we can probably drop the 1.11 targets from the build matrix.
