### PR TITLE
store: remove route from listener when not able to bind

### DIFF
--- a/.changelog/197.txt
+++ b/.changelog/197.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Clean up stale routes from gateway listeners when not able or allowed to bind, to prevent serving traffic for a detached route.
+```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul-api-gateway
 
-go 1.17
+go 1.18
 
 require (
 	github.com/armon/go-metrics v0.3.9
@@ -18,6 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.0
 	github.com/vladimirvivien/gexe v0.1.1
+	golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.40.0
@@ -99,7 +100,7 @@ require (
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -939,6 +939,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf h1:oXVg4h2qJDd9htKxb5SCpFBHLipW6hXmL3qpUixS2jw=
+golang.org/x/exp v0.0.0-20220518171630-0b5c67f07fdf/go.mod h1:yh0Ynu2b5ZUe3MQfp2nM0ecK7wsgouWTDN0FNeJuIys=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1143,6 +1145,8 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -1789,20 +1788,20 @@ func checkRoute(t *testing.T, port int, path, expected string, headers map[strin
 		}
 
 		resp, err := client.Do(req)
-		log.Print("RESPONSE_ERR: ", err)
 		if err != nil {
+			t.Log(err)
 			return false
 		}
 		defer resp.Body.Close()
 
 		data, err := io.ReadAll(resp.Body)
-		log.Print("READALL_DATA: ", string(data))
-		log.Print("READALL_ERR: ", err)
 		if err != nil {
+			t.Log(err)
 			return false
 		}
+		t.Log(string(data))
 
-		log.Print("STATUS_CODE: ", resp.StatusCode)
+		t.Log("status code", resp.StatusCode)
 		if resp.StatusCode != http.StatusOK {
 			return false
 		}
@@ -1845,15 +1844,16 @@ func checkTCPRoute(t *testing.T, port int, expected string, exact bool, message 
 			Port: port,
 		})
 		if err != nil {
-			log.Print("TCP_DIAL_ERROR: ", err)
+			t.Log(err)
 			return false
 		}
 		data, err := io.ReadAll(conn)
 		if err != nil {
-			log.Print("TCP_READALL_ERROR: ", err)
+			t.Log(err)
 			return false
 		}
-		log.Print("TCP_READALL_DATA: ", string(data))
+		t.Log(string(data))
+
 		if exact {
 			return string(data) == expected
 		} else {

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -1426,13 +1426,12 @@ func TestRouteParentRefChange(t *testing.T) {
 				if err := resources.Get(ctx, httpRouteName, namespace, updated); err != nil {
 					return false
 				}
-				firstGatewayParentRefFound := false
 				for _, status := range updated.Status.Parents {
 					if string(status.ParentRef.Name) == firstGatewayName {
-						firstGatewayParentRefFound = true
+						return false
 					}
 				}
-				return !firstGatewayParentRefFound
+				return true
 			}, checkTimeout, checkInterval, "HTTPRoute status not unset in allotted time")
 
 			assert.NoError(t, resources.Delete(ctx, firstGateway))

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -1266,54 +1266,9 @@ func TestRouteParentRefChange(t *testing.T) {
 
 			namespace := e2e.Namespace(ctx)
 			gwNamespace := gateway.Namespace(namespace)
-			configName := envconf.RandomName("gcc", 16)
-			className := envconf.RandomName("gc", 16)
 			resources := cfg.Client().Resources(namespace)
 
-			gcc := &apigwv1alpha1.GatewayClassConfig{
-				ObjectMeta: meta.ObjectMeta{
-					Name: configName,
-				},
-				Spec: apigwv1alpha1.GatewayClassConfigSpec{
-					ImageSpec: apigwv1alpha1.ImageSpec{
-						ConsulAPIGateway: e2e.DockerImage(ctx),
-					},
-					ServiceType:  serviceType(core.ServiceTypeNodePort),
-					UseHostPorts: true,
-					LogLevel:     "trace",
-					ConsulSpec: apigwv1alpha1.ConsulSpec{
-						Address: hostRoute,
-						Scheme:  "https",
-						PortSpec: apigwv1alpha1.PortSpec{
-							GRPC: e2e.ConsulGRPCPort(ctx),
-							HTTP: e2e.ConsulHTTPPort(ctx),
-						},
-						AuthSpec: apigwv1alpha1.AuthSpec{
-							Method:  "consul-api-gateway",
-							Account: "consul-api-gateway",
-						},
-					},
-				},
-			}
-			err = resources.Create(ctx, gcc)
-			require.NoError(t, err)
-
-			gc := &gateway.GatewayClass{
-				ObjectMeta: meta.ObjectMeta{
-					Name: className,
-				},
-				Spec: gateway.GatewayClassSpec{
-					ControllerName: k8s.ControllerName,
-					ParametersRef: &gateway.ParametersReference{
-						Group: apigwv1alpha1.Group,
-						Kind:  apigwv1alpha1.GatewayClassConfigKind,
-						Name:  configName,
-					},
-				},
-			}
-			err = resources.Create(ctx, gc)
-			require.NoError(t, err)
-
+			_, gc := createGatewayClass(ctx, t, resources)
 			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			// Create a Gateway and wait for it to be ready
@@ -1322,7 +1277,7 @@ func TestRouteParentRefChange(t *testing.T) {
 			firstGateway := createGateway(
 				ctx,
 				t,
-				cfg,
+				resources,
 				firstGatewayName,
 				gc,
 				[]gateway.Listener{createHTTPSListener(ctx, t, gateway.PortNumber(firstGatewayCheckPort))},
@@ -1387,7 +1342,7 @@ func TestRouteParentRefChange(t *testing.T) {
 			secondGateway := createGateway(
 				ctx,
 				t,
-				cfg,
+				resources,
 				secondGatewayName,
 				gc,
 				[]gateway.Listener{createHTTPSListener(ctx, t, gateway.PortNumber(secondGatewayCheckPort))},

--- a/internal/store/memory/gateway.go
+++ b/internal/store/memory/gateway.go
@@ -60,6 +60,7 @@ func (g *gatewayState) TryBind(ctx context.Context, route store.Route) {
 			if err != nil {
 				// consider each route distinct for the purposes of binding
 				g.logger.Debug("error binding route to gateway", "error", err, "route", route.ID())
+				l.RemoveRoute(route.ID())
 				bindError = multierror.Append(bindError, err)
 			}
 			if canBind {

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -83,21 +83,23 @@ func init() {
 }
 
 type consulTestEnvironment struct {
-	ca                      []byte
-	consulClient            *api.Client
-	token                   string
-	policy                  *api.ACLPolicy
-	httpPort                int
-	httpFlattenedPort       int
-	httpReferencePolicyPort int
-	tcpReferencePolicyPort  int
-	grpcPort                int
-	extraHTTPPort           int
-	extraTCPPort            int
-	extraTCPTLSPort         int
-	extraTCPTLSPortTwo      int
-	namespace               string
-	ip                      string
+	ca                               []byte
+	consulClient                     *api.Client
+	token                            string
+	policy                           *api.ACLPolicy
+	httpPort                         int
+	httpFlattenedPort                int
+	httpReferencePolicyPort          int
+	tcpReferencePolicyPort           int
+	parentRefChangeFirstGatewayPort  int
+	parentRefChangeSecondGatewayPort int
+	grpcPort                         int
+	extraHTTPPort                    int
+	extraTCPPort                     int
+	extraTCPTLSPort                  int
+	extraTCPTLSPortTwo               int
+	namespace                        string
+	ip                               string
 }
 
 func CreateTestConsulContainer(name, namespace string) env.Func {
@@ -113,6 +115,8 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 		httpFlattenedPort := cluster.httpsFlattenedPort
 		httpReferencePolicyPort := cluster.httpsReferencePolicyPort
 		tcpReferencePolicyPort := cluster.tcpReferencePolicyPort
+		parentRefChangeFirstGatewayPort := cluster.parentRefChangeFirstGatewayPort
+		parentRefChangeSecondGatewayPort := cluster.parentRefChangeSecondGatewayPort
 		grpcPort := cluster.grpcPort
 		extraTCPPort := cluster.extraTCPPort
 		extraTCPTLSPort := cluster.extraTCPTLSPort
@@ -201,18 +205,20 @@ func CreateTestConsulContainer(name, namespace string) env.Func {
 		}
 
 		env := &consulTestEnvironment{
-			ca:                      rootCA.CertBytes,
-			consulClient:            consulClient,
-			httpPort:                httpsPort,
-			httpFlattenedPort:       httpFlattenedPort,
-			httpReferencePolicyPort: httpReferencePolicyPort,
-			tcpReferencePolicyPort:  tcpReferencePolicyPort,
-			grpcPort:                grpcPort,
-			extraHTTPPort:           extraHTTPPort,
-			extraTCPPort:            extraTCPPort,
-			extraTCPTLSPort:         extraTCPTLSPort,
-			extraTCPTLSPortTwo:      extraTCPTLSPortTwo,
-			ip:                      ip,
+			ca:                               rootCA.CertBytes,
+			consulClient:                     consulClient,
+			httpPort:                         httpsPort,
+			httpFlattenedPort:                httpFlattenedPort,
+			httpReferencePolicyPort:          httpReferencePolicyPort,
+			tcpReferencePolicyPort:           tcpReferencePolicyPort,
+			parentRefChangeFirstGatewayPort:  parentRefChangeFirstGatewayPort,
+			parentRefChangeSecondGatewayPort: parentRefChangeSecondGatewayPort,
+			grpcPort:                         grpcPort,
+			extraHTTPPort:                    extraHTTPPort,
+			extraTCPPort:                     extraTCPPort,
+			extraTCPTLSPort:                  extraTCPTLSPort,
+			extraTCPTLSPortTwo:               extraTCPTLSPortTwo,
+			ip:                               ip,
 		}
 
 		return context.WithValue(ctx, consulTestContextKey, env), nil
@@ -507,6 +513,22 @@ func TCPReferencePolicyPort(ctx context.Context) int {
 		panic("must run this with an integration test that has called CreateTestConsul")
 	}
 	return consulEnvironment.(*consulTestEnvironment).tcpReferencePolicyPort
+}
+
+func ParentRefChangeFirstGatewayPort(ctx context.Context) int {
+	consulEnvironment := ctx.Value(consulTestContextKey)
+	if consulEnvironment == nil {
+		panic("must run this with an integration test that has called CreateTestConsul")
+	}
+	return consulEnvironment.(*consulTestEnvironment).parentRefChangeFirstGatewayPort
+}
+
+func ParentRefChangeSecondGatewayPort(ctx context.Context) int {
+	consulEnvironment := ctx.Value(consulTestContextKey)
+	if consulEnvironment == nil {
+		panic("must run this with an integration test that has called CreateTestConsul")
+	}
+	return consulEnvironment.(*consulTestEnvironment).parentRefChangeSecondGatewayPort
 }
 
 func ConsulHTTPPort(ctx context.Context) int {

--- a/internal/testing/e2e/kind.go
+++ b/internal/testing/e2e/kind.go
@@ -46,6 +46,12 @@ nodes:
   - containerPort: {{ .TCPReferencePolicyPort }}
     hostPort: {{ .TCPReferencePolicyPort }}
     protocol: TCP
+  - containerPort: {{ .ParentRefChangeFirstGatewayPort }}
+    hostPort: {{ .ParentRefChangeFirstGatewayPort }}
+    protocol: TCP
+  - containerPort: {{ .ParentRefChangeSecondGatewayPort }}
+    hostPort: {{ .ParentRefChangeSecondGatewayPort }}
+    protocol: TCP
   - containerPort: {{ .GRPCPort }}
     hostPort: {{ .GRPCPort }}
     protocol: TCP
@@ -72,35 +78,39 @@ func init() {
 
 // based off github.com/kubernetes-sigs/e2e-framework/support/kind
 type kindCluster struct {
-	name                     string
-	e                        *gexe.Echo
-	kubecfgFile              string
-	config                   string
-	httpsPort                int
-	httpsFlattenedPort       int
-	httpsReferencePolicyPort int
-	tcpReferencePolicyPort   int
-	grpcPort                 int
-	extraHTTPPort            int
-	extraTCPPort             int
-	extraTCPTLSPort          int
-	extraTCPTLSPortTwo       int
+	name                             string
+	e                                *gexe.Echo
+	kubecfgFile                      string
+	config                           string
+	httpsPort                        int
+	httpsFlattenedPort               int
+	httpsReferencePolicyPort         int
+	tcpReferencePolicyPort           int
+	parentRefChangeFirstGatewayPort  int
+	parentRefChangeSecondGatewayPort int
+	grpcPort                         int
+	extraHTTPPort                    int
+	extraTCPPort                     int
+	extraTCPTLSPort                  int
+	extraTCPTLSPortTwo               int
 }
 
 func newKindCluster(name string) *kindCluster {
-	ports := freeport.MustTake(9)
+	ports := freeport.MustTake(11)
 	return &kindCluster{
-		name:                     name,
-		e:                        gexe.New(),
-		httpsPort:                ports[0],
-		httpsFlattenedPort:       ports[1],
-		httpsReferencePolicyPort: ports[2],
-		tcpReferencePolicyPort:   ports[3],
-		grpcPort:                 ports[4],
-		extraHTTPPort:            ports[5],
-		extraTCPPort:             ports[6],
-		extraTCPTLSPort:          ports[7],
-		extraTCPTLSPortTwo:       ports[8],
+		name:                             name,
+		e:                                gexe.New(),
+		httpsPort:                        ports[0],
+		httpsFlattenedPort:               ports[1],
+		httpsReferencePolicyPort:         ports[2],
+		tcpReferencePolicyPort:           ports[3],
+		parentRefChangeFirstGatewayPort:  ports[4],
+		parentRefChangeSecondGatewayPort: ports[5],
+		grpcPort:                         ports[6],
+		extraHTTPPort:                    ports[7],
+		extraTCPPort:                     ports[8],
+		extraTCPTLSPort:                  ports[9],
+		extraTCPTLSPortTwo:               ports[10],
 	}
 }
 
@@ -109,25 +119,29 @@ func (k *kindCluster) Create() (string, error) {
 
 	var kindConfig bytes.Buffer
 	err := kindTemplate.Execute(&kindConfig, &struct {
-		HTTPSPort                int
-		HTTPSFlattenedPort       int
-		HTTPSReferencePolicyPort int
-		TCPReferencePolicyPort   int
-		GRPCPort                 int
-		ExtraTCPPort             int
-		ExtraTCPTLSPort          int
-		ExtraTCPTLSPortTwo       int
-		ExtraHTTPPort            int
+		HTTPSPort                        int
+		HTTPSFlattenedPort               int
+		HTTPSReferencePolicyPort         int
+		TCPReferencePolicyPort           int
+		ParentRefChangeFirstGatewayPort  int
+		ParentRefChangeSecondGatewayPort int
+		GRPCPort                         int
+		ExtraTCPPort                     int
+		ExtraTCPTLSPort                  int
+		ExtraTCPTLSPortTwo               int
+		ExtraHTTPPort                    int
 	}{
-		HTTPSPort:                k.httpsPort,
-		HTTPSFlattenedPort:       k.httpsFlattenedPort,
-		HTTPSReferencePolicyPort: k.httpsReferencePolicyPort,
-		TCPReferencePolicyPort:   k.tcpReferencePolicyPort,
-		GRPCPort:                 k.grpcPort,
-		ExtraTCPPort:             k.extraTCPPort,
-		ExtraTCPTLSPort:          k.extraTCPTLSPort,
-		ExtraTCPTLSPortTwo:       k.extraTCPTLSPortTwo,
-		ExtraHTTPPort:            k.extraHTTPPort,
+		HTTPSPort:                        k.httpsPort,
+		HTTPSFlattenedPort:               k.httpsFlattenedPort,
+		HTTPSReferencePolicyPort:         k.httpsReferencePolicyPort,
+		TCPReferencePolicyPort:           k.tcpReferencePolicyPort,
+		ParentRefChangeFirstGatewayPort:  k.parentRefChangeFirstGatewayPort,
+		ParentRefChangeSecondGatewayPort: k.parentRefChangeSecondGatewayPort,
+		GRPCPort:                         k.grpcPort,
+		ExtraTCPPort:                     k.extraTCPPort,
+		ExtraTCPTLSPort:                  k.extraTCPTLSPort,
+		ExtraTCPTLSPortTwo:               k.extraTCPTLSPortTwo,
+		ExtraHTTPPort:                    k.extraHTTPPort,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
### Changes proposed in this PR:
Removes a route from a listener if it fails to bind when reconciling. Fixes an issue where deleting a ReferencePolicy would update the route status, but the stale route would not be removed from the gateway listener.

As an aside, the `(bool, error)` return of `CanBind` seems redundant and makes it prone to misuse - should it be changed to just one of those values instead of the tuple?

### How I've tested this PR:
- [x] Add checks for gateway listener status `attachedRoutes` after deleting ReferencePolicy in e2e test
- [x] Add checks for TCP and HTTP connection errors after deleting ReferencePolicy in e2e test
- [x] Add e2e test for switching route binding from one gateway to another

### How I expect reviewers to test this PR:
- Review the test additions/changes.
- Confirm that a gateway removes a stale route and stops routing traffic after a route is invalidated by being modified or having a ReferencePolicy that affects it deleted.
- The `checkRouteError` function and only looking for an empty string TCP response feel like quite crude checks, is there a better way to handle these?
- `TestRouteParentRefChange` contains the checks/assertions that are _currently_ working as expected - I believe there's a _different_ bug here still preventing some functionality from working as expected, but punted further exploration of that out to https://github.com/hashicorp/consul-api-gateway/pull/200
- The debug logging I added in the helper funcs was quite helpful and I'm leaning towards wanting to keep it somehow, should it be switched to something like `t.Log` instead though?

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
