### PR TITLE
fix listener and route behavior when changing ParentRef

### DIFF
--- a/.changelog/200.txt
+++ b/.changelog/200.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Clean up stale routes from gateway listeners which no longer reference the gateway.
+Clean up stale routes from gateway listeners when route no longer references the gateway.
 ```

--- a/.changelog/200.txt
+++ b/.changelog/200.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Clean up stale routes from gateway listeners which no longer reference the gateway.
+```

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -1391,7 +1391,6 @@ func TestRouteParentRefChange(t *testing.T) {
 				return true
 			}, checkTimeout, checkInterval, "HTTPRoute status not unset in allotted time")
 
-			// FIXME: why are attached routes not being pruned as expected in this case?
 			require.Eventually(t, listenerStatusCheck(
 				ctx,
 				resources,
@@ -1400,8 +1399,8 @@ func TestRouteParentRefChange(t *testing.T) {
 				listenerAttachedRoutes(0),
 			), checkTimeout, checkInterval, "listeners not ready in the allotted time")
 
-			// TODO: when implementation is updated, this should be refactored to check for a 404 status code
-			// instead of a connection error
+			// TODO: when implementation is updated, this should be refactored
+			// to check for a 404 status code instead of a connection error
 			checkRouteError(t, firstGatewayCheckPort, "/", nil, "service one still routable in allotted time")
 
 			assert.NoError(t, resources.Delete(ctx, firstGateway))

--- a/internal/store/memory/gateway.go
+++ b/internal/store/memory/gateway.go
@@ -76,6 +76,10 @@ func (g *gatewayState) TryBind(ctx context.Context, route store.Route) {
 				tracker.OnBound(g.Gateway)
 			}
 		}
+	} else {
+		// Clean up route from gateway listeners if ParentRef no longer
+		// references gateway
+		g.Remove(route.ID())
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this PR:

Fixes the following issue:
- [x] Prior gateway listener doesn't update `attachedRoutes` back to zero when last route removes a ParentRef for that gateway

Updates test to document currently-expected behavior but not fixed yet - after discussing with @nathancoleman we believe support for multiple gateways is not yet implemented rather than a "bug":
- [x] An HTTPRoute fails to route traffic from a second ParentRef gateway to a backend service (503 reponses with `no healthy upstream`) until the first ParentRef is removed
  - Traffic _does_ still route successfully through the first gateway after adding the second gateway ParentRef


### How I've tested this PR:

Written e2e test assertions that demonstrate broken behavior when changing the ParentRef of a route.

### How I expect reviewers to test this PR:

Confirm that new test assertions demonstrate intended functionality, review fixes.

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
