### PR TITLE
Trigger CRT workflows for main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,10 @@ jobs:
       - name: Remove + from version
         run: |
           echo "version=$(echo $version | sed 's/+ent//g')" >> $GITHUB_ENV
-      - name: Docker Build
+
+      - name: Docker Build (Release Branch)
         uses: hashicorp/actions-docker-build@v1
+        if: startsWith(github.ref, 'refs/heads/release/')
         with:
           version: ${{env.version}}
           target: default
@@ -118,5 +120,17 @@ jobs:
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
           dev_tags: |
-            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}-dev
-            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}-dev-${{github.sha}}
+            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}
+
+      - name: Docker Build (Main Branch)
+        uses: hashicorp/actions-docker-build@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          version: ${{env.version}}
+          target: default
+          arch: ${{matrix.arch}}
+          tags: |
+            docker.io/hashicorp/${{env.repo}}:${{env.version}}
+          dev_tags: |
+            docker.io/hashicorppreview/${{env.repo}}:main
+            docker.io/hashicorppreview/${{env.repo}}:${{github.sha}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: build
 
 on:
   push:
-    branches:    
+    branches:
+      - 'main'
       - 'release/**'
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,9 +110,8 @@ jobs:
         run: |
           echo "version=$(echo $version | sed 's/+ent//g')" >> $GITHUB_ENV
 
-      - name: Docker Build (Release Branch)
+      - name: Docker Build
         uses: hashicorp/actions-docker-build@v1
-        if: startsWith(github.ref, 'refs/heads/release/')
         with:
           version: ${{env.version}}
           target: default
@@ -120,18 +119,5 @@ jobs:
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
           dev_tags: |
-            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}
-
-      - name: Docker Build (Main Branch)
-        uses: hashicorp/actions-docker-build@v1
-        if: github.ref == 'refs/heads/main'
-        with:
-          version: ${{env.version}}
-          target: default
-          arch: ${{matrix.arch}}
-          # We don't expect this specific build from main to be promoted, but we must declare tags
-          tags: |
-            docker.io/hashicorp/${{env.repo}}:${{github.sha}}
-          dev_tags: |
-            docker.io/hashicorppreview/${{env.repo}}:main
-            docker.io/hashicorppreview/${{env.repo}}:${{github.sha}}
+            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}-dev
+            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}-${{github.sha}}-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Remove + from version
         run: |
           echo "version=$(echo $version | sed 's/+ent//g')" >> $GITHUB_ENV
-      - name: Docker Build (Action)
+      - name: Docker Build
         uses: hashicorp/actions-docker-build@v1
         with:
           version: ${{env.version}}
@@ -118,4 +118,5 @@ jobs:
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
           dev_tags: |
-            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}
+            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}-dev
+            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}-dev-${{github.sha}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,9 @@ jobs:
           version: ${{env.version}}
           target: default
           arch: ${{matrix.arch}}
+          # We don't expect this specific build from main to be promoted, but we must declare tags
           tags: |
-            docker.io/hashicorp/${{env.repo}}:${{env.version}}
+            docker.io/hashicorp/${{env.repo}}:${{github.sha}}
           dev_tags: |
             docker.io/hashicorppreview/${{env.repo}}:main
             docker.io/hashicorppreview/${{env.repo}}:${{github.sha}}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -3,7 +3,7 @@ schema = "1"
 project "consul-api-gateway" {
   team = "consul-api-gateway"
   slack {
-    notification_channel = "C01RWVBQ6GJ"
+    notification_channel = "C03BY5JVCKS"
   }
   github {
     organization = "hashicorp"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -8,7 +8,7 @@ project "consul-api-gateway" {
   github {
     organization = "hashicorp"
     repository = "consul-api-gateway"
-    release_branches = ["release/0.1.x", "release/0.2.x"]
+    release_branches = ["main", "release/0.1.x", "release/0.2.x"]
   }
 }
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ endif
 test:
 	go test ./...
 
+generate-golden-files:
+	GENERATE=true go test ./internal/envoy
+	GENERATE=true go test ./internal/k8s/builder
+
 .PHONY: changelog
 changelog:
 ifeq (, $(shell which changelog-build))

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -80,7 +80,7 @@ spec:
         - cp
         - /bin/consul-api-gateway
         - /bootstrap/consul-api-gateway
-        image: hashicorp/consul-api-gateway:0.2.1
+        image: hashicorp/consul-api-gateway:0.3.0
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -80,7 +80,7 @@ spec:
         - cp
         - /bin/consul-api-gateway
         - /bootstrap/consul-api-gateway
-        image: hashicorp/consul-api-gateway:0.2.1
+        image: hashicorp/consul-api-gateway:0.3.0
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -83,7 +83,7 @@ spec:
         - cp
         - /bin/consul-api-gateway
         - /bootstrap/consul-api-gateway
-        image: hashicorp/consul-api-gateway:0.2.1
+        image: hashicorp/consul-api-gateway:0.3.0
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -83,7 +83,7 @@ spec:
         - cp
         - /bin/consul-api-gateway
         - /bootstrap/consul-api-gateway
-        image: hashicorp/consul-api-gateway:0.2.1
+        image: hashicorp/consul-api-gateway:0.3.0
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.2.1"
+	Version = "0.3.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
### Changes proposed in this PR:
- Add `main` to the list of branches that trigger Common Release Tooling workflows. This will produce the `dev_tags` images of consul-api-gateway defined [here](https://github.com/hashicorp/consul-api-gateway/blob/c8dd3efb17fd62091d3baaac956380728f87a3d9/.github/workflows/build.yml#L120) onto hashicorppreview whenever we push commits to `main`. Matches what Consul is doing [here](https://github.com/hashicorp/consul/blob/74ca6406ea7569ad42e5c8ffb575b42e3e524238/.release/ci.hcl#L13).
- Change CRT notification target to different Slack channel where the additional noise created by merges to `main` won't interrupt our daily conversations.
- Publish mutable + immutable `dev_tags` so that we can always test with a specific image even after newer versions have been published. I used the naming patterns from Consul's hashicorppreview repo [here](https://hub.docker.com/r/hashicorppreview/consul/tags).
- Change `version.go` to reflect our next release, `0.3.0`, so that dev tags reflect the in-progress work correctly

### How I've tested this PR:
There's not a good way to test this change without having the modified actions file merged into `main`, but the stakes are very low since we're only modifying our own internal process.

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
