### PR TITLE
Make whitespace chomp for NOTES in changelog consistent

### DIFF
--- a/.changelog/changelog.tmpl
+++ b/.changelog/changelog.tmpl
@@ -47,7 +47,7 @@ BUG FIXES:
 {{ end -}}
 {{- end -}}
 
-{{- if .NotesByType.note -}}
+{{- if .NotesByType.note }}
 NOTES:
 
 {{range .NotesByType.note -}}


### PR DESCRIPTION
### Changes proposed in this PR:
Fix whitespace inconsistency for `NOTES` section header of generated changelog

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/3476400/174653260-43a00c73-42db-4db1-8361-ef2e728fee86.png">


### How I've tested this PR:
Compare whitespace operator for `NOTES` to other section headers

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
