### PR TITLE
Specify explicit type config for Envoy bootstrap filters

### DIFF
--- a/internal/envoy/manager.go
+++ b/internal/envoy/manager.go
@@ -263,7 +263,10 @@ const bootstrapJSONTemplate = `{
                   },
                   "http_filters": [
                     {
-                      "name": "envoy.filters.http.router"
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
                     }
                   ]
                 }

--- a/internal/envoy/testdata/basic.golden.json
+++ b/internal/envoy/testdata/basic.golden.json
@@ -120,7 +120,10 @@
                   },
                   "http_filters": [
                     {
-                      "name": "envoy.filters.http.router"
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
                     }
                   ]
                 }

--- a/internal/envoy/testdata/empty.golden.json
+++ b/internal/envoy/testdata/empty.golden.json
@@ -120,7 +120,10 @@
                   },
                   "http_filters": [
                     {
-                      "name": "envoy.filters.http.router"
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
                     }
                   ]
                 }

--- a/internal/envoy/testdata/sds.golden.json
+++ b/internal/envoy/testdata/sds.golden.json
@@ -123,7 +123,10 @@
                   },
                   "http_filters": [
                     {
-                      "name": "envoy.filters.http.router"
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
                     }
                   ]
                 }

--- a/internal/envoy/testdata/tls.golden.json
+++ b/internal/envoy/testdata/tls.golden.json
@@ -133,7 +133,10 @@
                   },
                   "http_filters": [
                     {
-                      "name": "envoy.filters.http.router"
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                      }
                     }
                   ]
                 }


### PR DESCRIPTION
### Changes proposed in this PR:
Consul-K8s moved to Envoy 1.22 which includes a [minor behavior change](https://www.envoyproxy.io/docs/envoy/v1.22.0/version_history/current#minor-behavior-changes) that breaks due to our current bootstrap config:
> config: type URL is used to lookup extensions regardless of the name field. This may cause problems for empty filter configurations or mis-matched protobuf as the typed configurations. This behavioral change can be temporarily reverted by setting runtime guard envoy.reloadable_features.no_extension_lookup_by_name to false.

### How I've tested this PR:
🤖 conformance tests pass where they fail before

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
