### PR TITLE
http-route-controller: watch ReferencePolicy lifecycle

### DIFF
--- a/internal/k8s/controllers/http_route_controller.go
+++ b/internal/k8s/controllers/http_route_controller.go
@@ -3,7 +3,15 @@ package controllers
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	gateway "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
@@ -53,5 +61,143 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gateway.HTTPRoute{}).
+		Watches(
+			// TODO: how does this handle deletes?
+			&source.Kind{Type: &gateway.ReferencePolicy{}},
+			handler.EnqueueRequestsFromMapFunc(r.referencePolicyToRouteRequests),
+		).
 		Complete(gatewayclient.NewRequeueingMiddleware(r.Log, r))
+}
+
+func getReferencePolicyObjectsFrom(refPolicy gateway.ReferencePolicy) []client.Object {
+	matches := []client.Object{}
+
+	for _, from := range refPolicy.Spec.From {
+		matchLabels := map[string]string{
+			"kubernetes.io/metadata.kind":      string(from.Kind),
+			"kubernetes.io/metadata.namespace": string(from.Namespace),
+		}
+
+		if from.Group != "" {
+			matchLabels["kubernetes.io/metadata.group"] = string(from.Group)
+		} else {
+			// When empty, the Kubernetes core API group is inferred.
+			matchLabels["kubernetes.io/metadata.group"] = "core/v1"
+		}
+
+		selector := metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      "",
+				Operator: "In",
+				Values:   []string{},
+			}},
+			MatchLabels: matchLabels,
+		}
+
+		matches = append(matches, []client.Object{}...)
+	}
+
+	return matches
+}
+
+func getReferencePolicyObjectsTo(refPolicy gateway.ReferencePolicy) []client.Object {
+	matches := []client.Object{}
+
+	for _, to := range refPolicy.Spec.To {
+		selector := labels.NewSelector()
+
+		kindReq, _ := labels.NewRequirement(
+			"kubernetes.io/metadata.kind",
+			selection.In,
+			[]string{string(to.Kind)},
+		)
+
+		namespaceReq, _ := labels.NewRequirement(
+			"kubernetes.io/metadata.namesapce",
+			selection.In,
+			[]string{refPolicy.Namespace},
+		)
+
+		selector = selector.Add(*kindReq, *namespaceReq)
+
+		var groupReq *labels.Requirement
+		if to.Group != "" {
+			groupReq, _ = labels.NewRequirement(
+				"kubernetes.io/metadata.group",
+				selection.In,
+				[]string{string(to.Group)},
+			)
+		} else {
+			// When empty, the Kubernetes core API group is inferred.
+			groupReq, _ = labels.NewRequirement(
+				"kubernetes.io/metadata.group",
+				selection.In,
+				[]string{"core/v1"},
+			)
+		}
+
+		selector = selector.Add(*groupReq)
+
+		if to.Name != nil {
+			nameReq, _ := labels.NewRequirement(
+				"kubernetes.io/metadata.name",
+				selection.In,
+				[]string{string(*to.Name)},
+			)
+			selector = selector.Add(*nameReq)
+		}
+
+		// TODO: use selector
+		matches = append(matches, []client.Object{}...)
+	}
+
+	return matches
+}
+
+func GetRoutesAffectedByReferencePolicy(refPolicy gateway.ReferencePolicy) []gateway.HTTPRoute {
+	matches := []gateway.HTTPRoute{}
+	objectsTo := getReferencePolicyObjectsTo(refPolicy)
+
+	// FIXME: Only checking Routes selected by GetReferencePolicyObjectsFrom isn't
+	// enough, need to reconcile Routes which may have been allowed before but no
+	// longer are permitted
+	//
+	// GET Routes WHERE BackendRef is selected by GetReferencePolicyObjectsTo
+	for _, route := range getReferencePolicyObjectsFrom(refPolicy) {
+		// TODO: should this use reflection to handle xRoute types? seems expensive
+		for _, rules := range route.Spec.Rules {
+			for _, backendRef := range rules.BackendRefs {
+				for _, from := range objectsTo {
+					if backendRef.DeepEqual(from) {
+						matches = append(matches, backendRef)
+					}
+				}
+			}
+		}
+	}
+
+	return matches
+}
+
+func (r *HTTPRouteReconciler) referencePolicyToRouteRequests(object client.Object) []reconcile.Request {
+	r.Log.Info("event for ReferencePolicy", "object", object)
+
+	refPolicy := gateway.ReferencePolicy{}
+	routes := GetRoutesAffectedByReferencePolicy(refPolicy)
+	requests := []reconcile.Request{}
+
+	for _, route := range routes {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      route.Name,
+				Namespace: route.Namespace,
+			},
+		})
+	}
+
+	if len(requests) > 0 {
+		return requests
+	}
+
+	return nil
 }

