### PR TITLE
Consume consul 1.12.0-beta for conformance testing

### DIFF
--- a/internal/testing/conformance/consul-config.yaml
+++ b/internal/testing/conformance/consul-config.yaml
@@ -1,4 +1,5 @@
 global:
+  image: "hashicorp/consul:1.12.0-beta1"
   tls:
     enabled: true
 server:

--- a/internal/testing/conformance/consul-config.yaml
+++ b/internal/testing/conformance/consul-config.yaml
@@ -1,5 +1,5 @@
 global:
-  image: "hashicorp/consul:1.12.0-beta1"
+  image: "hashicorp/consul:1.12.0-beta1"  # TODO Remove once 1.12.0 is consumed in consul-k8s
   tls:
     enabled: true
 server:


### PR DESCRIPTION
### Changes proposed in this PR:
Consume consul 1.12.0-beta1 for conformance testing until the updating of consul-k8s next week

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
