### PR TITLE
Consume consul:1.12.0 for CI instead of 1.12.0-beta1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
       matrix:
         consul-version: 
         - 1.11.5
-        - 1.12.0-beta1
+        - 1.12.0
         - 1.11.5+ent
-        - 1.12.0-beta1+ent
+        - 1.12.0+ent
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/consul@${{ matrix.consul-version }}
@@ -89,8 +89,8 @@ jobs:
         consul-image: 
         - 'hashicorp/consul:1.11.5'
         - 'hashicorp/consul-enterprise:1.11.5-ent'
-        - 'hashicorp/consul:1.12.0-beta1'
-        - 'hashicorp/consul-enterprise:1.12.0-beta1-ent'
+        - 'hashicorp/consul:1.12.0'
+        - 'hashicorp/consul-enterprise:1.12.0-ent'
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}

--- a/internal/testing/conformance/consul-config.yaml
+++ b/internal/testing/conformance/consul-config.yaml
@@ -1,5 +1,5 @@
 global:
-  image: "hashicorp/consul:1.12.0-beta1"  # TODO Remove once 1.12.0 is consumed in consul-k8s
+  image: "hashicorp/consul:1.12.0"  # TODO Remove once 1.12.0 is consumed in consul-k8s
   tls:
     enabled: true
 server:


### PR DESCRIPTION
### Changes proposed in this PR:
Consume consul.1.12.0 where we were previously consuming 1.12.0-beta1 for CI

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