--- a/internal/k8s/controllers/http_route_controller.go
+++ b/internal/k8s/controllers/http_route_controller.go
@@ -154,7 +154,6 @@ func getReferencePolicyObjectsTo(refPolicy gateway.ReferencePolicy) []client.Obj
 	return matches
 }
 
-// For
 func (r *HTTPRouteReconciler) getRoutesAffectedByReferencePolicy(refPolicy gateway.ReferencePolicy) []gateway.HTTPRoute {
 	matches := []gateway.HTTPRoute{}
 

--- a/internal/k8s/controllers/http_route_controller.go
+++ b/internal/k8s/controllers/http_route_controller.go
@@ -69,6 +69,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(gatewayclient.NewRequeueingMiddleware(r.Log, r))
 }
 
+// FIXME: create client.MatchingLabels here instead
 func getReferencePolicyObjectsFrom(refPolicy gateway.ReferencePolicy) []client.Object {
 	matches := []client.Object{}
 
@@ -100,6 +101,7 @@ func getReferencePolicyObjectsFrom(refPolicy gateway.ReferencePolicy) []client.O
 	return matches
 }
 
+// FIXME: create client.MatchingLabels here instead
 func getReferencePolicyObjectsTo(refPolicy gateway.ReferencePolicy) []client.Object {
 	matches := []client.Object{}
 

--- a/internal/k8s/controllers/http_route_controller.go
+++ b/internal/k8s/controllers/http_route_controller.go
@@ -162,12 +162,10 @@ func (r *HTTPRouteReconciler) getRoutesAffectedByReferencePolicy(refPolicy gatew
 	// but are no longer permitted. It may be possible to improve performance
 	// here by filtering on the prior and current state of the ReferencePolicy
 	// From and To fields, but currently we just revalidate all routes
-	routeList, err := r.Client.GetHTTPRoutes(context.TODO())
+	routes, err := r.Client.GetHTTPRoutes(context.TODO())
 	if err != nil {
 		return matches
 	}
-
-	routes := routeList.Items
 
 	// Need to match the union of this selction for both current and prior state
 	// in case a ReferencePolicy has been modified to revoke permission from a

--- a/internal/k8s/controllers/http_route_controller.go
+++ b/internal/k8s/controllers/http_route_controller.go
@@ -211,9 +211,5 @@ func (r *HTTPRouteReconciler) referencePolicyToRouteRequests(object client.Objec
 		})
 	}
 
-	if len(requests) > 0 {
-		return requests
-	}
-
-	return nil
+	return requests
 }

--- a/internal/k8s/controllers/http_route_controller.go
+++ b/internal/k8s/controllers/http_route_controller.go
@@ -62,8 +62,10 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gateway.HTTPRoute{}).
 		Watches(
-			// TODO: how does this handle deletes?
 			&source.Kind{Type: &gateway.ReferencePolicy{}},
+			// For UpdateEvents which contain both a new and old object, the
+			// transformation function is run on both objects and both sets of
+			// Requests are enqueue.
 			handler.EnqueueRequestsFromMapFunc(r.referencePolicyToRouteRequests),
 		).
 		Complete(gatewayclient.NewRequeueingMiddleware(r.Log, r))
@@ -190,7 +192,7 @@ func (r *HTTPRouteReconciler) getRoutesAffectedByReferencePolicy(refPolicy gatew
 }
 
 func (r *HTTPRouteReconciler) referencePolicyToRouteRequests(object client.Object) []reconcile.Request {
-	r.Log.Error("event for ReferencePolicy", "object", object)
+	r.Log.Warn("event for ReferencePolicy", "object", object)
 
 	refPolicy := gateway.ReferencePolicy{}
 	routes := r.getRoutesAffectedByReferencePolicy(refPolicy)

--- a/internal/k8s/controllers/http_route_controller.go
+++ b/internal/k8s/controllers/http_route_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -63,9 +64,6 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gateway.HTTPRoute{}).
 		Watches(
 			&source.Kind{Type: &gateway.ReferencePolicy{}},
-			// For UpdateEvents which contain both a new and old object, the
-			// transformation function is run on both objects and both sets of
-			// Requests are enqueue.
 			handler.EnqueueRequestsFromMapFunc(r.referencePolicyToRouteRequests),
 		).
 		Complete(gatewayclient.NewRequeueingMiddleware(r.Log, r))
