### PR TITLE
conformance: specify consul-k8s-control-plane:latest

### DIFF
--- a/internal/testing/conformance/consul-config.yaml
+++ b/internal/testing/conformance/consul-config.yaml
@@ -1,4 +1,5 @@
 global:
+  imageK8S: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
   tls:
     enabled: true
 server:


### PR DESCRIPTION
### Changes proposed in this PR:
Specify `consul-k8s-control-plane:latest` image to support installing from Consul Helm chart main branch.

### How I've tested this PR:
Running conformance tests, which have been failing in the setup steps (`consul-controller` and `conect-inject-controller` pods never become healthy) with `Parsing flagset: flag provided but not defined: -consul-api-timeout` due to changes in the `main` branch of the Consul Helm chart but `imageK8s` defaulting to [`0.43.0`](https://github.com/hashicorp/consul-k8s/blob/dc7f08965c01d2180813d0d83539a49bcc60a7d3/charts/consul/values.yaml#L110) still.

### How I expect reviewers to test this PR:
Confirm that conformance tests are able to deploy Consul from the Helm chart successfully, and reach _expected_ failures in ReferencePolicy conformance test suite.

### Checklist:
- [ ] ~~Tests added~~
- [ ] ~~CHANGELOG entry added~~
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
