### PR TITLE
Allow manual conformance runs to start tmate session on failure

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false  # GitHub parses this value to string, see https://github.com/actions/runner/issues/1483
+      debug_timeout_minutes:
+        description: 'How many minutes should the tmate session close itself after?'
+        required: false
+        type: string  # No support for numeric value
+        default: '10'
 
 env:
   GO_VERSION: "1.17"
@@ -117,7 +122,7 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'
-        timeout-minutes: 10
+        timeout-minutes: ${{ fromJSON(github.event.inputs.debug_timeout_minutes) }}
 
       - name: Report Status
         if: always() && github.ref == 'refs/heads/main'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -11,7 +11,11 @@ on:
     - cron:  '0 0 * * *'
 
   workflow_dispatch:
-
+    inputs:
+      debug_enabled:
+        description: 'Start tmate session if any step fails'
+        required: false
+        default: 'false'  # GitHub parses any value to string, no support for boolean
 
 env:
   GO_VERSION: "1.17"
@@ -97,6 +101,11 @@ jobs:
         run: |
           helm install --values ./consul-config.yaml consul $GITHUB_WORKSPACE/consul-k8s/charts/consul --create-namespace --namespace=consul
           kubectl wait --for=condition=Ready --timeout=120s --namespace=consul pods --all
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'
+        timeout-minutes: 10
 
       - name: Patch testing resources
         working-directory: "consul-api-gateway/internal/testing/conformance"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -65,7 +65,7 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
           kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
           kubectl apply -f ./consul-api-gateway/internal/testing/conformance/metallb-config.yaml
-          kubectl wait --for=condition=Ready --timeout=120s --namespace=metallb-system pods --all
+          kubectl wait --for=condition=Ready --timeout=60s --namespace=metallb-system pods --all
 
       - name: Build binary
         env:
@@ -100,7 +100,7 @@ jobs:
         working-directory: "consul-api-gateway/internal/testing/conformance"
         run: |
           helm install --values ./consul-config.yaml consul $GITHUB_WORKSPACE/consul-k8s/charts/consul --create-namespace --namespace=consul
-          kubectl wait --for=condition=Ready --timeout=120s --namespace=consul pods --all
+          kubectl wait --for=condition=Ready --timeout=60s --namespace=consul pods --all
 
       - name: Patch testing resources
         working-directory: "consul-api-gateway/internal/testing/conformance"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'
+        if: failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'
         timeout-minutes: 10
 
       - name: Report Status

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,7 +15,7 @@ on:
       debug_enabled:
         description: 'Start tmate session if any step fails'
         required: false
-        default: 'false'  # GitHub parses any value to string, no support for boolean
+        default: 'false'  # GitHub parses any value to string, see https://github.com/actions/runner/issues/1483
 
 env:
   GO_VERSION: "1.17"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,9 +15,8 @@ on:
       debug_enabled:
         description: 'Start tmate session if any step fails'
         required: false
-        type: choice
-        options: ['true', 'false']
-        default: 'false'  # GitHub parses any value to string, see https://github.com/actions/runner/issues/1483
+        type: boolean
+        default: false  # GitHub parses this value to string, see https://github.com/actions/runner/issues/1483
 
 env:
   GO_VERSION: "1.17"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,6 +15,8 @@ on:
       debug_enabled:
         description: 'Start tmate session if any step fails'
         required: false
+        type: choice
+        options: ['true', 'false']
         default: 'false'  # GitHub parses any value to string, see https://github.com/actions/runner/issues/1483
 
 env:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -61,7 +61,7 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
           kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
           kubectl apply -f ./consul-api-gateway/internal/testing/conformance/metallb-config.yaml
-          kubectl wait --for=condition=Ready --timeout=60s --namespace=metallb-system pods --all
+          kubectl wait --for=condition=Ready --timeout=120s --namespace=metallb-system pods --all
 
       - name: Build binary
         env:
@@ -96,7 +96,7 @@ jobs:
         working-directory: "consul-api-gateway/internal/testing/conformance"
         run: |
           helm install --values ./consul-config.yaml consul $GITHUB_WORKSPACE/consul-k8s/charts/consul --create-namespace --namespace=consul
-          kubectl wait --for=condition=Ready --timeout=60s --namespace=consul pods --all
+          kubectl wait --for=condition=Ready --timeout=120s --namespace=consul pods --all
 
       - name: Patch testing resources
         working-directory: "consul-api-gateway/internal/testing/conformance"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -102,11 +102,6 @@ jobs:
           helm install --values ./consul-config.yaml consul $GITHUB_WORKSPACE/consul-k8s/charts/consul --create-namespace --namespace=consul
           kubectl wait --for=condition=Ready --timeout=120s --namespace=consul pods --all
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'
-        timeout-minutes: 10
-
       - name: Patch testing resources
         working-directory: "consul-api-gateway/internal/testing/conformance"
         run: |
@@ -117,6 +112,11 @@ jobs:
       - name: Run tests
         working-directory: "gateway-api/conformance"
         run: go test -v -timeout 10m ./ --gateway-class consul-api-gateway
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'
+        timeout-minutes: 10
 
       - name: Report Status
         if: always() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
### Changes proposed in this PR:
Rather than have to manually add in a tmate session to debug failing runs, allow a manual run to start up tmate whenever any step fails. This will add an option when running manually such as the ones seen [here](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/).

### How I've tested this PR:
If you go to the Actions tab for the repo and choose to run the conformance workflow on this branch, you'll see this nice new setting:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/3476400/163597672-0456104c-092e-4121-895a-026c67edf188.png">


### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
