### PR TITLE
Automate version + changelog updates for release

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -36,13 +36,6 @@ jobs:
           echo "$VERSION" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Update version.go
-        uses: jacobtomlinson/gha-find-replace@v2
-        with:
-          include: 'internal/version/version.go'
-          find: 'Version = "[0-9\.]+"'
-          replace: 'Version = "${{ env.NEW_API_GATEWAY_VERSION }}"'
-
       - name: Update deployment.yaml
         uses: 'jacobtomlinson/gha-find-replace@v2'
         with:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,9 +1,6 @@
 name: prepare_release
 
 on:
-  push:
-    branches: ['prepare-release-workflow']
-
   workflow_dispatch:
     inputs:
       new-min-consul-version:
@@ -19,8 +16,8 @@ jobs:
   update-versions:
     runs-on: ubuntu-latest
     env:
-      NEW_CONSUL_REQ: ${{ github.event.inputs.new-min-consul-version || '1.13.0' }}
-      NEW_CONSUL_K8S_REQ: ${{ github.event.inputs.new-min-consul-k8s-version || '0.44.0' }}
+      NEW_CONSUL_REQ: ${{ github.event.inputs.new-min-consul-version }}
+      NEW_CONSUL_K8S_REQ: ${{ github.event.inputs.new-min-consul-k8s-version }}
 
     steps:
 

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,130 @@
+name: prepare_release
+
+on:
+  push:
+    branches: ['prepare-release-workflow']
+
+  workflow_dispatch:
+    inputs:
+      new-min-consul-version:
+        description: 'The new minimum version of Consul (no "v" prefix)'
+        required: true
+        type: string
+      new-min-consul-k8s-version:
+        description: 'The new minimum version of Consul K8s (no "v" prefix)'
+        required: true
+        type: string
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-latest
+    env:
+      NEW_CONSUL_REQ: ${{ github.event.inputs.new-min-consul-version || '1.13.0' }}
+      NEW_CONSUL_K8S_REQ: ${{ github.event.inputs.new-min-consul-k8s-version || '0.44.0' }}
+
+    steps:
+
+      - name: Checkout consul-api-gateway
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
+
+      - name: Set version being released
+        run: |
+          VERSION=$(make version)
+          echo "NEW_API_GATEWAY_VERSION<<EOF" >> $GITHUB_ENV
+          echo "$VERSION" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Update version.go
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'internal/version/version.go'
+          find: 'Version = "[0-9\.]+"'
+          replace: 'Version = "${{ env.NEW_API_GATEWAY_VERSION }}"'
+
+      - name: Update deployment.yaml
+        uses: 'jacobtomlinson/gha-find-replace@v2'
+        with:
+          include: config/deployment/deployment.yaml
+          find: 'image: hashicorp/consul-api-gateway:[0-9\.]+'
+          replace: 'image: hashicorp/consul-api-gateway:${{ env.NEW_API_GATEWAY_VERSION }}'
+
+      - name: Update example-setup.md
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'dev/docs/example-setup.md'
+          find: 'ref=v[0-9\.]+'
+          replace: 'ref=v${{ env.NEW_API_GATEWAY_VERSION }}'
+
+      - name: Update README.md (Consul version)
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'README.md'
+          find: 'The installed version of Consul must be `v[0-9\.]+` or greater.'
+          replace: 'The installed version of Consul must be `v${{ env.NEW_CONSUL_REQ }}` or greater.'
+
+      - name: Update README.md (Consul K8s version)
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'README.md'
+          find: 'The Consul Helm chart must be version `[0-9\.]+` or greater.'
+          replace: 'The Consul Helm chart must be version `${{ env.NEW_CONSUL_K8S_REQ }}` or greater.'
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+
+      - name: Update release_branches config
+        # TODO Make more robust in the future, could currently be a major or minor release
+        if: endsWith(env.NEW_API_GATEWAY_VERSION, '.0')
+        run: |
+          sudo apt-get -y install jq
+          go install github.com/mattolenik/hclq@latest
+          MINOR_VERSION=${NEW_API_GATEWAY_VERSION%.*}
+          NEW_RELEASE_BRANCH=release/$MINOR_VERSION.x
+          export NV=$(cat .release/ci.hcl | hclq get 'project.consul-api-gateway.github.release_branches[]' | jq -c ". += [\"$NEW_RELEASE_BRANCH\"]")
+          hclq --in=.release/ci.hcl --out=.release/ci.hcl set 'project.consul-api-gateway.github.release_branches[]' $NV
+
+      - name: Regenerate golden files
+        run: make generate-golden-files
+
+      - name: Get current date
+        id: get-current-date
+        run: echo "::set-output name=date::$(date +'%B %d, %Y')"
+
+      - name: Generate changelog patch
+        id: generate-changelog-patch
+        run: | # Pass via environment variable to keep multiline in tact
+          export LAST_RELEASE_GIT_TAG=$(git tag --sort=committerdate | tail -1)
+          CHANGELOG_PATCH=$(make changelog)
+          echo "CHANGELOG_PATCH<<EOF" >> $GITHUB_ENV
+          echo "$CHANGELOG_PATCH" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Update CHANGELOG.md
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'CHANGELOG.md'
+          find: |
+            ## UNRELEASED
+
+          replace: |
+            ## UNRELEASED
+            
+            ## ${{ env.NEW_API_GATEWAY_VERSION }} (${{ steps.get-current-date.outputs.date }})
+            ${{ env.CHANGELOG_PATCH }}
+          regex: false
+
+      - name: Create branch
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: 'v${{ env.NEW_API_GATEWAY_VERSION }}-release-prep'
+          commit_message: |
+            Prepare for release of v${{ env.NEW_API_GATEWAY_VERSION }}
+            Consul API Gateway version being released: `${{ env.NEW_API_GATEWAY_VERSION }}`
+            Now requires:
+            - consul: `${{ env.NEW_CONSUL_REQ }}`
+            - consul-k8s: `${{ env.NEW_CONSUL_K8S_REQ }}`
+          create_branch: true

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -13,8 +13,7 @@ project "consul-api-gateway" {
 }
 
 event "merge" {
-  // "entrypoint" to use if build is not run automatically
-  // i.e. send "merge" complete signal to orchestrator to trigger build
+  // "entrypoint" to use if build is not run automatically i.e. send "merge" complete signal to orchestrator to trigger build
 }
 
 event "build" {
@@ -112,8 +111,7 @@ event "promote-dev-docker" {
 ## they should be added to the end of the file after the verify event stanza.
 
 event "trigger-staging" {
-// This event is dispatched by the bob trigger-promotion command
-// and is required - do not delete.
+// This event is dispatched by the bob trigger-promotion command and is required - do not delete.
 }
 
 event "promote-staging" {
@@ -144,8 +142,7 @@ event "promote-staging-docker" {
 }
 
 event "trigger-production" {
-// This event is dispatched by the bob trigger-promotion command
-// and is required - do not delete.
+// This event is dispatched by the bob trigger-promotion command and is required - do not delete.
 }
 
 event "promote-production" {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## UNRELEASED
 
-IMPROVEMENTS:
-
-* go: build with Go 1.18 [[GH-167](https://github.com/hashicorp/consul-api-gateway/issues/167)]
-
 ## 0.2.1 (April 29, 2022)
 
 BUG FIXES:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ endif
 ifeq (, $(LAST_RELEASE_GIT_TAG))
 	@echo "Please set the LAST_RELEASE_GIT_TAG environment variable to generate a changelog section of notes since the last release."
 else
-	changelog-build -last-release ${LAST_RELEASE_GIT_TAG} -entries-dir .changelog/ -changelog-template .changelog/changelog.tmpl -note-template .changelog/release-note.tmpl -this-release $(shell git rev-parse HEAD)
+	@changelog-build -last-release ${LAST_RELEASE_GIT_TAG} -entries-dir .changelog/ -changelog-template .changelog/changelog.tmpl -note-template .changelog/release-note.tmpl -this-release $(shell git rev-parse HEAD)
 endif
 
 .PHONY: changelog-entry


### PR DESCRIPTION
### Changes proposed in this PR:
Instead of requiring the host of manual updates that we do today, we can just kick off an Actions workflow to make the changes and create a PR for us.

### How I've tested this PR:
Temporarily triggered on push of this branch.
[Example branch this action creates](https://github.com/hashicorp/consul-api-gateway/compare/prepare-release-workflow...v0.3.0-release-prep?expand=1)

> **Note**: I previously had this script creating a PR for the resulting branch; however, Actions is now configured in a way that [blocks PR creation](https://github.blog/changelog/2022-05-03-github-actions-prevent-github-actions-from-creating-and-approving-pull-requests/) 😢 . As a result, you need to run the action and then get the link from the "Create branch" step output.

### How I expect reviewers to test this PR:
Review resulting branch linked above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
