### PR TITLE
Require ReferencePolicy for certificateRef in other namespace

### DIFF
--- a/.changelog/154.txt
+++ b/.changelog/154.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+Added support for cross namespace Gateway certificateRefs with [ReferencePolicy](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1alpha2.ReferencePolicy)
+```

--- a/.changelog/154.txt
+++ b/.changelog/154.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-Added support for cross namespace Gateway certificateRefs with [ReferencePolicy](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1alpha2.ReferencePolicy)
+Gateway listener `certificateRefs` to secrets in a different namespace now require a [ReferencePolicy](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1alpha2.ReferencePolicy)
 ```

--- a/internal/k8s/reconciler/config/errors.yaml
+++ b/internal/k8s/reconciler/config/errors.yaml
@@ -1,4 +1,4 @@
 - name: CertificateResolution
-  types: ["NotFound","Unsupported"]
+  types: ["NotFound","NotPermitted","Unsupported"]
 - name: Bind
   types: ["RouteKind","ListenerNamespacePolicy","HostnameMismatch","RouteInvalid"]

--- a/internal/k8s/reconciler/listener.go
+++ b/internal/k8s/reconciler/listener.go
@@ -126,10 +126,10 @@ func (l *K8sListener) validateTLS(ctx context.Context) error {
 	if err != nil {
 		return err
 	} else if !allowed {
-		// TODO Generalize getServiceID to work for logging any namespaced type with an optional+inherited namespace
-		l.logger.Warn("Cross-namespace listener certificate not allowed without matching ReferencePolicy", "refName", ref.Name, "refNamespace", ref.Namespace)
+		nsName := getNamespacedName(ref.Name, ref.Namespace, l.gateway.Namespace)
+		l.logger.Warn("Cross-namespace listener certificate not allowed without matching ReferencePolicy", "refName", nsName.Name, "refNamespace", nsName.Namespace)
 		l.status.ResolvedRefs.InvalidCertificateRef = NewCertificateResolutionErrorNotPermitted(
-			fmt.Sprintf("Cross-namespace listener certificate not allowed without matching ReferencePolicy for Secret %s/%s", ref.Name, ref.Name))
+			fmt.Sprintf("Cross-namespace listener certificate not allowed without matching ReferencePolicy for Secret %q", nsName))
 		return nil
 	}
 

