### PR TITLE
Prepare for release of v0.3.0

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -2,13 +2,21 @@ schema = "1"
 
 project "consul-api-gateway" {
   team = "consul-api-gateway"
+
   slack {
     notification_channel = "C03BY5JVCKS"
   }
+
   github {
     organization = "hashicorp"
-    repository = "consul-api-gateway"
-    release_branches = ["main", "release/0.1.x", "release/0.2.x"]
+    repository   = "consul-api-gateway"
+
+    release_branches = [
+      "main",
+      "release/0.1.x",
+      "release/0.2.x",
+      "release/0.3.x",
+    ]
   }
 }
 
@@ -18,20 +26,22 @@ event "merge" {
 
 event "build" {
   depends = ["merge"]
+
   action "build" {
     organization = "hashicorp"
-    repository = "consul-api-gateway"
-    workflow = "build"
+    repository   = "consul-api-gateway"
+    workflow     = "build"
   }
 }
 
 event "upload-dev" {
   depends = ["build"]
+
   action "upload-dev" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "upload-dev"
-    depends = ["build"]
+    repository   = "crt-workflows-common"
+    workflow     = "upload-dev"
+    depends      = ["build"]
   }
 
   notification {
@@ -41,11 +51,12 @@ event "upload-dev" {
 
 event "security-scan-binaries" {
   depends = ["upload-dev"]
+
   action "security-scan-binaries" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-binaries"
-    config = "security-scan.hcl"
+    repository   = "crt-workflows-common"
+    workflow     = "security-scan-binaries"
+    config       = "security-scan.hcl"
   }
 
   notification {
@@ -55,11 +66,12 @@ event "security-scan-binaries" {
 
 event "security-scan-containers" {
   depends = ["security-scan-binaries"]
+
   action "security-scan-containers" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "security-scan-containers"
-    config = "security-scan.hcl"
+    repository   = "crt-workflows-common"
+    workflow     = "security-scan-containers"
+    config       = "security-scan.hcl"
   }
 
   notification {
@@ -69,10 +81,11 @@ event "security-scan-containers" {
 
 event "sign" {
   depends = ["security-scan-containers"]
+
   action "sign" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "sign"
+    repository   = "crt-workflows-common"
+    workflow     = "sign"
   }
 
   notification {
@@ -82,10 +95,11 @@ event "sign" {
 
 event "verify" {
   depends = ["sign"]
+
   action "verify" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "verify"
+    repository   = "crt-workflows-common"
+    workflow     = "verify"
   }
 
   notification {
@@ -95,11 +109,12 @@ event "verify" {
 
 event "promote-dev-docker" {
   depends = ["verify"]
+
   action "promote-dev-docker" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-dev-docker"
-    depends = ["verify"]
+    repository   = "crt-workflows-common"
+    workflow     = "promote-dev-docker"
+    depends      = ["verify"]
   }
 
   notification {
@@ -111,16 +126,17 @@ event "promote-dev-docker" {
 ## they should be added to the end of the file after the verify event stanza.
 
 event "trigger-staging" {
-// This event is dispatched by the bob trigger-promotion command and is required - do not delete.
+  // This event is dispatched by the bob trigger-promotion command and is required - do not delete.
 }
 
 event "promote-staging" {
   depends = ["trigger-staging"]
+
   action "promote-staging" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-staging"
-    config = "release-metadata.hcl"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-staging"
+    config       = "release-metadata.hcl"
   }
 
   notification {
@@ -130,10 +146,11 @@ event "promote-staging" {
 
 event "promote-staging-docker" {
   depends = ["promote-staging"]
+
   action "promote-staging-docker" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-staging-docker"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-staging-docker"
   }
 
   notification {
@@ -142,15 +159,16 @@ event "promote-staging-docker" {
 }
 
 event "trigger-production" {
-// This event is dispatched by the bob trigger-promotion command and is required - do not delete.
+  // This event is dispatched by the bob trigger-promotion command and is required - do not delete.
 }
 
 event "promote-production" {
   depends = ["trigger-production"]
+
   action "promote-production" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-production"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production"
   }
 
   notification {
@@ -160,10 +178,11 @@ event "promote-production" {
 
 event "promote-production-docker" {
   depends = ["promote-production"]
+
   action "promote-production-docker" {
     organization = "hashicorp"
-    repository = "crt-workflows-common"
-    workflow = "promote-production-docker"
+    repository   = "crt-workflows-common"
+    workflow     = "promote-production-docker"
   }
 
   notification {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UNRELEASED
 
-## 0.3.0 (June 20, 2022)
+## 0.3.0 (June 21, 2022)
 BREAKING CHANGES:
 
 * Gateway listener `certificateRefs` to secrets in a different namespace now require a [ReferencePolicy](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1alpha2.ReferencePolicy) [[GH-154](https://github.com/hashicorp/consul-api-gateway/issues/154)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 ## UNRELEASED
 
+## 0.3.0 (June 20, 2022)
+BREAKING CHANGES:
+
+* Gateway listener `certificateRefs` to secrets in a different namespace now require a [ReferencePolicy](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io%2fv1alpha2.ReferencePolicy) [[GH-154](https://github.com/hashicorp/consul-api-gateway/issues/154)]
+
+FEATURES:
+
+* Added a new configuration option called deployment to GatewayClassConfig that allows the user to configure the number of instances that are deployed per gateway. [[GH-195](https://github.com/hashicorp/consul-api-gateway/issues/195)]
+* Define anti-affinity rules so that the scheduler will attempt to evenly spread gateway pods across all available nodes [[GH-202](https://github.com/hashicorp/consul-api-gateway/issues/202)]
+
+IMPROVEMENTS:
+
+* go: build with Go 1.18 [[GH-167](https://github.com/hashicorp/consul-api-gateway/issues/167)]
+* k8s/controllers: watch for ReferencePolicy changes to reconcile and revalidate affected Gateways [[GH-207](https://github.com/hashicorp/consul-api-gateway/issues/207)]
+
+BUG FIXES:
+
+* Clean up stale routes from gateway listeners when not able or allowed to bind, to prevent serving traffic for a detached route. [[GH-197](https://github.com/hashicorp/consul-api-gateway/issues/197)]
+* Clean up stale routes from gateway listeners when route no longer references the gateway. [[GH-200](https://github.com/hashicorp/consul-api-gateway/issues/200)]
+* Fix SPIFFE validation for connect certificates that have no URL (e.g., Vault connect certificates) [[GH-225](https://github.com/hashicorp/consul-api-gateway/issues/225)]
+* Properly handle re-registration of deployed gateways when an agent no longer has the gateway in its catalog [[GH-227](https://github.com/hashicorp/consul-api-gateway/issues/227)]
+
+NOTES:
+
+* Gateway IP address assignment logic updated to include the case when multiple different pod IPs exist [[GH-201](https://github.com/hashicorp/consul-api-gateway/issues/201)]
+
 ## 0.2.1 (April 29, 2022)
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Consul API Gateway implements the Kubernetes [Gateway API Specification](https:/
 ## Prerequisites  
 
 The Consul API Gateway must be installed on a Kubernetes cluster with the [Consul K8s](https://github.com/hashicorp/consul-k8s) service
-mesh deployed on it. The installed version of Consul must be `v1.12.0` or greater.
+mesh deployed on it. The installed version of Consul must be `v1.12.2` or greater.
 
 The Consul Helm chart must be used, with specific settings, to install Consul on the Kubernetes
-cluster. The Consul Helm chart must be version `0.43.0` or greater.  See the Consul API Gateway documentation for the required settings.
+cluster. The Consul Helm chart must be version `0.45.0` or greater.  See the Consul API Gateway documentation for the required settings.
 
 # Documentation
 

--- a/config/deployment/deployment.yaml
+++ b/config/deployment/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: consul-api-gateway-controller
       containers:
-      - image: hashicorp/consul-api-gateway:0.2.1
+      - image: hashicorp/consul-api-gateway:0.3.0
         command: ["consul-api-gateway", "server", "-consul-address", "$(HOST_IP):8501", "-ca-file", "/ca/tls.crt", "-sds-server-host", "$(IP)", "-k8s-namespace", "$(CONSUL_K8S_NAMESPACE)", "-log-level", "$(LOG_LEVEL)"]
         name: consul-api-gateway-controller
         ports:

--- a/dev/docs/example-setup.md
+++ b/dev/docs/example-setup.md
@@ -72,8 +72,8 @@ We have provided a set of `kustomize` manifests for installing the Consul API Ga
 Apply them to your cluster using the following commands.
 
 ```bash
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.2.1"
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.2.1"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.3.0"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.3.0"
 ```
 
 ## Installing the demo Gateway and Mesh Service
@@ -116,7 +116,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.2.1
+- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.3.0
 
 patches:
 - target:


### PR DESCRIPTION
### Changes proposed in this PR:
Consul API Gateway version being released: `0.3.0`
Now requires:
- consul: `1.12.2`
- consul-k8s: `0.45.0`

### How I've tested this PR:
Compare to #168 

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
