### PR TITLE
Add release notes URL to release metadata

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,4 +1,5 @@
 url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/consul-api-gateway"
 url_license = "https://github.com/hashicorp/consul-api-gateway/blob/main/LICENSE.md"
 url_project_website = "https://www.consul.io/docs/api-gateway"
+url_release_notes = "https://www.consul.io/docs/release-notes"
 url_source_repository = "https://github.com/hashicorp/consul-api-gateway"


### PR DESCRIPTION
### Changes proposed in this PR:
Add link to release notes in release metadata.
Note that the link goes to the top level release notes page for all packages in the Consul product line where Consul API Gateway is a subitem. There is no such top-level page specific to Consul API Gateway.

### How I've tested this PR:
- Manual inspection

### How I expect reviewers to test this PR:
- Manual inspection

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
