### PR TITLE
ci: remove broken Consul binary install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,6 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    - name: Install Consul
-      uses: nickethier/action-setup-hashicorp-tool@main #TODO: update action when migrated to hc org
-      with:
-        product: consul
-        version: ${{ matrix.consul-version }}
-
     - name: Clean Generate
       run: |
         echo "Checking that code generation is up-to-date"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,16 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
+    - name: Install Consul
+      shell: bash
+      run: |
+        CONSUL_VERSION="${{ matrix.consul-version }}"
+        FILENAME="consul_${CONSUL_VERSION}_linux_amd64.zip"
+        curl -sSLO "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/${FILENAME}" && \
+          unzip "${FILENAME}" -d /usr/local/bin && \
+          rm "${FILENAME}"
+        consul version
+
     - name: Clean Generate
       run: |
         echo "Checking that code generation is up-to-date"


### PR DESCRIPTION
### Changes proposed in this PR:

- Remove flaky Consul install using https://github.com/nickethier/action-setup-hashicorp-tool
- Install binary directly with `curl` instead

### How I've tested this PR:

- Let CI tests run and confirm they don't fail on downloading Consul binary

### How I expect reviewers to test this PR:

- Confirm that CI tests are less flaky with this approach

### Checklist:
- [ ] ~~Tests added~~
- [ ] ~~CHANGELOG entry added~~
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