--- a/internal/k8s/reconciler/listener.go
+++ b/internal/k8s/reconciler/listener.go
@@ -122,6 +122,7 @@ func (l *K8sListener) validateTLS(ctx context.Context) error {
 	// we only support a single certificate for now
 	ref := *l.listener.TLS.CertificateRefs[0]
 
+	// require ReferencePolicy for cross-namespace certificateRef
 	allowed, err := gatewayAllowedForSecretRef(ctx, l.gateway, ref, l.client)
 	if err != nil {
 		return err

--- a/internal/k8s/reconciler/listener_test.go
+++ b/internal/k8s/reconciler/listener_test.go
@@ -218,7 +218,7 @@ func TestListenerValidate(t *testing.T) {
 		assert.Equal(t, meta.ConditionTrue, condition.Status)
 	})
 
-	t.Run("Valid same-namespace secret ref", func(t *testing.T) {
+	t.Run("Valid same-namespace secret ref without ReferencePolicy", func(t *testing.T) {
 		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
 			Protocol: gw.HTTPSProtocolType,
 			TLS: &gw.GatewayTLSConfig{

--- a/internal/k8s/reconciler/listener_test.go
+++ b/internal/k8s/reconciler/listener_test.go
@@ -6,17 +6,19 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8s "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
 	"github.com/hashicorp/consul-api-gateway/internal/store"
 	storeMocks "github.com/hashicorp/consul-api-gateway/internal/store/mocks"
-	"github.com/hashicorp/go-hclog"
 )
 
 func TestListenerID(t *testing.T) {
@@ -40,268 +42,293 @@ func TestListenerValidate(t *testing.T) {
 	defer ctrl.Finish()
 	client := mocks.NewMockClient(ctrl)
 
-	// protocols
-	listener := NewK8sListener(&gw.Gateway{}, gw.Listener{}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
+	t.Run("Unsupported protocol", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+		})
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Ready.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
+		condition = listener.status.Detached.Condition(0)
+		require.Equal(t, ListenerConditionReasonUnsupportedProtocol, condition.Reason)
 	})
-	require.NoError(t, listener.Validate(context.Background()))
-	condition := listener.status.Ready.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
-	condition = listener.status.Detached.Condition(0)
-	require.Equal(t, ListenerConditionReasonUnsupportedProtocol, condition.Reason)
 
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPProtocolType,
-		AllowedRoutes: &gw.AllowedRoutes{
-			Kinds: []gw.RouteGroupKind{{
-				Kind: gw.Kind("UDPRoute"),
-			}},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.ResolvedRefs.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalidRouteKinds, condition.Reason)
-
-	// Addresses
-	listener = NewK8sListener(&gw.Gateway{
-		Spec: gw.GatewaySpec{
-			Addresses: []gw.GatewayAddress{{}},
-		},
-	}, gw.Listener{
-		Protocol: gw.HTTPProtocolType,
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.Detached.Condition(0)
-	require.Equal(t, ListenerConditionReasonUnsupportedAddress, condition.Reason)
-
-	// TLS validations
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.Ready.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
-
-	mode := gw.TLSModePassthrough
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			Mode: &mode,
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.Ready.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
-
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS:      &gw.GatewayTLSConfig{},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-	})
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.ResolvedRefs.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalidCertificateRef, condition.Reason)
-
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Name: "secret",
-			}},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
-	})
-	client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(nil, expected)
-	require.True(t, errors.Is(listener.Validate(context.Background()), expected))
-
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Name: "secret",
-			}},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
-	})
-	client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(nil, nil)
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.ResolvedRefs.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalidCertificateRef, condition.Reason)
-
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Name: "secret",
-			}},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
-	})
-	client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
-		ObjectMeta: meta.ObjectMeta{
-			Name: "secret",
-		},
-	}, nil)
-	require.Len(t, listener.Config().TLS.Certificates, 0)
-	require.NoError(t, listener.Validate(context.Background()))
-	require.Len(t, listener.Config().TLS.Certificates, 1)
-
-	group := gw.Group("group")
-	kind := gw.Kind("kind")
-	namespace := gw.Namespace("namespace")
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Namespace: &namespace,
-				Group:     &group,
-				Kind:      &kind,
-				Name:      "secret",
-			}},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
-	})
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.ResolvedRefs.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalidCertificateRef, condition.Reason)
-
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Name: "secret",
-			}},
-			Options: map[gw.AnnotationKey]gw.AnnotationValue{
-				"api-gateway.consul.hashicorp.com/tls_min_version": "TLSv1_2",
+	t.Run("Invalid route kinds", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPProtocolType,
+			AllowedRoutes: &gw.AllowedRoutes{
+				Kinds: []gw.RouteGroupKind{{
+					Kind: "UDPRoute",
+				}},
 			},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+		})
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.ResolvedRefs.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalidRouteKinds, condition.Reason)
 	})
-	client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
-		ObjectMeta: meta.ObjectMeta{
-			Name: "secret",
-		},
-	}, nil)
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.Ready.Condition(0)
-	require.Equal(t, ListenerConditionReasonReady, condition.Reason)
-	require.Equal(t, "TLSv1_2", listener.tls.MinVersion)
 
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Name: "secret",
-			}},
-			Options: map[gw.AnnotationKey]gw.AnnotationValue{
-				"api-gateway.consul.hashicorp.com/tls_min_version": "foo",
+	t.Run("Unsupported address", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{
+			Spec: gw.GatewaySpec{
+				Addresses: []gw.GatewayAddress{{}},
 			},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
+		}, gw.Listener{
+			Protocol: gw.HTTPProtocolType,
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+		})
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Detached.Condition(0)
+		require.Equal(t, ListenerConditionReasonUnsupportedAddress, condition.Reason)
 	})
-	client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
-		ObjectMeta: meta.ObjectMeta{
-			Name: "secret",
-		},
-	}, nil)
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.Ready.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
-	require.Equal(t, "unrecognized TLS min version", condition.Message)
 
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Name: "secret",
-			}},
-			Options: map[gw.AnnotationKey]gw.AnnotationValue{
-				"api-gateway.consul.hashicorp.com/tls_cipher_suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-			},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
+	t.Run("Invalid TLS config", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+		})
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Ready.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
 	})
