### PR TITLE
Bug: LoadBalancers - Use Hostnames in addition to IP

### DIFF
--- a/.changelog/187.txt
+++ b/.changelog/187.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+k8s/reconciler: gateway addresses have invalid empty string when LoadBalancer services use a hostname for ExternalIP (like EKS)
+```

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -187,8 +187,14 @@ func (g *K8sGateway) assignGatewayIPFromServiceIngress(ctx context.Context, serv
 	}
 
 	for _, ingress := range updated.Status.LoadBalancer.Ingress {
-		g.serviceReady = true
-		g.addresses = append(g.addresses, ingress.IP)
+		if ingress.IP != "" {
+			g.serviceReady = true
+			g.addresses = append(g.addresses, ingress.IP)
+		}
+		if ingress.Hostname != "" {
+			g.serviceReady = true
+			g.addresses = append(g.addresses, ingress.Hostname)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Changes proposed in this PR:

This adds hostname values to addresses for a loadbalancer. In particular this is necessary for AWS EKS. In EKS LoadBalancers get "ExternalP" values that aren't actually IP addresses, but rather are hostnames. This is accounted for in the underlying `Service.Status.LoadBalancer.Ingress[*].Hostname` fields.

The problem is two-fold. In EKS LoadBalancer have hostnames rather than ips, so we:

1. Were never getting a valid ExternalIP value for the gateway address, and
2. Since we didn't have an empty string check on the IP, were attempting to append an empty value onto the gateway addresses.

This was resulting in the following error:

```
2022-04-29T03:20:58.298Z [ERROR] k8s/logger.go:23: consul-api-gateway-server.controller-runtime.controller.gateway: Reconciler error: name=selling-fears-gateway namespace=default reconciler group=gateway.networking.k8s.io reconciler kind=Gateway
  error=
  | 1 error occurred:
  | 	* Gateway.gateway.networking.k8s.io "selling-fears-gateway" is invalid: status.addresses.value: Invalid value: "": status.addresses.value in body should be at least 1 chars long
```

The fix is to:

1. Guard all of our address appending with an empty string check, and
2. Use both IP and Hostname values for any LoadBalancer ingress

### How I've tested this PR:
Unit tests and verified the bug and fix on EKS with a test image pushed to `public.ecr.aws/d1c7c4d0/testing123:1`.