@@ -156,6 +154,7 @@ func getReferencePolicyObjectsTo(refPolicy gateway.ReferencePolicy) []client.Obj
 	return matches
 }
 
+// For
 func (r *HTTPRouteReconciler) getRoutesAffectedByReferencePolicy(refPolicy gateway.ReferencePolicy) []gateway.HTTPRoute {
 	matches := []gateway.HTTPRoute{}
 
@@ -191,10 +190,16 @@ func (r *HTTPRouteReconciler) getRoutesAffectedByReferencePolicy(refPolicy gatew
 	return routes
 }
 
+// For UpdateEvents which contain both a new and old object, this transformation
+// function is run on both objects and both sets of Requests are enqueued.
 func (r *HTTPRouteReconciler) referencePolicyToRouteRequests(object client.Object) []reconcile.Request {
-	r.Log.Warn("event for ReferencePolicy", "object", object)
+	// FIXME: How to safely cast client.Object to gateway.ReferencePolicy?
+	fmt.Printf("%s", object.GetObjectKind())
+	fmt.Printf("%s", object)
 
 	refPolicy := gateway.ReferencePolicy{}
+	r.Log.Info("event for ReferencePolicy", "object", refPolicy)
+
 	routes := r.getRoutesAffectedByReferencePolicy(refPolicy)
 	requests := []reconcile.Request{}
 

--- a/internal/k8s/controllers/http_route_controller_test.go
+++ b/internal/k8s/controllers/http_route_controller_test.go
@@ -158,13 +158,13 @@ func TestHTTPRouteWatchesReferencePolicy(t *testing.T) {
 	// FIXME: This should only request reconciliation for the one HTTPRoute in the
 	// allowed namespace
 	//
-	// require.Equal(t, len(requests), 1)
-	require.Equal(t, requests, []reconcile.Request{{
+	// require.Equal(t, 1, len(requests))
+	require.Equal(t, []reconcile.Request{{
 		NamespacedName: types.NamespacedName{
 			Name:      "httproute",
 			Namespace: "namespace1",
 		},
-	}})
+	}}, requests)
 }
 
 // FIXME: this should be refactored into a test utility package

--- a/internal/k8s/controllers/http_route_controller_test.go
+++ b/internal/k8s/controllers/http_route_controller_test.go
@@ -110,6 +110,7 @@ func TestHTTPRouteWatchesReferencePolicy(t *testing.T) {
 	}
 
 	refPolicy := gw.ReferencePolicy{
+		TypeMeta:   metav1.TypeMeta{Kind: "ReferencePolicy"},
 		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace3"},
 		Spec: gw.ReferencePolicySpec{
 			From: []gw.ReferencePolicyFrom{{

--- a/internal/k8s/controllers/http_route_controller_test.go
+++ b/internal/k8s/controllers/http_route_controller_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
 	reconcilerMocks "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/mocks"
@@ -73,5 +75,27 @@ func TestHTTPRoute(t *testing.T) {
 			}
 			require.Equal(t, test.result, result)
 		})
+	}
+}
+
+func TestHTTPRouteWatchesReferencePolicy(t *testing.T) {
+	t.Parallel()
+
+	backendName := gw.ObjectName("service1")
+	_ = &gw.ReferencePolicy{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace2"},
+		Spec: gw.ReferencePolicySpec{
+			From: []gw.ReferencePolicyFrom{{
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "HTTPRoute",
+				Namespace: "namespace1",
+			}},
+			To: []gw.ReferencePolicyTo{{
+				Group: "",
+				Kind:  "Service",
+				Name:  &backendName,
+			}},
+		},
 	}
 }

--- a/internal/k8s/controllers/http_route_controller_test.go
+++ b/internal/k8s/controllers/http_route_controller_test.go
@@ -7,13 +7,21 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
 	reconcilerMocks "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/mocks"
 	"github.com/hashicorp/go-hclog"
+
+	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 )
 
 var (
@@ -81,10 +89,28 @@ func TestHTTPRoute(t *testing.T) {
 func TestHTTPRouteWatchesReferencePolicy(t *testing.T) {
 	t.Parallel()
 
-	backendName := gw.ObjectName("service1")
-	_ = &gw.ReferencePolicy{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace2"},
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	serviceNamespace := gw.Namespace("namespace3")
+
+	backendObjRef := gw.BackendObjectReference{
+		Name:      gw.ObjectName("service"),
+		Namespace: &serviceNamespace,
+	}
+
+	httpRouteSpec := gw.HTTPRouteSpec{
+		Rules: []gw.HTTPRouteRule{{
+			BackendRefs: []gw.HTTPBackendRef{{
+				BackendRef: gw.BackendRef{
+					BackendObjectReference: backendObjRef,
+				},
+			}},
+		}},
+	}
+
+	refPolicy := gw.ReferencePolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace3"},
 		Spec: gw.ReferencePolicySpec{
 			From: []gw.ReferencePolicyFrom{{
 				Group:     "gateway.networking.k8s.io",
@@ -92,10 +118,67 @@ func TestHTTPRouteWatchesReferencePolicy(t *testing.T) {
 				Namespace: "namespace1",
 			}},
 			To: []gw.ReferencePolicyTo{{
-				Group: "",
-				Kind:  "Service",
-				Name:  &backendName,
+				Kind: "Service",
 			}},
 		},
 	}
+
+	gatewayclient := NewTestClient(
+		&gw.HTTPRouteList{
+			Items: []gw.HTTPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "httproute",
+						Namespace: "namespace1",
+					},
+					Spec: httpRouteSpec,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "httproute",
+						Namespace: "namespace2",
+					},
+					Spec: httpRouteSpec,
+				},
+			},
+		},
+		&refPolicy,
+	)
+
+	controller := &HTTPRouteReconciler{
+		Client:         gatewayclient,
+		Log:            hclog.NewNullLogger(),
+		ControllerName: mockControllerName,
+		Manager:        reconcilerMocks.NewMockReconcileManager(ctrl),
+	}
+
+	requests := controller.referencePolicyToRouteRequests(&refPolicy)
+
+	// require.Equal(t, len(requests), 1)
+	require.Equal(t, requests, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Name:      "httproute",
+			Namespace: "namespace1",
+		},
+	}})
+}
+
+// FIXME: this should be refactored into a test utility package
+func NewTestClient(list client.ObjectList, objects ...client.Object) gatewayclient.Client {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(gw.AddToScheme(scheme))
+	apigwv1alpha1.RegisterTypes(scheme)
+
+	builder := fake.
+		NewClientBuilder().
+		WithScheme(scheme)
+	if list != nil {
+		builder = builder.WithLists(list)
+	}
+	if len(objects) > 0 {
+		builder = builder.WithObjects(objects...)
+	}
+
+	return gatewayclient.New(builder.Build(), scheme, "")
 }

