### PR TITLE
ci: update binary build Go version to 1.18.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         goos: ["linux"]
         goarch: ["arm", "arm64", "386", "amd64"]
-        go: ["1.17.9"]
+        go: ["1.18.1"]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build


### PR DESCRIPTION
Refs https://github.com/hashicorp/consul-api-gateway/pull/167#issuecomment-1115079861 (which already added a changelog entry for this)