### PR TITLE
e2e: fixup checkGatewayConfigAnnotation and clean up TestGatewayWithClassConfigChange

### DIFF
--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -927,7 +927,6 @@ func TestReferencePolicyLifecycle(t *testing.T) {
 
 			resources := cfg.Client().Resources(namespace)
 
-			// Create a GatewayClassConfig
 			_, gc := createGatewayClass(ctx, t, cfg, 1)
 			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
 

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -679,8 +679,6 @@ func TestTCPMeshService(t *testing.T) {
 			require.NoError(t, err)
 
 			namespace := e2e.Namespace(ctx)
-			configName := envconf.RandomName("gcc", 16)
-			className := envconf.RandomName("gc", 16)
 			gatewayName := envconf.RandomName("gw", 16)
 			routeOneName := envconf.RandomName("route", 16)
 			routeTwoName := envconf.RandomName("route", 16)
@@ -699,49 +697,7 @@ func TestTCPMeshService(t *testing.T) {
 				},
 			}))
 
-			gcc := &apigwv1alpha1.GatewayClassConfig{
-				ObjectMeta: meta.ObjectMeta{
-					Name: configName,
-				},
-				Spec: apigwv1alpha1.GatewayClassConfigSpec{
-					ImageSpec: apigwv1alpha1.ImageSpec{
-						ConsulAPIGateway: e2e.DockerImage(ctx),
-					},
-					ServiceType:  serviceType(core.ServiceTypeNodePort),
-					UseHostPorts: true,
-					LogLevel:     "trace",
-					ConsulSpec: apigwv1alpha1.ConsulSpec{
-						Address: hostRoute,
-						Scheme:  "https",
-						PortSpec: apigwv1alpha1.PortSpec{
-							GRPC: e2e.ConsulGRPCPort(ctx),
-							HTTP: e2e.ConsulHTTPPort(ctx),
-						},
-						AuthSpec: apigwv1alpha1.AuthSpec{
-							Method:  "consul-api-gateway",
-							Account: "consul-api-gateway",
-						},
-					},
-				},
-			}
-			err = resources.Create(ctx, gcc)
-			require.NoError(t, err)
-
-			gc := &gateway.GatewayClass{
-				ObjectMeta: meta.ObjectMeta{
-					Name: className,
-				},
-				Spec: gateway.GatewayClassSpec{
-					ControllerName: k8s.ControllerName,
-					ParametersRef: &gateway.ParametersReference{
-						Group: apigwv1alpha1.Group,
-						Kind:  apigwv1alpha1.GatewayClassConfigKind,
-						Name:  configName,
-					},
-				},
-			}
-			err = resources.Create(ctx, gc)
-			require.NoError(t, err)
+			_, gc := createGatewayClass(ctx, t, cfg, 1)
 
 			gw := &gateway.Gateway{
 				ObjectMeta: meta.ObjectMeta{
@@ -856,8 +812,6 @@ func TestTCPMeshService(t *testing.T) {
 			require.NoError(t, err)
 
 			namespace := e2e.Namespace(ctx)
-			configName := envconf.RandomName("gcc", 16)
-			className := envconf.RandomName("gc", 16)
 			gatewayName := envconf.RandomName("gw", 16)
 			routeOneName := envconf.RandomName("route", 16)
 			routeTwoName := envconf.RandomName("route", 16)
@@ -869,49 +823,7 @@ func TestTCPMeshService(t *testing.T) {
 			gatewayNamespace := gateway.Namespace(namespace)
 			resources := cfg.Client().Resources(namespace)
 
-			gcc := &apigwv1alpha1.GatewayClassConfig{
-				ObjectMeta: meta.ObjectMeta{
-					Name: configName,
-				},
-				Spec: apigwv1alpha1.GatewayClassConfigSpec{
-					ImageSpec: apigwv1alpha1.ImageSpec{
-						ConsulAPIGateway: e2e.DockerImage(ctx),
-					},
-					ServiceType:  serviceType(core.ServiceTypeNodePort),
-					UseHostPorts: true,
-					LogLevel:     "trace",
-					ConsulSpec: apigwv1alpha1.ConsulSpec{
-						Address: hostRoute,
-						Scheme:  "https",
-						PortSpec: apigwv1alpha1.PortSpec{
-							GRPC: e2e.ConsulGRPCPort(ctx),
-							HTTP: e2e.ConsulHTTPPort(ctx),
-						},
-						AuthSpec: apigwv1alpha1.AuthSpec{
-							Method:  "consul-api-gateway",
-							Account: "consul-api-gateway",
-						},
-					},
-				},
-			}
-			err = resources.Create(ctx, gcc)
-			require.NoError(t, err)
-
-			gc := &gateway.GatewayClass{
-				ObjectMeta: meta.ObjectMeta{
-					Name: className,
-				},
-				Spec: gateway.GatewayClassSpec{
-					ControllerName: k8s.ControllerName,
-					ParametersRef: &gateway.ParametersReference{
-						Group: apigwv1alpha1.Group,
-						Kind:  apigwv1alpha1.GatewayClassConfigKind,
-						Name:  configName,
-					},
-				},
-			}
-			err = resources.Create(ctx, gc)
-			require.NoError(t, err)
+			_, gc := createGatewayClass(ctx, t, cfg, 1)
 
 			gw := &gateway.Gateway{
 				ObjectMeta: meta.ObjectMeta{

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -73,7 +73,7 @@ func TestGatewayWithClassConfigChange(t *testing.T) {
 			firstConfig, gc := createGatewayClassWithParams(ctx, t, resources, GatewayClassConfigParams{
 				UseHostPorts: &useHostPorts,
 			})
-			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			oldUseHostPorts := firstConfig.Spec.UseHostPorts
 
@@ -204,7 +204,7 @@ func TestGatewayBasic(t *testing.T) {
 			gcc, gc := createGatewayClassWithParams(ctx, t, resources, GatewayClassConfigParams{
 				UseHostPorts: &useHostPorts,
 			})
-			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			httpsListener := createHTTPSListener(ctx, t, 443)
 			gw := createGateway(ctx, t, resources, gatewayName, gc, []gateway.Listener{httpsListener})
@@ -267,7 +267,7 @@ func TestServiceListeners(t *testing.T) {
 			_, gc := createGatewayClassWithParams(ctx, t, resources, GatewayClassConfigParams{
 				UseHostPorts: &useHostPorts,
 			})
-			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			httpsListener := createHTTPSListener(ctx, t, 443)
 			gw := createGateway(ctx, t, resources, gatewayName, gc, []gateway.Listener{httpsListener})
@@ -329,7 +329,7 @@ func TestHTTPRouteFlattening(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			_, gc := createGatewayClass(ctx, t, resources)
-			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			checkPort := e2e.HTTPFlattenedPort(ctx)
 			httpsListener := createHTTPSListener(ctx, t, gateway.PortNumber(checkPort))
@@ -456,7 +456,7 @@ func TestHTTPMeshService(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			_, gc := createGatewayClass(ctx, t, resources)
-			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			httpsListener := createHTTPSListener(ctx, t, gateway.PortNumber(e2e.HTTPPort(ctx)))
 			gw := createGateway(ctx, t, resources, gatewayName, gc, []gateway.Listener{httpsListener})
@@ -674,7 +674,7 @@ func TestTCPMeshService(t *testing.T) {
 			}))
 
 			_, gc := createGatewayClass(ctx, t, resources)
-			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			gw := &gateway.Gateway{
 				ObjectMeta: meta.ObjectMeta{
@@ -801,7 +801,7 @@ func TestTCPMeshService(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			_, gc := createGatewayClass(ctx, t, resources)
-			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			gw := &gateway.Gateway{
 				ObjectMeta: meta.ObjectMeta{
@@ -906,7 +906,7 @@ func TestReferencePolicyLifecycle(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			_, gc := createGatewayClass(ctx, t, resources)
-			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			httpCheckPort := e2e.HTTPReferencePolicyPort(ctx)
 			tcpCheckPort := e2e.TCPReferencePolicyPort(ctx)

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -345,8 +345,6 @@ func TestHTTPRouteFlattening(t *testing.T) {
 			require.NoError(t, err)
 
 			namespace := e2e.Namespace(ctx)
-			configName := envconf.RandomName("gcc", 16)
-			className := envconf.RandomName("gc", 16)
 			gatewayName := envconf.RandomName("gw", 16)
 			routeOneName := envconf.RandomName("route", 16)
 			routeTwoName := envconf.RandomName("route", 16)
@@ -356,48 +354,7 @@ func TestHTTPRouteFlattening(t *testing.T) {
 
 			resources := cfg.Client().Resources(namespace)
 
-			gcc := &apigwv1alpha1.GatewayClassConfig{
-				ObjectMeta: meta.ObjectMeta{
-					Name: configName,
-				},
-				Spec: apigwv1alpha1.GatewayClassConfigSpec{
-					ImageSpec: apigwv1alpha1.ImageSpec{
-						ConsulAPIGateway: e2e.DockerImage(ctx),
-					},
-					UseHostPorts: true,
-					LogLevel:     "trace",
-					ConsulSpec: apigwv1alpha1.ConsulSpec{
-						Address: hostRoute,
-						Scheme:  "https",
-						PortSpec: apigwv1alpha1.PortSpec{
-							GRPC: e2e.ConsulGRPCPort(ctx),
-							HTTP: e2e.ConsulHTTPPort(ctx),
-						},
-						AuthSpec: apigwv1alpha1.AuthSpec{
-							Method:  "consul-api-gateway",
-							Account: "consul-api-gateway",
-						},
-					},
-				},
-			}
-			err = resources.Create(ctx, gcc)
-			require.NoError(t, err)
-
-			gc := &gateway.GatewayClass{
-				ObjectMeta: meta.ObjectMeta{
-					Name: className,
-				},
-				Spec: gateway.GatewayClassSpec{
-					ControllerName: k8s.ControllerName,
-					ParametersRef: &gateway.ParametersReference{
-						Group: apigwv1alpha1.Group,
-						Kind:  apigwv1alpha1.GatewayClassConfigKind,
-						Name:  configName,
-					},
-				},
-			}
-			err = resources.Create(ctx, gc)
-			require.NoError(t, err)
+			_, gc := createGatewayClass(ctx, t, cfg, 1)
 
 			checkPort := e2e.HTTPFlattenedPort(ctx)
 			httpsListener := createHTTPSListener(ctx, t, gateway.PortNumber(checkPort))

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -121,7 +121,9 @@ func TestGatewayWithReplicas(t *testing.T) {
 
 			var numberOfReplicas int32 = 3
 
+			useHostPorts := false
 			gcc, gc := createGatewayClassWithParams(ctx, t, resources, GatewayClassConfigParams{
+				UseHostPorts:     &useHostPorts,
 				DefaultInstances: &numberOfReplicas,
 			})
 			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
@@ -156,7 +158,9 @@ func TestGatewayWithReplicasCanScale(t *testing.T) {
 			var initialReplicas int32 = 3
 			var finalReplicas int32 = 8
 
+			useHostPorts := false
 			gcc, gc := createGatewayClassWithParams(ctx, t, resources, GatewayClassConfigParams{
+				UseHostPorts:     &useHostPorts,
 				DefaultInstances: &initialReplicas,
 			})
 			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -225,13 +225,9 @@ func TestGatewayBasic(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			gatewayName := envconf.RandomName("gw", 16)
-			gcc, gc := createGatewayClass(ctx, t, cfg, 1)
 
-			require.Eventually(t, func() bool {
-				created := &gateway.GatewayClass{}
-				err := resources.Get(ctx, gc.Name, "", created)
-				return err == nil && conditionAccepted(created.Status.Conditions)
-			}, checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
+			gcc, gc := createGatewayClass(ctx, t, cfg, 1)
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			httpsListener := createHTTPSListener(ctx, t, 443)
 			_ = createGateway(ctx, t, cfg, gatewayName, gc, []gateway.Listener{httpsListener})
@@ -293,7 +289,9 @@ func TestServiceListeners(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			gatewayName := envconf.RandomName("gw", 16)
+
 			_, gc := createGatewayClass(ctx, t, cfg, 1)
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			httpsListener := createHTTPSListener(ctx, t, 443)
 			gw := createGateway(ctx, t, cfg, gatewayName, gc, []gateway.Listener{httpsListener})
@@ -355,6 +353,7 @@ func TestHTTPRouteFlattening(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			_, gc := createGatewayClass(ctx, t, cfg, 1)
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			checkPort := e2e.HTTPFlattenedPort(ctx)
 			httpsListener := createHTTPSListener(ctx, t, gateway.PortNumber(checkPort))
@@ -481,6 +480,7 @@ func TestHTTPMeshService(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			_, gc := createGatewayClass(ctx, t, cfg, 1)
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			httpsListener := createHTTPSListener(ctx, t, gateway.PortNumber(e2e.HTTPPort(ctx)))
 			gw := createGateway(ctx, t, cfg, gatewayName, gc, []gateway.Listener{httpsListener})
@@ -698,6 +698,7 @@ func TestTCPMeshService(t *testing.T) {
 			}))
 
 			_, gc := createGatewayClass(ctx, t, cfg, 1)
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			gw := &gateway.Gateway{
 				ObjectMeta: meta.ObjectMeta{
@@ -824,6 +825,7 @@ func TestTCPMeshService(t *testing.T) {
 			resources := cfg.Client().Resources(namespace)
 
 			_, gc := createGatewayClass(ctx, t, cfg, 1)
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), 30*time.Second, checkInterval, "gatewayclass not accepted in the allotted time")
 
 			gw := &gateway.Gateway{
 				ObjectMeta: meta.ObjectMeta{


### PR DESCRIPTION
### Changes proposed in this PR:

- Refactor `checkGatewayConfigAnnotation` to get the gateway resource directly rather than relying on passing in an updated gateway resource as a side effect of a prior check.
- Fixes an incorrect assertion and removes substantial redundant checks from TestGatewayWithClassConfigChange
- Minor refactor to pass `resources.Resources` instead of `*envconf.Config` into `createGatewayClass` and `createGateway` helpers, clean up many tests to use these helpers when possible.

The motivation for this was stumbling over writing a new test with a similar two gateway setup - finding several redundant checks and spending too long figuring out why things weren't working as expected when deleting the verbose checks in favor of the streamlined helpers (the subsequent `checkGatewayConfigAnnotation` checks were dependent on a side effect from the verbose status check).

### How I've tested this PR:

Running the e2e tests. The following snippet was helpful for iterating more quickly:
```
go test ./... -tags e2e -v -failfast -run TestGatewayWithClassConfigChange
```

### How I expect reviewers to test this PR:

Confirm that these changes seem desirable.

### Checklist:
- [x] Tests added
- [ ] ~~CHANGELOG entry added~~
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