--- a/internal/k8s/controllers/http_route_controller_test.go
+++ b/internal/k8s/controllers/http_route_controller_test.go
@@ -155,6 +155,9 @@ func TestHTTPRouteWatchesReferencePolicy(t *testing.T) {
 
 	requests := controller.referencePolicyToRouteRequests(&refPolicy)
 
+	// FIXME: This should only request reconciliation for the one HTTPRoute in the
+	// allowed namespace
+	//
 	// require.Equal(t, len(requests), 1)
 	require.Equal(t, requests, []reconcile.Request{{
 		NamespacedName: types.NamespacedName{

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -33,7 +33,7 @@ type Client interface {
 	GetSecret(ctx context.Context, key types.NamespacedName) (*core.Secret, error)
 	GetService(ctx context.Context, key types.NamespacedName) (*core.Service, error)
 	GetHTTPRoute(ctx context.Context, key types.NamespacedName) (*gateway.HTTPRoute, error)
-	GetHTTPRoutes(ctx context.Context) (gateway.HTTPRouteList, error)
+	GetHTTPRoutes(ctx context.Context) ([]gateway.HTTPRoute, error)
 	GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error)
 	GetMeshService(ctx context.Context, key types.NamespacedName) (*apigwv1alpha1.MeshService, error)
 	GetNamespace(ctx context.Context, key types.NamespacedName) (*core.Namespace, error)
@@ -251,15 +251,15 @@ func (g *gatewayClient) GetHTTPRoute(ctx context.Context, key types.NamespacedNa
 	return route, nil
 }
 
-func (g *gatewayClient) GetHTTPRoutes(ctx context.Context) (gateway.HTTPRouteList, error) {
-	routes := &gateway.HTTPRouteList{}
-	if err := g.Client.List(ctx, routes); err != nil {
+func (g *gatewayClient) GetHTTPRoutes(ctx context.Context) ([]gateway.HTTPRoute, error) {
+	routeList := &gateway.HTTPRouteList{}
+	if err := g.Client.List(ctx, routeList); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return gateway.HTTPRouteList{}, nil
+			return []gateway.HTTPRoute{}, nil
 		}
-		return gateway.HTTPRouteList{}, NewK8sError(err)
+		return []gateway.HTTPRoute{}, NewK8sError(err)
 	}
-	return *routes, nil
+	return routeList.Items, nil
 }
 
 func (g *gatewayClient) GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error) {

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -33,6 +33,7 @@ type Client interface {
 	GetSecret(ctx context.Context, key types.NamespacedName) (*core.Secret, error)
 	GetService(ctx context.Context, key types.NamespacedName) (*core.Service, error)
 	GetHTTPRoute(ctx context.Context, key types.NamespacedName) (*gateway.HTTPRoute, error)
+	GetHTTPRoutes(ctx context.Context) (gateway.HTTPRouteList, error)
 	GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error)
 	GetMeshService(ctx context.Context, key types.NamespacedName) (*apigwv1alpha1.MeshService, error)
 	GetNamespace(ctx context.Context, key types.NamespacedName) (*core.Namespace, error)
@@ -248,6 +249,17 @@ func (g *gatewayClient) GetHTTPRoute(ctx context.Context, key types.NamespacedNa
 		return nil, NewK8sError(err)
 	}
 	return route, nil
+}
+
+func (g *gatewayClient) GetHTTPRoutes(ctx context.Context) (gateway.HTTPRouteList, error) {
+	routes := &gateway.HTTPRouteList{}
+	if err := g.Client.List(ctx, routes); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return gateway.HTTPRouteList{}, nil
+		}
+		return gateway.HTTPRouteList{}, NewK8sError(err)
+	}
+	return *routes, nil
 }
 
 func (g *gatewayClient) GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error) {

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -33,7 +33,7 @@ type Client interface {
 	GetSecret(ctx context.Context, key types.NamespacedName) (*core.Secret, error)
 	GetService(ctx context.Context, key types.NamespacedName) (*core.Service, error)
 	GetHTTPRoute(ctx context.Context, key types.NamespacedName) (*gateway.HTTPRoute, error)
-	GetHTTPRoutes(ctx context.Context) ([]gateway.HTTPRoute, error)
+	GetHTTPRoutesInNamespace(ctx context.Context, ns string) ([]gateway.HTTPRoute, error)
 	GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error)
 	GetMeshService(ctx context.Context, key types.NamespacedName) (*apigwv1alpha1.MeshService, error)
 	GetNamespace(ctx context.Context, key types.NamespacedName) (*core.Namespace, error)
@@ -251,12 +251,10 @@ func (g *gatewayClient) GetHTTPRoute(ctx context.Context, key types.NamespacedNa
 	return route, nil
 }
 
-func (g *gatewayClient) GetHTTPRoutes(ctx context.Context) ([]gateway.HTTPRoute, error) {
+// TODO: Make this generic over Group and Kind, returning []client.Object
+func (g *gatewayClient) GetHTTPRoutesInNamespace(ctx context.Context, ns string) ([]gateway.HTTPRoute, error) {
 	routeList := &gateway.HTTPRouteList{}
-	if err := g.Client.List(ctx, routeList); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return []gateway.HTTPRoute{}, nil
-		}
+	if err := g.Client.List(ctx, routeList, client.InNamespace(ns)); err != nil {
 		return []gateway.HTTPRoute{}, NewK8sError(err)
 	}
 	return routeList.Items, nil

--- a/internal/k8s/gatewayclient/gatewayclient_test.go
+++ b/internal/k8s/gatewayclient/gatewayclient_test.go
@@ -100,6 +100,21 @@ func TestGetHTTPRoute(t *testing.T) {
 	require.NotNil(t, route)
 }
 
+func TestGetHTTPRoutes(t *testing.T) {
+	t.Parallel()
+
+	gatewayclient := newTestClient(nil, &gateway.HTTPRoute{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "httproute",
+			Namespace: "namespace",
+		},
+	})
+
+	routes, err := gatewayclient.GetHTTPRoutes(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, len(routes), 1)
+}
+
 func TestGetGatewayClass(t *testing.T) {
 	t.Parallel()
 

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -259,19 +259,19 @@ func (mr *MockClientMockRecorder) GetHTTPRoute(ctx, key interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPRoute", reflect.TypeOf((*MockClient)(nil).GetHTTPRoute), ctx, key)
 }
 
-// GetHTTPRoutes mocks base method.
-func (m *MockClient) GetHTTPRoutes(ctx context.Context) ([]v1alpha2.HTTPRoute, error) {
+// GetHTTPRoutesInNamespace mocks base method.
+func (m *MockClient) GetHTTPRoutesInNamespace(ctx context.Context, ns string) ([]v1alpha2.HTTPRoute, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHTTPRoutes", ctx)
+	ret := m.ctrl.Call(m, "GetHTTPRoutesInNamespace", ctx, ns)
 	ret0, _ := ret[0].([]v1alpha2.HTTPRoute)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetHTTPRoutes indicates an expected call of GetHTTPRoutes.
-func (mr *MockClientMockRecorder) GetHTTPRoutes(ctx interface{}) *gomock.Call {
+// GetHTTPRoutesInNamespace indicates an expected call of GetHTTPRoutesInNamespace.
+func (mr *MockClientMockRecorder) GetHTTPRoutesInNamespace(ctx, ns interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPRoutes", reflect.TypeOf((*MockClient)(nil).GetHTTPRoutes), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPRoutesInNamespace", reflect.TypeOf((*MockClient)(nil).GetHTTPRoutesInNamespace), ctx, ns)
 }
 
 // GetMeshService mocks base method.

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -260,10 +260,10 @@ func (mr *MockClientMockRecorder) GetHTTPRoute(ctx, key interface{}) *gomock.Cal
 }
 
 // GetHTTPRoutes mocks base method.
-func (m *MockClient) GetHTTPRoutes(ctx context.Context) (v1alpha2.HTTPRouteList, error) {
+func (m *MockClient) GetHTTPRoutes(ctx context.Context) ([]v1alpha2.HTTPRoute, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPRoutes", ctx)
-	ret0, _ := ret[0].(v1alpha2.HTTPRouteList)
+	ret0, _ := ret[0].([]v1alpha2.HTTPRoute)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -259,6 +259,21 @@ func (mr *MockClientMockRecorder) GetHTTPRoute(ctx, key interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPRoute", reflect.TypeOf((*MockClient)(nil).GetHTTPRoute), ctx, key)
 }
 
+// GetHTTPRoutes mocks base method.
+func (m *MockClient) GetHTTPRoutes(ctx context.Context) (v1alpha2.HTTPRouteList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHTTPRoutes", ctx)
+	ret0, _ := ret[0].(v1alpha2.HTTPRouteList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHTTPRoutes indicates an expected call of GetHTTPRoutes.
+func (mr *MockClientMockRecorder) GetHTTPRoutes(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPRoutes", reflect.TypeOf((*MockClient)(nil).GetHTTPRoutes), ctx)
+}
+
 // GetMeshService mocks base method.
 func (m *MockClient) GetMeshService(ctx context.Context, key types.NamespacedName) (*v1alpha1.MeshService, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Changes proposed in this PR:

Adds a `Watches` clause to the HTTPRouteReconciler to watch for changes to ReferencePolicy objects and trigger reconciliation and re-validation for any HTTPRoutes that may be affected by changes.

(Please don't view by commit, it's too messy to bother trying to interactive rebase cleanly 🙈)

### How I've tested this PR:
- [x] Added a unit test for `GatewayClient.GetHTTPRoutesInNamespace`
- [x] Added a unit test for `HTTPRouteReconciler.referencePolicyToRouteRequests`
- [ ] **TODO:** Add end-to-end tests for adding, updating and deleting a ReferencePolicy 

### How I expect reviewers to test this PR:

### Reference Documentation:
- https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.ReferencePolicySpec
- https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.2/pkg/controller#Controller
- https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.2/pkg/handler#EnqueueRequestsFromMapFunc
- https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.2/pkg/event#pkg-overview
- https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.2/pkg/client#InNamespace

For unimplemented GroupKind matching on ReferencePolicyFrom instead of assuming HTTPRoute, and BackendRef filtering on ReferencePolicyTo:
- https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.2/pkg/client#MatchingFieldsSelector
- https://pkg.go.dev/k8s.io/apimachinery/pkg/fields#Selector
- https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
