### PR TITLE
conformance: remove Helm chart consul image config

### DIFF
--- a/internal/testing/conformance/consul-config.yaml
+++ b/internal/testing/conformance/consul-config.yaml
@@ -1,5 +1,4 @@
 global:
-  image: "hashicorp/consul:1.12.0"  # TODO Remove once 1.12.0 is consumed in consul-k8s
   tls:
     enabled: true
 server:


### PR DESCRIPTION
### Changes proposed in this PR:

- Remove explicit `consul: hashicorp/consul:1.12.0` config from conformance testing Helm config
  - Default was bumped in https://github.com/hashicorp/consul-k8s/pull/1182 and has been included in latest 0.43.0 Helm chart release.

### How I've tested this PR:

Let the conformance tests run in CI on this PR.

### How I expect reviewers to test this PR:

Should we switch to pinning against a Helm chart release, or do we like staying on hashicorp/consul-k8s `HEAD`?

### Checklist:
- [ ] ~~Tests added~~
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
