### PR TITLE
ci: bump Go version to 1.18

### DIFF
--- a/.changelog/167.txt
+++ b/.changelog/167.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+go: build with Go 1.18
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["main", "release/**"]
 env:
-  GO_VERSION: '1.17'
+  GO_VERSION: '1.18'
   CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
 jobs:
   lint:
@@ -35,7 +35,7 @@ jobs:
     name: unit test (consul-version=${{ matrix.consul-version }})
     strategy:
       matrix:
-        consul-version: 
+        consul-version:
         - 1.11.5
         - 1.12.0
         - 1.11.5+ent
@@ -86,7 +86,7 @@ jobs:
     name: e2e tests (consul-image=${{ matrix.consul-image }})
     strategy:
       matrix:
-        consul-image: 
+        consul-image:
         - 'hashicorp/consul:1.11.5'
         - 'hashicorp/consul-enterprise:1.11.5-ent'
         - 'hashicorp/consul:1.12.0'

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -24,7 +24,7 @@ on:
         default: '10'
 
 env:
-  GO_VERSION: "1.17"
+  GO_VERSION: "1.18"
 
 jobs:
   run-on-kind:

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/moby/sys/mount v0.2.0 // indirect
 	github.com/moby/sys/mountinfo v0.4.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onsi/gomega v1.15.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -651,8 +651,9 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -966,6 +966,7 @@ func TestTCPMeshService(t *testing.T) {
 			// supported by Envoy defaults
 			checkTCPTLSRoute(t, listenerOnePort, &tls.Config{
 				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS10,
 				MaxVersion:         tls.VersionTLS11,
 			}, "remote error: tls: protocol version not supported", "connection not rejected with expected error in allotted time")
 
@@ -973,6 +974,7 @@ func TestTCPMeshService(t *testing.T) {
 			checkTCPTLSRoute(t, listenerTwoPort, &tls.Config{
 				InsecureSkipVerify: true,
 				CipherSuites:       []uint16{tls.TLS_RSA_WITH_AES_128_CBC_SHA},
+				MinVersion:         tls.VersionTLS10,
 				MaxVersion:         tls.VersionTLS11,
 			}, serviceTwo.Name, "service not routable in allotted time")
 


### PR DESCRIPTION
### Changes proposed in this PR:

- Bump `GO_VERSION` for CI to 1.18
- Bump the `reflect2` dependency to avoid a segfault

### How I've tested this PR:

Running `go test ./...` in `internal/k8s/builder` previously failed with a segfault when running with Go 1.18 locally due to unsafe code used by the `reflect2` package (an indirect dependency from Kubernetes core). With this change tests now pass locally, and should be able to pass in CI as well.

### How I expect reviewers to test this PR:

- Confirm that bumping the version in `go.mod` is not necessary as we aren't actually using any features like generic that require Go 1.18 yet, just fixing compatibility.
- Did I miss anywhere this needs to be bumped, e.g. for release pipelines?

- [x] CHANGELOG entry added 
  > HashiCorp engineers only, community PRs should not add a changelog entry.
  > Entries should use imperative present tense (e.g. Add support for...)