-	client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
-		ObjectMeta: meta.ObjectMeta{
-			Name: "secret",
-		},
-	}, nil)
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.Ready.Condition(0)
-	require.Equal(t, ListenerConditionReasonReady, condition.Reason)
-	require.Equal(t, []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"}, listener.tls.CipherSuites)
 
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Name: "secret",
-			}},
-			Options: map[gw.AnnotationKey]gw.AnnotationValue{
-				"api-gateway.consul.hashicorp.com/tls_min_version":   "TLSv1_3",
-				"api-gateway.consul.hashicorp.com/tls_cipher_suites": "foo",
+	t.Run("Invalid TLS passthrough", func(t *testing.T) {
+		mode := gw.TLSModePassthrough
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				Mode: &mode,
 			},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+		})
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Ready.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
 	})
-	client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
-		ObjectMeta: meta.ObjectMeta{
-			Name: "secret",
-		},
-	}, nil)
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.Ready.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
-	require.Equal(t, "configuring TLS cipher suites is only supported for TLS 1.2 and earlier", condition.Message)
 
-	listener = NewK8sListener(&gw.Gateway{}, gw.Listener{
-		Protocol: gw.HTTPSProtocolType,
-		TLS: &gw.GatewayTLSConfig{
-			CertificateRefs: []*gw.SecretObjectReference{{
-				Name: "secret",
-			}},
-			Options: map[gw.AnnotationKey]gw.AnnotationValue{
-				"api-gateway.consul.hashicorp.com/tls_cipher_suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, foo",
-			},
-		},
-	}, K8sListenerConfig{
-		Logger: hclog.NewNullLogger(),
-		Client: client,
+	t.Run("Invalid certificate ref", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS:      &gw.GatewayTLSConfig{},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+		})
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.ResolvedRefs.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalidCertificateRef, condition.Reason)
 	})
