### PR TITLE
Consolidate steps for Kind setup into single action

### DIFF
--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -1,0 +1,35 @@
+name: "Setup Kind"
+description: "Setup a Kind cluster with MetalLB for ingress"
+inputs:
+  cluster-name:
+    description: "The name to assign to the Kind cluster"
+    required: false
+    default: "consul-api-gateway-test"
+  load-docker-image:
+    description: "A Docker image to load into Kind cluster, if any"
+    required: false
+    default: ""
+  metallb-config-path:
+    description: "The path to a config file for MetalLB"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Create Kind cluster
+      uses: helm/kind-action@2a525709fd0874b75d7ae842d257981b0e0f557d
+      with:
+        cluster_name: ${{ inputs.cluster-name }}
+        kubectl_version: "v1.21.0"
+
+    - name: Install MetalLB
+      shell: bash
+      run: |
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
+        kubectl apply -f ${{ inputs.metallb-config-path }}
+        kubectl wait --for=condition=Ready --timeout=60s --namespace=metallb-system pods --all
+
+    - name: Load Docker image
+      if: inputs.load-docker-image != ''
+      shell: bash
+      run: kind load docker-image ${{ inputs.load-docker-image }} --name ${{ inputs.cluster-name }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -60,19 +60,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Create Kind cluster
-        uses: helm/kind-action@2a525709fd0874b75d7ae842d257981b0e0f557d
-        with:
-          cluster_name: "consul-api-gateway-test"
-          kubectl_version: "v1.21.0"
-
-      - name: Install MetalLB
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
-          kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
-          kubectl apply -f ./consul-api-gateway/internal/testing/conformance/metallb-config.yaml
-          kubectl wait --for=condition=Ready --timeout=60s --namespace=metallb-system pods --all
-
       - name: Build binary
         env:
           CGO_ENABLED: "0"
@@ -95,8 +82,11 @@ jobs:
           push: false
           tags: "consul-api-gateway:test"
 
-      - name: Load Docker image into Kind
-        run: kind load docker-image consul-api-gateway:test --name consul-api-gateway-test
+      - name: Setup Kind cluster
+        uses: ./consul-api-gateway/.github/actions/setup-kind
+        with:
+          load-docker-image: "consul-api-gateway:test"
+          metallb-config-path: "./consul-api-gateway/internal/testing/conformance/metallb-config.yaml"
 
       - name: Install Consul API Gateway CRDs
         working-directory: "consul-api-gateway"


### PR DESCRIPTION
### Changes proposed in this PR:
Shifting steps to setup a Kind cluster over into their own action.

This gets us one step closer to having what's essentially a test matrix for e2e+conformance where we vary the type of cluster across a list of setup actions in the future:
- `setup-kind/action.yml`
- `setup-eks/action.yml`
- `setup-gke/action.yml`
- `setup-aks/action.yml`

### How I've tested this PR:
:robot: tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
