### PR TITLE
Disable NVD scanning temporarily

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -9,5 +9,5 @@ binary {
 	go_modules   = true
 	osv          = true
 	oss_index    = true
-	nvd          = true
+	nvd          = false
 }


### PR DESCRIPTION
CVE-2020-29509 and CVE-2020-29511 do not currently have a fix available and are used only in test code.

```shell
$ go mod why encoding/xml
# encoding/xml
github.com/hashicorp/consul-api-gateway/internal/testing
math/big
math/big.test
encoding/xml
```

The long-term plan is an allow-list to ignore particular CVEs that don't have a functional impact on the product that we're shipping; however, that allow list doesn't currently exist. ProdSec has an outstanding issue for addressing this.

At the recommendation of ProdSec, I'm disabling NVD scanning on our binary similar to [other repos that have encountered the same issue](https://cs.github.com/?scope=org%3Ahashicorp&scopeName=hashicorp&q=%22nvd%22+%3D+false+language%3AHCL). There will be followup work to set this back to `true` once the long-term solution is in place.

### Changes proposed in this PR:
Set `nvd=false` in our release scanning config

### How I've tested this PR:
Discussed change with ProdSec and mirrored other repos having the same issues

### How I expect reviewers to test this PR:
Check into the links above to verify my paper trail

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
