### PR TITLE
TCPRouteController: watch ReferencePolicy lifecycle

### DIFF
--- a/.changelog/162.txt
+++ b/.changelog/162.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+k8s/controllers: watch for ReferencePolicy changes to reconcile and revalidate affected TCPRoutes
+```

--- a/internal/k8s/controllers/http_route_controller_test.go
+++ b/internal/k8s/controllers/http_route_controller_test.go
@@ -7,12 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
@@ -20,8 +15,6 @@ import (
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
 	reconcilerMocks "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/mocks"
 	"github.com/hashicorp/go-hclog"
-
-	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 )
 
 var (
@@ -125,7 +118,7 @@ func TestHTTPRouteReferencePolicyToRouteRequests(t *testing.T) {
 		},
 	}
 
-	gatewayclient := NewTestClient(
+	client := gatewayclient.NewTestClient(
 		&gw.HTTPRouteList{
 			Items: []gw.HTTPRoute{
 				{
@@ -148,7 +141,7 @@ func TestHTTPRouteReferencePolicyToRouteRequests(t *testing.T) {
 	)
 
 	controller := &HTTPRouteReconciler{
-		Client:         gatewayclient,
+		Client:         client,
 		Log:            hclog.NewNullLogger(),
 		ControllerName: mockControllerName,
 		Manager:        reconcilerMocks.NewMockReconcileManager(ctrl),
@@ -162,24 +155,4 @@ func TestHTTPRouteReferencePolicyToRouteRequests(t *testing.T) {
 			Namespace: "namespace1",
 		},
 	}}, requests)
-}
-
-// FIXME: this should be refactored into a test utility package
-func NewTestClient(list client.ObjectList, objects ...client.Object) gatewayclient.Client {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(gw.AddToScheme(scheme))
-	apigwv1alpha1.RegisterTypes(scheme)
-
-	builder := fake.
-		NewClientBuilder().
-		WithScheme(scheme)
-	if list != nil {
-		builder = builder.WithLists(list)
-	}
-	if len(objects) > 0 {
-		builder = builder.WithObjects(objects...)
-	}
-
-	return gatewayclient.New(builder.Build(), scheme, "")
 }

--- a/internal/k8s/controllers/http_route_controller_test.go
+++ b/internal/k8s/controllers/http_route_controller_test.go
@@ -144,7 +144,7 @@ func TestHTTPRouteReferencePolicyToRouteRequests(t *testing.T) {
 		},
 		&gw.TCPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "httproute",
+				Name:      "tcproute",
 				Namespace: "namespace1",
 			},
 			Spec: tcpRouteSpec,

--- a/internal/k8s/controllers/http_route_controller_test.go
+++ b/internal/k8s/controllers/http_route_controller_test.go
@@ -103,6 +103,14 @@ func TestHTTPRouteReferencePolicyToRouteRequests(t *testing.T) {
 		}},
 	}
 
+	tcpRouteSpec := gw.TCPRouteSpec{
+		Rules: []gw.TCPRouteRule{{
+			BackendRefs: []gw.BackendRef{{
+				BackendObjectReference: backendObjRef,
+			}},
+		}},
+	}
+
 	refPolicy := gw.ReferencePolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "ReferencePolicy"},
 		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace3"},
@@ -119,23 +127,27 @@ func TestHTTPRouteReferencePolicyToRouteRequests(t *testing.T) {
 	}
 
 	client := gatewayclient.NewTestClient(
-		&gw.HTTPRouteList{
-			Items: []gw.HTTPRoute{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "httproute",
-						Namespace: "namespace1",
-					},
-					Spec: httpRouteSpec,
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "httproute",
-						Namespace: "namespace2",
-					},
-					Spec: httpRouteSpec,
-				},
+		nil,
+		&gw.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "httproute",
+				Namespace: "namespace1",
 			},
+			Spec: httpRouteSpec,
+		},
+		&gw.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "httproute",
+				Namespace: "namespace2",
+			},
+			Spec: httpRouteSpec,
+		},
+		&gw.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "httproute",
+				Namespace: "namespace1",
+			},
+			Spec: tcpRouteSpec,
 		},
 		&refPolicy,
 	)

--- a/internal/k8s/controllers/tcp_route_controller.go
+++ b/internal/k8s/controllers/tcp_route_controller.go
@@ -3,7 +3,12 @@ package controllers
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 	gateway "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
@@ -11,8 +16,9 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-// TCPRouteReconciler reconciles a HTTPRoute object
+// TCPRouteReconciler reconciles a TCPRoute object
 type TCPRouteReconciler struct {
+	Context        context.Context
 	Client         gatewayclient.Client
 	Log            hclog.Logger
 	ControllerName string
@@ -53,5 +59,67 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gateway.TCPRoute{}).
+		Watches(
+			&source.Kind{Type: &gateway.ReferencePolicy{}},
+			handler.EnqueueRequestsFromMapFunc(r.referencePolicyToRouteRequests),
+		).
 		Complete(gatewayclient.NewRequeueingMiddleware(r.Log, r))
+}
+
+// For UpdateEvents which contain both a new and old object, this transformation
+// function is run on both objects and both sets of Requests are enqueued.
+//
+// This is needed to reconcile any objects matched by both current and prior
+// state in case a ReferencePolicy has been modified to revoke permission from a
+// namespace or to a service
+//
+// It may be possible to improve performance here by filtering Routes by
+// BackendRefs selectable by the To fields, but currently we just revalidate
+// all Routes allowed in the From Namespaces
+func (r *TCPRouteReconciler) referencePolicyToRouteRequests(object client.Object) []reconcile.Request {
+	refPolicy := object.(*gateway.ReferencePolicy)
+
+	routes := r.getRoutesAffectedByReferencePolicy(refPolicy)
+	requests := []reconcile.Request{}
+
+	for _, route := range routes {
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      route.Name,
+				Namespace: route.Namespace,
+			},
+		})
+	}
+
+	return requests
+}
+
+func (r *TCPRouteReconciler) getRoutesAffectedByReferencePolicy(refPolicy *gateway.ReferencePolicy) []gateway.TCPRoute {
+	matches := []gateway.TCPRoute{}
+
+	routes := r.getReferencePolicyObjectsFrom(refPolicy)
+
+	// TODO: match only routes with BackendRefs selectable by a
+	// ReferencePolicyTo instead of appending all routes. This seems expensive,
+	// so not sure if it would actually improve performance or not.
+	matches = append(matches, routes...)
+
+	return matches
+}
+
+func (r *TCPRouteReconciler) getReferencePolicyObjectsFrom(refPolicy *gateway.ReferencePolicy) []gateway.TCPRoute {
+	matches := []gateway.TCPRoute{}
+
+	for _, from := range refPolicy.Spec.From {
+		// TODO: search by from.Group and from.Kind instead of assuming TCPRoute
+		routes, err := r.Client.GetTCPRoutesInNamespace(r.Context, string(from.Namespace))
+		if err != nil {
+			r.Log.Error("error fetching routes", err)
+			return matches
+		}
+
+		matches = append(matches, routes...)
+	}
+
+	return matches
 }

--- a/internal/k8s/controllers/tcp_route_controller_test.go
+++ b/internal/k8s/controllers/tcp_route_controller_test.go
@@ -1,0 +1,170 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
+	reconcilerMocks "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/mocks"
+	"github.com/hashicorp/go-hclog"
+)
+
+var (
+	tcpRouteName = types.NamespacedName{
+		Name:      "tcp-route",
+		Namespace: "default",
+	}
+)
+
+func TestTCPRouteSetup(t *testing.T) {
+	require.Error(t, (&TCPRouteReconciler{}).SetupWithManager(nil))
+}
+
+func TestTCPRoute(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name          string
+		err           error
+		result        reconcile.Result
+		expectationCB func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager)
+	}{{
+		name: "get-error",
+		err:  errExpected,
+		expectationCB: func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager) {
+			client.EXPECT().GetTCPRoute(gomock.Any(), tcpRouteName).Return(nil, errExpected)
+		},
+	}, {
+		name: "deleted",
+		expectationCB: func(client *mocks.MockClient, reconciler *reconcilerMocks.MockReconcileManager) {
+			client.EXPECT().GetTCPRoute(gomock.Any(), tcpRouteName).Return(nil, nil)
+			reconciler.EXPECT().DeleteTCPRoute(gomock.Any(), tcpRouteName)
+		},
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			client := mocks.NewMockClient(ctrl)
+			reconciler := reconcilerMocks.NewMockReconcileManager(ctrl)
+			if test.expectationCB != nil {
+				test.expectationCB(client, reconciler)
+			}
+
+			controller := &TCPRouteReconciler{
+				Context:        context.Background(),
+				Client:         client,
+				Log:            hclog.NewNullLogger(),
+				ControllerName: mockControllerName,
+				Manager:        reconciler,
+			}
+			result, err := controller.Reconcile(context.Background(), reconcile.Request{
+				NamespacedName: tcpRouteName,
+			})
+			if test.err != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, test.err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.result, result)
+		})
+	}
+}
+
+func TestTCPRouteReferencePolicyToRouteRequests(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	serviceNamespace := gw.Namespace("namespace3")
+
+	backendObjRef := gw.BackendObjectReference{
+		Name:      gw.ObjectName("service"),
+		Namespace: &serviceNamespace,
+	}
+
+	httpRouteSpec := gw.HTTPRouteSpec{
+		Rules: []gw.HTTPRouteRule{{
+			BackendRefs: []gw.HTTPBackendRef{{
+				BackendRef: gw.BackendRef{
+					BackendObjectReference: backendObjRef,
+				},
+			}},
+		}},
+	}
+
+	tcpRouteSpec := gw.TCPRouteSpec{
+		Rules: []gw.TCPRouteRule{{
+			BackendRefs: []gw.BackendRef{{
+				BackendObjectReference: backendObjRef,
+			}},
+		}},
+	}
+
+	refPolicy := gw.ReferencePolicy{
+		TypeMeta:   metav1.TypeMeta{Kind: "ReferencePolicy"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace3"},
+		Spec: gw.ReferencePolicySpec{
+			From: []gw.ReferencePolicyFrom{{
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "TCPRoute",
+				Namespace: "namespace1",
+			}},
+			To: []gw.ReferencePolicyTo{{
+				Kind: "Service",
+			}},
+		},
+	}
+
+	client := gatewayclient.NewTestClient(
+		nil,
+		&gw.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tcproute",
+				Namespace: "namespace1",
+			},
+			Spec: httpRouteSpec,
+		},
+		&gw.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tcproute",
+				Namespace: "namespace1",
+			},
+			Spec: tcpRouteSpec,
+		},
+		&gw.TCPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tcproute",
+				Namespace: "namespace2",
+			},
+			Spec: tcpRouteSpec,
+		},
+		&refPolicy,
+	)
+
+	controller := &TCPRouteReconciler{
+		Client:         client,
+		Log:            hclog.NewNullLogger(),
+		ControllerName: mockControllerName,
+		Manager:        reconcilerMocks.NewMockReconcileManager(ctrl),
+	}
+
+	requests := controller.referencePolicyToRouteRequests(&refPolicy)
+
+	require.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Name:      "tcproute",
+			Namespace: "namespace1",
+		},
+	}}, requests)
+}

--- a/internal/k8s/controllers/tcp_route_controller_test.go
+++ b/internal/k8s/controllers/tcp_route_controller_test.go
@@ -129,7 +129,7 @@ func TestTCPRouteReferencePolicyToRouteRequests(t *testing.T) {
 		nil,
 		&gw.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "tcproute",
+				Name:      "httproute",
 				Namespace: "namespace1",
 			},
 			Spec: httpRouteSpec,

--- a/internal/k8s/controllers/tcp_route_controller_test.go
+++ b/internal/k8s/controllers/tcp_route_controller_test.go
@@ -70,7 +70,6 @@ func TestTCPRoute(t *testing.T) {
 				NamespacedName: tcpRouteName,
 			})
 			if test.err != nil {
-				require.Error(t, err)
 				require.ErrorIs(t, err, test.err)
 			} else {
 				require.NoError(t, err)

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -35,6 +35,7 @@ type Client interface {
 	GetHTTPRoute(ctx context.Context, key types.NamespacedName) (*gateway.HTTPRoute, error)
 	GetHTTPRoutesInNamespace(ctx context.Context, ns string) ([]gateway.HTTPRoute, error)
 	GetTCPRoute(ctx context.Context, key types.NamespacedName) (*gateway.TCPRoute, error)
+	GetTCPRoutesInNamespace(ctx context.Context, ns string) ([]gateway.TCPRoute, error)
 	GetMeshService(ctx context.Context, key types.NamespacedName) (*apigwv1alpha1.MeshService, error)
 	GetNamespace(ctx context.Context, key types.NamespacedName) (*core.Namespace, error)
 
@@ -269,6 +270,14 @@ func (g *gatewayClient) GetTCPRoute(ctx context.Context, key types.NamespacedNam
 		return nil, NewK8sError(err)
 	}
 	return route, nil
+}
+
+func (g *gatewayClient) GetTCPRoutesInNamespace(ctx context.Context, ns string) ([]gateway.TCPRoute, error) {
+	routeList := &gateway.TCPRouteList{}
+	if err := g.Client.List(ctx, routeList, client.InNamespace(ns)); err != nil {
+		return []gateway.TCPRoute{}, NewK8sError(err)
+	}
+	return routeList.Items, nil
 }
 
 func (g *gatewayClient) GetMeshService(ctx context.Context, key types.NamespacedName) (*apigwv1alpha1.MeshService, error) {

--- a/internal/k8s/gatewayclient/gatewayclient_test.go
+++ b/internal/k8s/gatewayclient/gatewayclient_test.go
@@ -7,12 +7,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gateway "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/stretchr/testify/assert"
@@ -24,7 +19,7 @@ import (
 func TestGetGateway(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(nil, &gateway.Gateway{
+	gatewayclient := NewTestClient(nil, &gateway.Gateway{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "gateway",
 			Namespace: "namespace",
@@ -49,7 +44,7 @@ func TestGetGateway(t *testing.T) {
 func TestGetGatewayClassConfig(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(nil, &apigwv1alpha1.GatewayClassConfig{
+	gatewayclient := NewTestClient(nil, &apigwv1alpha1.GatewayClassConfig{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "gatewayclassconfig",
 		},
@@ -71,7 +66,7 @@ func TestGetGatewayClassConfig(t *testing.T) {
 func TestGetHTTPRoute(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(nil, &gateway.HTTPRoute{
+	gatewayclient := NewTestClient(nil, &gateway.HTTPRoute{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "httproute",
 			Namespace: "namespace",
@@ -103,7 +98,7 @@ func TestGetHTTPRoute(t *testing.T) {
 func TestGetHTTPRoutesInNamespace(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(nil, &gateway.HTTPRoute{
+	gatewayclient := NewTestClient(nil, &gateway.HTTPRoute{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "httproute",
 			Namespace: "namespace1",
@@ -122,7 +117,7 @@ func TestGetHTTPRoutesInNamespace(t *testing.T) {
 func TestGetGatewayClass(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(nil, &gateway.GatewayClass{
+	gatewayclient := NewTestClient(nil, &gateway.GatewayClass{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "gatewayclass",
 		},
@@ -144,7 +139,7 @@ func TestGetGatewayClass(t *testing.T) {
 func TestDeploymentForGateway(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(nil, &apps.Deployment{
+	gatewayclient := NewTestClient(nil, &apps.Deployment{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "gateway",
 			Namespace: "namespace",
@@ -182,7 +177,7 @@ func TestDeploymentForGateway(t *testing.T) {
 func TestEnsureFinalizer(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(nil, &gateway.GatewayClass{
+	gatewayclient := NewTestClient(nil, &gateway.GatewayClass{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "gatewayclass",
 		},
@@ -216,7 +211,7 @@ func TestEnsureFinalizer(t *testing.T) {
 func TestRemoveFinalizer(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(nil, &gateway.GatewayClass{
+	gatewayclient := NewTestClient(nil, &gateway.GatewayClass{
 		ObjectMeta: meta.ObjectMeta{
 			Name:       "gatewayclass",
 			Finalizers: []string{"finalizer", "other"},
@@ -258,7 +253,7 @@ func TestRemoveFinalizer(t *testing.T) {
 func TestGatewayClassesUsingConfig(t *testing.T) {
 	t.Parallel()
 
-	gatewayClient := newTestClient(&gateway.GatewayClassList{
+	gatewayClient := NewTestClient(&gateway.GatewayClassList{
 		Items: []gateway.GatewayClass{
 			{
 				ObjectMeta: meta.ObjectMeta{Name: "gatewayclass1"},
@@ -305,7 +300,7 @@ func TestGatewayClassesUsingConfig(t *testing.T) {
 func TestGatewayClassConfigInUse(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(&gateway.GatewayClassList{
+	gatewayclient := NewTestClient(&gateway.GatewayClassList{
 		Items: []gateway.GatewayClass{{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "gatewayclass",
@@ -339,7 +334,7 @@ func TestGatewayClassConfigInUse(t *testing.T) {
 func TestGatewayClassInUse(t *testing.T) {
 	t.Parallel()
 
-	gatewayclient := newTestClient(&gateway.GatewayList{
+	gatewayclient := NewTestClient(&gateway.GatewayList{
 		Items: []gateway.Gateway{{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "gateway",
@@ -366,7 +361,7 @@ func TestGatewayClassInUse(t *testing.T) {
 	require.False(t, used)
 }
 func TestPodWithLabelsNoItems(t *testing.T) {
-	gatewayclient := newTestClient(nil)
+	gatewayclient := NewTestClient(nil)
 
 	pod, err := gatewayclient.PodWithLabels(context.Background(), map[string]string{
 		"label": "test",
@@ -379,7 +374,7 @@ func TestPodWithLabelsOneItem(t *testing.T) {
 	labels := map[string]string{
 		"label": "test",
 	}
-	gatewayclient := newTestClient(&core.PodList{
+	gatewayclient := NewTestClient(&core.PodList{
 		Items: []core.Pod{{
 			ObjectMeta: meta.ObjectMeta{
 				Labels: labels,
@@ -397,7 +392,7 @@ func TestPodWithLabelsMultipleItems(t *testing.T) {
 		"label": "test",
 	}
 	now := meta.Now()
-	gatewayclient := newTestClient(&core.PodList{
+	gatewayclient := NewTestClient(&core.PodList{
 		Items: []core.Pod{{
 			ObjectMeta: meta.ObjectMeta{
 				Labels:            labels,
@@ -420,23 +415,4 @@ func TestPodWithLabelsMultipleItems(t *testing.T) {
 	pod, err := gatewayclient.PodWithLabels(context.Background(), labels)
 	require.NoError(t, err)
 	require.NotNil(t, pod)
-}
-
-func newTestClient(list client.ObjectList, objects ...client.Object) Client {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(gateway.AddToScheme(scheme))
-	apigwv1alpha1.RegisterTypes(scheme)
-
-	builder := fake.
-		NewClientBuilder().
-		WithScheme(scheme)
-	if list != nil {
-		builder = builder.WithLists(list)
-	}
-	if len(objects) > 0 {
-		builder = builder.WithObjects(objects...)
-	}
-
-	return New(builder.Build(), scheme, "")
 }

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -364,6 +364,21 @@ func (mr *MockClientMockRecorder) GetTCPRoute(ctx, key interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTCPRoute", reflect.TypeOf((*MockClient)(nil).GetTCPRoute), ctx, key)
 }
 
+// GetTCPRoutesInNamespace mocks base method.
+func (m *MockClient) GetTCPRoutesInNamespace(ctx context.Context, ns string) ([]v1alpha2.TCPRoute, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTCPRoutesInNamespace", ctx, ns)
+	ret0, _ := ret[0].([]v1alpha2.TCPRoute)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTCPRoutesInNamespace indicates an expected call of GetTCPRoutesInNamespace.
+func (mr *MockClientMockRecorder) GetTCPRoutesInNamespace(ctx, ns interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTCPRoutesInNamespace", reflect.TypeOf((*MockClient)(nil).GetTCPRoutesInNamespace), ctx, ns)
+}
+
 // HasManagedDeployment mocks base method.
 func (m *MockClient) HasManagedDeployment(ctx context.Context, gw *v1alpha2.Gateway) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/k8s/gatewayclient/test_helpers.go
+++ b/internal/k8s/gatewayclient/test_helpers.go
@@ -1,0 +1,30 @@
+package gatewayclient
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gw "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
+)
+
+func NewTestClient(list client.ObjectList, objects ...client.Object) Client {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(gw.AddToScheme(scheme))
+	apigwv1alpha1.RegisterTypes(scheme)
+
+	builder := fake.
+		NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...)
+
+	if list != nil {
+		builder = builder.WithLists(list)
+	}
+
+	return New(builder.Build(), scheme, "")
+}

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -90,6 +90,7 @@ type consulTestEnvironment struct {
 	httpPort                int
 	httpFlattenedPort       int
 	httpReferencePolicyPort int
+	tcpReferencePolicyPort  int
 	grpcPort                int
 	extraHTTPPort           int
 	extraTCPPort            int
@@ -111,6 +112,7 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 		httpsPort := cluster.httpsPort
 		httpFlattenedPort := cluster.httpsFlattenedPort
 		httpReferencePolicyPort := cluster.httpsReferencePolicyPort
+		tcpReferencePolicyPort := cluster.tcpReferencePolicyPort
 		grpcPort := cluster.grpcPort
 		extraTCPPort := cluster.extraTCPPort
 		extraTCPTLSPort := cluster.extraTCPTLSPort
@@ -204,6 +206,7 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 			httpPort:                httpsPort,
 			httpFlattenedPort:       httpFlattenedPort,
 			httpReferencePolicyPort: httpReferencePolicyPort,
+			tcpReferencePolicyPort:  tcpReferencePolicyPort,
 			grpcPort:                grpcPort,
 			extraHTTPPort:           extraHTTPPort,
 			extraTCPPort:            extraTCPPort,
@@ -496,6 +499,14 @@ func HTTPReferencePolicyPort(ctx context.Context) int {
 		panic("must run this with an integration test that has called CreateTestConsul")
 	}
 	return consulEnvironment.(*consulTestEnvironment).httpReferencePolicyPort
+}
+
+func TCPReferencePolicyPort(ctx context.Context) int {
+	consulEnvironment := ctx.Value(consulTestContextKey)
+	if consulEnvironment == nil {
+		panic("must run this with an integration test that has called CreateTestConsul")
+	}
+	return consulEnvironment.(*consulTestEnvironment).tcpReferencePolicyPort
 }
 
 func ConsulHTTPPort(ctx context.Context) int {

--- a/internal/testing/e2e/kind.go
+++ b/internal/testing/e2e/kind.go
@@ -43,6 +43,9 @@ nodes:
   - containerPort: {{ .HTTPSReferencePolicyPort }}
     hostPort: {{ .HTTPSReferencePolicyPort }}
     protocol: TCP
+  - containerPort: {{ .TCPReferencePolicyPort }}
+    hostPort: {{ .TCPReferencePolicyPort }}
+    protocol: TCP
   - containerPort: {{ .GRPCPort }}
     hostPort: {{ .GRPCPort }}
     protocol: TCP
@@ -76,6 +79,7 @@ type kindCluster struct {
 	httpsPort                int
 	httpsFlattenedPort       int
 	httpsReferencePolicyPort int
+	tcpReferencePolicyPort   int
 	grpcPort                 int
 	extraHTTPPort            int
 	extraTCPPort             int
@@ -84,18 +88,19 @@ type kindCluster struct {
 }
 
 func newKindCluster(name string) *kindCluster {
-	ports := freeport.MustTake(8)
+	ports := freeport.MustTake(9)
 	return &kindCluster{
 		name:                     name,
 		e:                        gexe.New(),
 		httpsPort:                ports[0],
 		httpsFlattenedPort:       ports[1],
 		httpsReferencePolicyPort: ports[2],
-		grpcPort:                 ports[3],
-		extraHTTPPort:            ports[4],
-		extraTCPPort:             ports[5],
-		extraTCPTLSPort:          ports[6],
-		extraTCPTLSPortTwo:       ports[7],
+		tcpReferencePolicyPort:   ports[3],
+		grpcPort:                 ports[4],
+		extraHTTPPort:            ports[5],
+		extraTCPPort:             ports[6],
+		extraTCPTLSPort:          ports[7],
+		extraTCPTLSPortTwo:       ports[8],
 	}
 }
 
@@ -107,6 +112,7 @@ func (k *kindCluster) Create() (string, error) {
 		HTTPSPort                int
 		HTTPSFlattenedPort       int
 		HTTPSReferencePolicyPort int
+		TCPReferencePolicyPort   int
 		GRPCPort                 int
 		ExtraTCPPort             int
 		ExtraTCPTLSPort          int
@@ -116,6 +122,7 @@ func (k *kindCluster) Create() (string, error) {
 		HTTPSPort:                k.httpsPort,
 		HTTPSFlattenedPort:       k.httpsFlattenedPort,
 		HTTPSReferencePolicyPort: k.httpsReferencePolicyPort,
+		TCPReferencePolicyPort:   k.tcpReferencePolicyPort,
 		GRPCPort:                 k.grpcPort,
 		ExtraTCPPort:             k.extraTCPPort,
 		ExtraTCPTLSPort:          k.extraTCPTLSPort,


### PR DESCRIPTION
### Changes proposed in this PR:

Adds ReferencePolicy lifecycle watch to TCPRouteController. Refs #156 

### How I've tested this PR:

- [x] Added unit tests copy-pasted from HTTPRouteController tests.
- [x] Update e2e ReferencePolicy test to check TCPRoute too.

### How I expect reviewers to test this PR:

- Validate that tests offer sufficient coverage.
- Offer any suggestions on how best to avoid the `gatewayclient` <> `k8stest` import cycle

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)
