### PR TITLE
e2e: specify k8s v1.23 image to avoid breaking change

### DIFF
--- a/internal/testing/e2e/kind.go
+++ b/internal/testing/e2e/kind.go
@@ -27,6 +27,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration


### PR DESCRIPTION
ServiceAccount no longer auto-generates an associated Secret in Kubernetes v1.24, which breaks our expectation in test helpers at https://github.com/hashicorp/consul-api-gateway/blob/main/internal/testing/e2e/kubernetes.go#L87-L101

### Changes proposed in this PR:
Temporarily pin the Kubernetes version used for the e2e tests on `kind` to v1.23, as documented at https://kind.sigs.k8s.io/docs/user/configuration/#kubernetes-version

### How I've tested this PR:
Running the e2e tests locally after applying this change.

### How I expect reviewers to test this PR:
Confirm this change is sufficient for the e2e tests to run successfully on Kubernetes v1.23 by default.

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
