### PR TITLE
Fix SPIFFE url handling

### DIFF
--- a/.changelog/225.txt
+++ b/.changelog/225.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix SPIFFE handling for Vault connect certificates
+```

--- a/.changelog/225.txt
+++ b/.changelog/225.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-fix SPIFFE handling for Vault connect certificates
+Fix SPIFFE validation for connect certificates that have no URL (e.g., Vault connect certificates)
 ```

--- a/internal/consul/certmanager.go
+++ b/internal/consul/certmanager.go
@@ -5,10 +5,8 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"sync"
@@ -116,7 +114,6 @@ type CertManager struct {
 	privateKey          []byte
 	tlsCertificate      *tls.Certificate
 	rootCertificatePool *x509.CertPool
-	spiffeURL           *url.URL
 
 	// watches
 	rootWatch *watch.Plan
@@ -164,18 +161,6 @@ func (c *CertManager) handleRootWatch(blockParam watch.BlockingParamVal, raw int
 	for _, root := range v.Roots {
 		roots.AppendCertsFromPEM([]byte(root.RootCertPEM))
 		if root.Active {
-			block, _ := pem.Decode([]byte(root.RootCertPEM))
-			caCert, err := x509.ParseCertificate(block.Bytes)
-			if err != nil {
-				c.logger.Error("failed to parse root certificate")
-				return
-			}
-			for _, uri := range caCert.URIs {
-				if uri.Scheme == "spiffe" {
-					c.spiffeURL = uri
-					break
-				}
-			}
 			c.ca = []byte(root.RootCertPEM)
 		}
 	}
@@ -338,13 +323,6 @@ func (c *CertManager) RootPool() *x509.CertPool {
 	defer c.lock.RUnlock()
 
 	return c.rootCertificatePool
-}
-
-func (c *CertManager) SPIFFE() *url.URL {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-
-	return c.spiffeURL
 }
 
 // Certificate returns the current leaf cert

--- a/internal/envoy/mocks/sds.go
+++ b/internal/envoy/mocks/sds.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	tls "crypto/tls"
 	x509 "crypto/x509"
-	url "net/url"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -48,20 +47,6 @@ func (m *MockCertificateFetcher) RootPool() *x509.CertPool {
 func (mr *MockCertificateFetcherMockRecorder) RootPool() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootPool", reflect.TypeOf((*MockCertificateFetcher)(nil).RootPool))
-}
-
-// SPIFFE mocks base method.
-func (m *MockCertificateFetcher) SPIFFE() *url.URL {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SPIFFE")
-	ret0, _ := ret[0].(*url.URL)
-	return ret0
-}
-
-// SPIFFE indicates an expected call of SPIFFE.
-func (mr *MockCertificateFetcherMockRecorder) SPIFFE() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SPIFFE", reflect.TypeOf((*MockCertificateFetcher)(nil).SPIFFE))
 }
 
 // TLSCertificate mocks base method.

--- a/internal/envoy/sds.go
+++ b/internal/envoy/sds.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/url"
 	"sync"
 	"time"
 
@@ -40,7 +39,6 @@ var logOnce sync.Once
 // CertificateFetcher is used to fetch the CA and server certificate
 // that the server should use for TLS
 type CertificateFetcher interface {
-	SPIFFE() *url.URL
 	RootPool() *x509.CertPool
 	TLSCertificate() *tls.Certificate
 }

--- a/internal/envoy/sds_test.go
+++ b/internal/envoy/sds_test.go
@@ -249,9 +249,7 @@ func runTestServer(t *testing.T, ca []byte, registryFn func(*gomock.Controller) 
 	require.NoError(t, err)
 	certPool := x509.NewCertPool()
 	certPool.AddCert(caCert)
-	spiffe := caCert.URIs[0]
 
-	fetcher.EXPECT().SPIFFE().AnyTimes().Return(spiffe)
 	fetcher.EXPECT().RootPool().AnyTimes().Return(certPool)
 	secretClient.EXPECT().FetchSecret(gomock.Any(), "test").AnyTimes().Return(&envoyTLS.Secret{
 		Name: "test",


### PR DESCRIPTION
### Changes proposed in this PR:

When users use root connect certificates without SPIFFE information (i.e. via Vault), the controller crashes. This removes the piece of code in our mTLS middleware that verifies the corresponding host between root cert and the derived leaf cert. This should be alright since we're still validating that the root actually generated the leaf certificate cryptographically before these checks.

Fixes: https://github.com/hashicorp/consul-api-gateway/issues/208

### Checklist:
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