-	client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
-		ObjectMeta: meta.ObjectMeta{
-			Name: "secret",
-		},
-	}, nil)
-	require.NoError(t, listener.Validate(context.Background()))
-	condition = listener.status.Ready.Condition(0)
-	require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
-	require.Equal(t, "unrecognized or unsupported TLS cipher suite: foo", condition.Message)
+
+	t.Run("Fail to retrieve secret", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Name: "secret",
+				}},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(nil, expected)
+		require.True(t, errors.Is(listener.Validate(context.Background()), expected))
+	})
+
+	t.Run("No secret found", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Name: "secret",
+				}},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(nil, nil)
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.ResolvedRefs.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalidCertificateRef, condition.Reason)
+	})
+
+	t.Run("Happy path", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Name: "secret",
+				}},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "secret",
+			},
+		}, nil)
+		assert.Len(t, listener.Config().TLS.Certificates, 0)
+		assert.NoError(t, listener.Validate(context.Background()))
+		assert.Len(t, listener.Config().TLS.Certificates, 1)
+	})
+
+	t.Run("Unsupported certificate type", func(t *testing.T) {
+		group := gw.Group("group")
+		kind := gw.Kind("kind")
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Group: &group,
+					Kind:  &kind,
+					Name:  "secret",
+				}},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.ResolvedRefs.Condition(0)
+		assert.Equal(t, ListenerConditionReasonInvalidCertificateRef, condition.Reason)
+	})
+
+	t.Run("Valid minimum TLS version", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Name: "secret",
+				}},
+				Options: map[gw.AnnotationKey]gw.AnnotationValue{
+					"api-gateway.consul.hashicorp.com/tls_min_version": "TLSv1_2",
+				},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "secret",
+			},
+		}, nil)
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Ready.Condition(0)
+		require.Equal(t, ListenerConditionReasonReady, condition.Reason)
+		require.Equal(t, "TLSv1_2", listener.tls.MinVersion)
+	})
+
+	t.Run("Invalid minimum TLS version", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Name: "secret",
+				}},
+				Options: map[gw.AnnotationKey]gw.AnnotationValue{
+					"api-gateway.consul.hashicorp.com/tls_min_version": "foo",
+				},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "secret",
+			},
+		}, nil)
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Ready.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
+		require.Equal(t, "unrecognized TLS min version", condition.Message)
+	})
+
+	t.Run("Valid TLS cipher suite", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Name: "secret",
+				}},
+				Options: map[gw.AnnotationKey]gw.AnnotationValue{
+					"api-gateway.consul.hashicorp.com/tls_cipher_suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+				},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "secret",
+			},
+		}, nil)
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Ready.Condition(0)
+		require.Equal(t, ListenerConditionReasonReady, condition.Reason)
+		require.Equal(t, []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"}, listener.tls.CipherSuites)
+	})
+
+	t.Run("TLS cipher suite not allowed", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Name: "secret",
+				}},
+				Options: map[gw.AnnotationKey]gw.AnnotationValue{
+					"api-gateway.consul.hashicorp.com/tls_min_version":   "TLSv1_3",
+					"api-gateway.consul.hashicorp.com/tls_cipher_suites": "foo",
+				},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "secret",
+			},
+		}, nil)
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Ready.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
+		require.Equal(t, "configuring TLS cipher suites is only supported for TLS 1.2 and earlier", condition.Message)
+	})
+
+	t.Run("Invalid TLS cipher suite", func(t *testing.T) {
+		listener := NewK8sListener(&gw.Gateway{}, gw.Listener{
+			Protocol: gw.HTTPSProtocolType,
+			TLS: &gw.GatewayTLSConfig{
+				CertificateRefs: []*gw.SecretObjectReference{{
+					Name: "secret",
+				}},
+				Options: map[gw.AnnotationKey]gw.AnnotationValue{
+					"api-gateway.consul.hashicorp.com/tls_cipher_suites": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, foo",
+				},
+			},
+		}, K8sListenerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		})
+		client.EXPECT().GetSecret(gomock.Any(), gomock.Any()).Return(&k8s.Secret{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "secret",
+			},
+		}, nil)
+		require.NoError(t, listener.Validate(context.Background()))
+		condition := listener.status.Ready.Condition(0)
+		require.Equal(t, ListenerConditionReasonInvalid, condition.Reason)
+		require.Equal(t, "unrecognized or unsupported TLS cipher suite: foo", condition.Message)
+	})
 }
 
 func TestIsKindInSet(t *testing.T) {

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -373,8 +373,9 @@ func (r *K8sRoute) Validate(ctx context.Context) error {
 				if err != nil {
 					return err
 				} else if !allowed {
-					msg := fmt.Sprintf("Cross-namespace routing not allowed without matching ReferencePolicy for Service %q", getServiceID(ref.Name, ref.Namespace, route.GetNamespace()))
-					r.logger.Warn("Cross-namespace routing not allowed without matching ReferencePolicy", "refName", ref.Name, "refNamespace", ref.Namespace)
+					nsName := getNamespacedName(ref.Name, ref.Namespace, route.Namespace)
+					msg := fmt.Sprintf("Cross-namespace routing not allowed without matching ReferencePolicy for Service %q", nsName)
+					r.logger.Warn("Cross-namespace routing not allowed without matching ReferencePolicy", "refName", nsName.Name, "refNamespace", nsName.Namespace)
 					r.resolutionErrors.Add(service.NewRefNotPermittedError(msg))
 					continue
 				}
@@ -415,8 +416,9 @@ func (r *K8sRoute) Validate(ctx context.Context) error {
 		if err != nil {
 			return err
 		} else if !allowed {
-			msg := fmt.Sprintf("Cross-namespace routing not allowed without matching ReferencePolicy for Service %q", getServiceID(ref.Name, ref.Namespace, route.GetNamespace()))
-			r.logger.Warn("Cross-namespace routing not allowed without matching ReferencePolicy", "refName", ref.Name, "refNamespace", ref.Namespace)
+			nsName := getNamespacedName(ref.Name, ref.Namespace, route.Namespace)
+			msg := fmt.Sprintf("Cross-namespace routing not allowed without matching ReferencePolicy for Service %q", nsName)
+			r.logger.Warn("Cross-namespace routing not allowed without matching ReferencePolicy", "refName", nsName.Name, "refNamespace", nsName.Namespace)
 			r.resolutionErrors.Add(service.NewRefNotPermittedError(msg))
 			return nil
 		}

--- a/internal/k8s/reconciler/utils.go
+++ b/internal/k8s/reconciler/utils.go
@@ -217,11 +217,15 @@ func referenceAllowed(ctx context.Context, fromGK metav1.GroupKind, fromNamespac
 		// Check for a To that applies
 		for _, to := range refPolicy.Spec.To {
 			if toGK.Group == string(to.Group) && toGK.Kind == string(to.Kind) {
-				if to.Name == nil {
+				if to.Name == nil || *to.Name == "" {
 					// No name specified is treated as a wildcard within the namespace
 					return true, nil
 				}
-				return gw.ObjectName(toName) == *to.Name, nil
+
+				if gw.ObjectName(toName) == *to.Name {
+					// The ReferencePolicy specifically targets this object
+					return true, nil
+				}
 			}
 		}
 	}

--- a/internal/k8s/reconciler/utils.go
+++ b/internal/k8s/reconciler/utils.go
@@ -389,10 +389,11 @@ func gatewayStatusEqual(a, b gw.GatewayStatus) bool {
 	return true
 }
 
-func getServiceID(name gw.ObjectName, namespace *gw.Namespace, parentNamespace string) string {
-	serviceID := fmt.Sprintf("%s/%s", name, parentNamespace)
+// getNamespacedName returns types.NamespacedName defaulted to a parent
+// namespace in the case where the provided namespace is nil.
+func getNamespacedName(name gw.ObjectName, namespace *gw.Namespace, parentNamespace string) types.NamespacedName {
 	if namespace != nil {
-		serviceID = fmt.Sprintf("%s/%s", name, *namespace)
+		return types.NamespacedName{Namespace: string(*namespace), Name: string(name)}
 	}
-	return serviceID
+	return types.NamespacedName{Namespace: parentNamespace, Name: string(name)}
 }

--- a/internal/k8s/reconciler/utils_test.go
+++ b/internal/k8s/reconciler/utils_test.go
@@ -363,13 +363,126 @@ func TestGatewayStatusEqual(t *testing.T) {
 	}))
 }
 
+func TestGatewayAllowedForSecretRef(t *testing.T) {
+	type testCase struct {
+		name         string
+		fromNS       string
+		toNS         *string
+		toKind       *string
+		toName       string
+		policyFromNS string
+		policyToName *string
+		allowed      bool
+	}
+
+	ns1, ns2, ns3 := "namespace1", "namespace2", "namespace3"
+	secret1, secret2, secret3 := "secret1", "secret2", "secret3"
+
+	for _, tc := range []testCase{
+		{name: "unspecified-secret-namespace-allowed", fromNS: ns1, toNS: nil, toName: secret1, policyFromNS: ns1, policyToName: nil, allowed: true},
+		{name: "same-namespace-no-name-allowed", fromNS: ns1, toNS: &ns1, toName: secret1, policyFromNS: ns1, policyToName: nil, allowed: true},
+		{name: "same-namespace-with-name-allowed", fromNS: ns1, toNS: &ns1, toName: secret1, policyFromNS: ns1, policyToName: &secret1, allowed: true},
+		{name: "different-namespace-no-name-allowed", fromNS: ns1, toNS: &ns2, toName: secret2, policyFromNS: ns1, policyToName: nil, allowed: true},
+		{name: "different-namespace-with-name-allowed", fromNS: ns1, toNS: &ns2, toName: secret2, policyFromNS: ns1, policyToName: &secret2, allowed: true},
+		{name: "mismatched-policy-from-namespace-disallowed", fromNS: ns1, toNS: &ns2, toName: secret2, policyFromNS: ns3, policyToName: &secret2, allowed: false},
+		{name: "mismatched-policy-to-name-disallowed", fromNS: ns1, toNS: &ns2, toName: secret2, policyFromNS: ns1, policyToName: &secret3, allowed: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			client := mocks.NewMockClient(ctrl)
+
+			group := gw.Group("")
+
+			secretRef := gw.SecretObjectReference{
+				Group: &group,
+				Name:  gw.ObjectName(tc.toName),
+			}
+
+			if tc.toNS != nil {
+				ns := gw.Namespace(*tc.toNS)
+				secretRef.Namespace = &ns
+			}
+
+			if tc.toKind != nil {
+				k := gw.Kind(*tc.toKind)
+				secretRef.Kind = &k
+			}
+
+			gateway := &gw.Gateway{
+				TypeMeta:   meta.TypeMeta{APIVersion: "gateway.networking.k8s.io/v1alpha2", Kind: "Gateway"},
+				ObjectMeta: meta.ObjectMeta{Namespace: tc.fromNS},
+				Spec: gw.GatewaySpec{
+					Listeners: []gw.Listener{{
+						TLS: &gw.GatewayTLSConfig{
+							CertificateRefs: []*gw.SecretObjectReference{{
+								Group: &group,
+								Name:  gw.ObjectName(tc.toName),
+							}},
+						},
+					}},
+				},
+			}
+
+			var toName *gw.ObjectName
+			if tc.policyToName != nil {
+				on := gw.ObjectName(*tc.policyToName)
+				toName = &on
+			}
+
+			if tc.toNS != nil && tc.fromNS != *tc.toNS {
+				referencePolicy := gw.ReferencePolicy{
+					TypeMeta:   meta.TypeMeta{},
+					ObjectMeta: meta.ObjectMeta{Namespace: *tc.toNS},
+					Spec: gw.ReferencePolicySpec{
+						From: []gw.ReferencePolicyFrom{{
+							Group:     "gateway.networking.k8s.io",
+							Kind:      gw.Kind("Gateway"),
+							Namespace: gw.Namespace(tc.policyFromNS),
+						}},
+						To: []gw.ReferencePolicyTo{{
+							Group: "",
+							Kind:  "Secret",
+							Name:  toName,
+						}},
+					},
+				}
+
+				throwawayPolicy := gw.ReferencePolicy{
+					ObjectMeta: meta.ObjectMeta{Namespace: *tc.toNS},
+					Spec: gw.ReferencePolicySpec{
+						From: []gw.ReferencePolicyFrom{{
+							Group:     "Kool & The Gang",
+							Kind:      "Jungle Boogie",
+							Namespace: "Wild And Peaceful",
+						}},
+						To: []gw.ReferencePolicyTo{{
+							Group: "does not exist",
+							Kind:  "does not exist",
+							Name:  nil,
+						}},
+					},
+				}
+
+				client.EXPECT().
+					GetReferencePoliciesInNamespace(gomock.Any(), *tc.toNS).
+					Return([]gw.ReferencePolicy{throwawayPolicy, referencePolicy}, nil)
+			}
+
+			allowed, err := gatewayAllowedForSecretRef(context.Background(), gateway, secretRef, client)
+			require.NoError(t, err)
+			assert.Equal(t, tc.allowed, allowed)
+		})
+	}
+}
+
 func TestRouteAllowedForBackendRef(t *testing.T) {
 	type testCase struct {
 		name         string
-		routeNS      string
-		backendNS    *string
-		backendKind  *string
-		backendName  string
+		fromNS       string
+		toNS         *string
+		toKind       *string
+		toName       string
 		policyFromNS string
 		policyToName *string
 		allowed      bool
@@ -379,13 +492,13 @@ func TestRouteAllowedForBackendRef(t *testing.T) {
 	backend1, backend2, backend3 := "backend1", "backend2", "backend3"
 
 	for _, tc := range []testCase{
-		{name: "unspecified-backend-namespace-allowed", routeNS: ns1, backendNS: nil, backendName: backend1, policyFromNS: ns1, policyToName: nil, allowed: true},
-		{name: "same-namespace-no-name-allowed", routeNS: ns1, backendNS: &ns1, backendName: backend1, policyFromNS: ns1, policyToName: nil, allowed: true},
-		{name: "same-namespace-with-name-allowed", routeNS: ns1, backendNS: &ns1, backendName: backend1, policyFromNS: ns1, policyToName: &backend1, allowed: true},
-		{name: "different-namespace-no-name-allowed", routeNS: ns1, backendNS: &ns2, backendName: backend2, policyFromNS: ns1, policyToName: nil, allowed: true},
-		{name: "different-namespace-with-name-allowed", routeNS: ns1, backendNS: &ns2, backendName: backend2, policyFromNS: ns1, policyToName: &backend2, allowed: true},
-		{name: "mismatched-policy-from-namespace-disallowed", routeNS: ns1, backendNS: &ns2, backendName: backend2, policyFromNS: ns3, policyToName: &backend2, allowed: false},
-		{name: "mismatched-policy-to-name-disallowed", routeNS: ns1, backendNS: &ns2, backendName: backend2, policyFromNS: ns1, policyToName: &backend3, allowed: false},
+		{name: "unspecified-backend-namespace-allowed", fromNS: ns1, toNS: nil, toName: backend1, policyFromNS: ns1, policyToName: nil, allowed: true},
+		{name: "same-namespace-no-name-allowed", fromNS: ns1, toNS: &ns1, toName: backend1, policyFromNS: ns1, policyToName: nil, allowed: true},
+		{name: "same-namespace-with-name-allowed", fromNS: ns1, toNS: &ns1, toName: backend1, policyFromNS: ns1, policyToName: &backend1, allowed: true},
+		{name: "different-namespace-no-name-allowed", fromNS: ns1, toNS: &ns2, toName: backend2, policyFromNS: ns1, policyToName: nil, allowed: true},
+		{name: "different-namespace-with-name-allowed", fromNS: ns1, toNS: &ns2, toName: backend2, policyFromNS: ns1, policyToName: &backend2, allowed: true},
+		{name: "mismatched-policy-from-namespace-disallowed", fromNS: ns1, toNS: &ns2, toName: backend2, policyFromNS: ns3, policyToName: &backend2, allowed: false},
+		{name: "mismatched-policy-to-name-disallowed", fromNS: ns1, toNS: &ns2, toName: backend2, policyFromNS: ns1, policyToName: &backend3, allowed: false},
 	} {
 		// Test each case for both HTTPRoute + TCPRoute which should function identically
 		for _, routeType := range []string{"HTTPRoute", "TCPRoute"} {
@@ -399,17 +512,17 @@ func TestRouteAllowedForBackendRef(t *testing.T) {
 				backendRef := gw.BackendRef{
 					BackendObjectReference: gw.BackendObjectReference{
 						Group: &group,
-						Name:  gw.ObjectName(tc.backendName),
+						Name:  gw.ObjectName(tc.toName),
 					},
 				}
 
-				if tc.backendNS != nil {
-					ns := gw.Namespace(*tc.backendNS)
+				if tc.toNS != nil {
+					ns := gw.Namespace(*tc.toNS)
 					backendRef.BackendObjectReference.Namespace = &ns
 				}
 
-				if tc.backendKind != nil {
-					k := gw.Kind(*tc.backendKind)
+				if tc.toKind != nil {
+					k := gw.Kind(*tc.toKind)
 					backendRef.Kind = &k
 				}
 
@@ -417,7 +530,7 @@ func TestRouteAllowedForBackendRef(t *testing.T) {
 				switch routeType {
 				case "HTTPRoute":
 					route = &gw.HTTPRoute{
-						ObjectMeta: meta.ObjectMeta{Namespace: tc.routeNS},
+						ObjectMeta: meta.ObjectMeta{Namespace: tc.fromNS},
 						TypeMeta:   meta.TypeMeta{APIVersion: "gateway.networking.k8s.io/v1alpha2", Kind: "HTTPRoute"},
 						Spec: gw.HTTPRouteSpec{
 							Rules: []gw.HTTPRouteRule{{
@@ -427,7 +540,7 @@ func TestRouteAllowedForBackendRef(t *testing.T) {
 					}
 				case "TCPRoute":
 					route = &gw.TCPRoute{
-						ObjectMeta: meta.ObjectMeta{Namespace: tc.routeNS},
+						ObjectMeta: meta.ObjectMeta{Namespace: tc.fromNS},
 						TypeMeta:   meta.TypeMeta{APIVersion: "gateway.networking.k8s.io/v1alpha2", Kind: "TCPRoute"},
 						Spec: gw.TCPRouteSpec{
 							Rules: []gw.TCPRouteRule{{
@@ -445,10 +558,10 @@ func TestRouteAllowedForBackendRef(t *testing.T) {
 					toName = &on
 				}
 
-				if tc.backendNS != nil && tc.routeNS != *tc.backendNS {
+				if tc.toNS != nil && tc.fromNS != *tc.toNS {
 					referencePolicy := gw.ReferencePolicy{
 						TypeMeta:   meta.TypeMeta{},
-						ObjectMeta: meta.ObjectMeta{Namespace: *tc.backendNS},
+						ObjectMeta: meta.ObjectMeta{Namespace: *tc.toNS},
 						Spec: gw.ReferencePolicySpec{
 							From: []gw.ReferencePolicyFrom{{
 								Group:     "gateway.networking.k8s.io",
@@ -464,7 +577,7 @@ func TestRouteAllowedForBackendRef(t *testing.T) {
 					}
 
 					throwawayPolicy := gw.ReferencePolicy{
-						ObjectMeta: meta.ObjectMeta{Namespace: *tc.backendNS},
+						ObjectMeta: meta.ObjectMeta{Namespace: *tc.toNS},
 						Spec: gw.ReferencePolicySpec{
 							From: []gw.ReferencePolicyFrom{{
 								Group:     "Kool & The Gang",
@@ -480,7 +593,7 @@ func TestRouteAllowedForBackendRef(t *testing.T) {
 					}
 
 					client.EXPECT().
-						GetReferencePoliciesInNamespace(gomock.Any(), *tc.backendNS).
+						GetReferencePoliciesInNamespace(gomock.Any(), *tc.toNS).
 						Return([]gw.ReferencePolicy{throwawayPolicy, referencePolicy}, nil)
 				}
 

--- a/internal/k8s/reconciler/zz_generated_errors.go
+++ b/internal/k8s/reconciler/zz_generated_errors.go
@@ -6,6 +6,7 @@ type CertificateResolutionErrorType int
 
 const (
 	CertificateResolutionErrorTypeNotFound CertificateResolutionErrorType = iota
+	CertificateResolutionErrorTypeNotPermitted
 	CertificateResolutionErrorTypeUnsupported
 )
 
@@ -16,6 +17,9 @@ type CertificateResolutionError struct {
 
 func NewCertificateResolutionErrorNotFound(inner string) CertificateResolutionError {
 	return CertificateResolutionError{inner, CertificateResolutionErrorTypeNotFound}
+}
+func NewCertificateResolutionErrorNotPermitted(inner string) CertificateResolutionError {
+	return CertificateResolutionError{inner, CertificateResolutionErrorTypeNotPermitted}
 }
 func NewCertificateResolutionErrorUnsupported(inner string) CertificateResolutionError {
 	return CertificateResolutionError{inner, CertificateResolutionErrorTypeUnsupported}

--- a/internal/k8s/reconciler/zz_generated_errors_test.go
+++ b/internal/k8s/reconciler/zz_generated_errors_test.go
@@ -15,6 +15,8 @@ func TestCertificateResolutionErrorType(t *testing.T) {
 
 	require.Equal(t, expected, NewCertificateResolutionErrorNotFound(expected).Error())
 	require.Equal(t, CertificateResolutionErrorTypeNotFound, NewCertificateResolutionErrorNotFound(expected).Kind())
+	require.Equal(t, expected, NewCertificateResolutionErrorNotPermitted(expected).Error())
+	require.Equal(t, CertificateResolutionErrorTypeNotPermitted, NewCertificateResolutionErrorNotPermitted(expected).Kind())
 	require.Equal(t, expected, NewCertificateResolutionErrorUnsupported(expected).Error())
 	require.Equal(t, CertificateResolutionErrorTypeUnsupported, NewCertificateResolutionErrorUnsupported(expected).Kind())
 }


### PR DESCRIPTION
### Changes proposed in this PR:
When a listener on a `Gateway` contains a `certificateRef` from a different namespace, require applicable `ReferencePolicy`. The expectations for the listener status in the scenario are described [here](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#:~:text=References%20to%20a,the%20%E2%80%9CInvalidCertificateRef%E2%80%9D%20reason.).
<details>
<summary>Example</summary>

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: Gateway
metadata:
  name: example-gateway
  namespace: default
spec:
  gatewayClassName: consul-api-gateway
  listeners:
  - protocol: HTTPS
    port: 8443
    name: https
    allowedRoutes:
      namespaces:
        from: Same
    tls:
      certificateRefs:
        - name: consul-server-cert
          namespace: consul
---
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: ReferencePolicy
metadata:
  name: secret-reference-policy
  namespace: consul
spec:
  from:
    - group: gateway.networking.k8s.io
      kind: Gateway
      namespace: default
  to:
    - group: ""
      kind: Secret
```
</details>

### How I've tested this PR:
Deployed the API Gateway using this build and added `certificateRefs` across namespaces and within the same namespaces, both with and without an applicable `ReferencePolicy` in place.

### How I expect reviewers to test this PR:

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
