### PR TITLE
Upgrade default envoy image to use 1.22 distroless

### DIFF
--- a/internal/k8s/builder/builder.go
+++ b/internal/k8s/builder/builder.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 const (
-	defaultEnvoyImage     = "envoyproxy/envoy:v1.20-latest"
+	defaultEnvoyImage     = "envoyproxy/envoy-distroless:v1.22-latest"
 	defaultLogLevel       = "info"
 	defaultConsulAddress  = "$(HOST_IP)"
 	defaultConsulHTTPPort = "8500"

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -52,7 +52,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: envoyproxy/envoy:v1.20-latest
+        image: envoyproxy/envoy-distroless:v1.22-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -52,7 +52,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: envoyproxy/envoy:v1.20-latest
+        image: envoyproxy/envoy-distroless:v1.22-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -53,7 +53,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: envoyproxy/envoy:v1.20-latest
+        image: envoyproxy/envoy-distroless:v1.22-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -56,7 +56,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: envoyproxy/envoy:v1.20-latest
+        image: envoyproxy/envoy-distroless:v1.22-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/testing/e2e/service.go
+++ b/internal/testing/e2e/service.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	envoyImage                = "envoyproxy/envoy:v1.20-latest"
+	envoyImage                = "envoyproxy/envoy-distroless:v1.22-latest"
 	httpBootstrapJSONTemplate = `{
 		"admin": {
 			"access_log_path": "/dev/null",


### PR DESCRIPTION
### Changes proposed in this PR:

Upgrades the envoy we use everywhere to use [distroless releases](https://hub.docker.com/r/envoyproxy/envoy-distroless), which run without a shell. Not entirely sure if tests will pass initially as we may need to update our [entrypoint template](https://github.com/hashicorp/consul-api-gateway/blob/7af23d42414c6651d73e4ee941a866073b3c8c0d/internal/k8s/builder/gateway.go#L315) as it uses a shell script to inject Consul's CA certificate. We can probably fix this using environment variables directly on the deployment definition.