### PR TITLE
Add lightweight conformance workflow that builds image for test

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,10 +31,12 @@ jobs:
           - eks
         config:
           - name: "consul@v1.11 + consul-k8s@v0.45.0"
+            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4.0-dev"
             consul-image: "hashicorp/consul:1.11"
             envoy-image: "envoyproxy/envoy:v1.20-latest"
             consul-k8s-version: "0.45.0"
           - name: "consul@v1.12 + consul-k8s@v0.45.0"
+            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4.0-dev"
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
             consul-k8s-version: "0.45.0"
@@ -96,7 +98,7 @@ jobs:
         working-directory: "consul-api-gateway/internal/testing/conformance"
         run: |
           helm repo add hashicorp https://helm.releases.hashicorp.com
-          helm install --values ./consul-config.yaml consul hashicorp/consul --version "${{ matrix.config.consul-k8s-version }}" --set global.image=${{ matrix.config.consul-image }} --set global.imageEnvoy=${{ matrix.config.envoy-image }} --create-namespace --namespace=consul
+          helm install --values ./consul-config.yaml consul hashicorp/consul --version "${{ matrix.config.consul-k8s-version }}" --set global.image=${{ matrix.config.consul-image }} --set global.imageEnvoy=${{ matrix.config.envoy-image }} --set apiGateway.image=${{ matrix.config.api-gateway-image }} --create-namespace --namespace=consul
           kubectl wait --for=condition=Ready --timeout=120s --namespace=consul pods --all
 
       - name: Patch testing resources

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,12 +1,6 @@
-name: conformance
+name: Conformance (Main)
 
 on:
-  pull_request:
-    types: ["opened", "reopened", "synchronize", "labeled"]
-
-  push:
-     branches: ["conformance/*"]
-
   schedule:
     - cron:  '0 0 * * *'
 
@@ -29,13 +23,9 @@ env:
 
 jobs:
   run-on-environment:
-    # Run on PR only if there is a `pr/run-conformance` label
-    if: "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr/run-conformance')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        aws-region:
-          - us-west-2
         cluster-type:
           - kind
           - eks

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -30,11 +30,11 @@ jobs:
           - kind
           - eks
         config:
-          - name: "consul@v1.11.5 + consul-k8s@v0.45.0"
+          - name: "consul@v1.11 + consul-k8s@v0.45.0"
             consul-image: "hashicorp/consul:1.11"
             envoy-image: "envoyproxy/envoy:v1.20-latest"
             consul-k8s-version: "0.45.0"
-          - name: "consul@v1.12.2 + consul-k8s@v0.45.0"
+          - name: "consul@v1.12 + consul-k8s@v0.45.0"
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
             consul-k8s-version: "0.45.0"

--- a/.github/workflows/conformance_with_build.yml
+++ b/.github/workflows/conformance_with_build.yml
@@ -32,10 +32,12 @@ jobs:
       matrix:
         config:
           - name: "consul@v1.11 + consul-k8s@v0.45.0"
+            api-gateway-image: "consul-api-gateway:local-build"
             consul-image: "hashicorp/consul:1.11"
             envoy-image: "envoyproxy/envoy:v1.20-latest"
             consul-k8s-version: "0.45.0"
           - name: "consul@v1.12 + consul-k8s@v0.45.0"
+            api-gateway-image: "consul-api-gateway:local-build"
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
             consul-k8s-version: "0.45.0"
@@ -75,7 +77,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      # docker build -f Dockerfile.local -t consul-api-gateway:test --platform linux/amd64 .
+      # docker build -f Dockerfile.local -t consul-api-gateway:local-build --platform linux/amd64 .
       - name: Build Docker image
         uses: docker/build-push-action@v2
         with:
@@ -84,12 +86,12 @@ jobs:
           file: "./consul-api-gateway/Dockerfile.local"
           load: true
           push: false
-          tags: "consul-api-gateway:test"
+          tags: ${{ matrix.config.api-gateway-image }}
 
       - name: Setup Kind cluster
         uses: ./consul-api-gateway/.github/actions/setup-kind
         with:
-          load-docker-image: "consul-api-gateway:test"
+          load-docker-image: ${{ matrix.config.api-gateway-image }}
           metallb-config-path: "./consul-api-gateway/internal/testing/conformance/metallb-config.yaml"
 
       - name: Install Consul API Gateway CRDs
@@ -100,7 +102,7 @@ jobs:
         working-directory: "consul-api-gateway/internal/testing/conformance"
         run: |
           helm repo add hashicorp https://helm.releases.hashicorp.com
-          helm install --values ./consul-config.yaml consul hashicorp/consul --version "${{ matrix.config.consul-k8s-version }}" --set global.image=${{ matrix.config.consul-image }} --set global.imageEnvoy=${{ matrix.config.envoy-image }} --set apiGateway.image=consul-api-gateway:test --create-namespace --namespace=consul
+          helm install --values ./consul-config.yaml consul hashicorp/consul --version "${{ matrix.config.consul-k8s-version }}" --set global.image=${{ matrix.config.consul-image }} --set global.imageEnvoy=${{ matrix.config.envoy-image }} --set apiGateway.image=${{ matrix.config.api-gateway-image }} --create-namespace --namespace=consul
           kubectl wait --for=condition=Ready --timeout=60s --namespace=consul pods --all
 
       - name: Patch testing resources

--- a/.github/workflows/conformance_with_build.yml
+++ b/.github/workflows/conformance_with_build.yml
@@ -100,7 +100,7 @@ jobs:
         working-directory: "consul-api-gateway/internal/testing/conformance"
         run: |
           helm repo add hashicorp https://helm.releases.hashicorp.com
-          helm install --values ./consul-config.yaml consul hashicorp/consul --version "${{ matrix.config.consul-k8s-version }}" --set global.image=${{ matrix.config.consul-image }} --set global.imageEnvoy=${{ matrix.config.envoy-image }} --create-namespace --namespace=consul
+          helm install --values ./consul-config.yaml consul hashicorp/consul --version "${{ matrix.config.consul-k8s-version }}" --set global.image=${{ matrix.config.consul-image }} --set global.imageEnvoy=${{ matrix.config.envoy-image }} --set apiGateway.image=consul-api-gateway:test --create-namespace --namespace=consul
           kubectl wait --for=condition=Ready --timeout=60s --namespace=consul pods --all
 
       - name: Patch testing resources

--- a/.github/workflows/conformance_with_build.yml
+++ b/.github/workflows/conformance_with_build.yml
@@ -1,0 +1,120 @@
+name: Conformance (Build)
+
+on:
+  pull_request:
+    types: ["opened", "reopened", "synchronize", "labeled"]
+
+  push:
+    branches: ["conformance/*"]
+
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Start tmate session if any step fails'
+        required: false
+        type: boolean
+        default: false  # GitHub parses this value to string, see https://github.com/actions/runner/issues/1483
+      debug_timeout_minutes:
+        description: 'How many minutes should the tmate session close itself after?'
+        required: false
+        type: string  # No support for numeric value
+        default: '10'
+
+env:
+  GO_VERSION: "1.18"
+
+jobs:
+  run-on-kind:
+    # Run on PR only if there is a `pr/run-conformance` label
+    if: "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr/run-conformance')"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - name: "consul@v1.11.5 + consul-k8s@v0.44.0"
+            consul-image: "hashicorp/consul:1.11"
+            envoy-image: "envoyproxy/envoy:v1.20-latest"
+            consul-k8s-version: "0.44.0"
+          - name: "consul@v1.12.2 + consul-k8s@v0.44.0"
+            consul-image: "hashicorp/consul:1.12"
+            envoy-image: "envoyproxy/envoy:v1.22-latest"
+            consul-k8s-version: "0.44.0"
+      fail-fast: true
+    name: "${{ matrix.config.name }}"
+
+    steps:
+      # Clone repos side-by-side:
+      # GITHUB_WORKSPACE/
+      #     consul-api-gateway/
+      #     gateway-api/
+      - name: Checkout consul-api-gateway
+        uses: actions/checkout@v2
+        with:
+          path: "consul-api-gateway"
+
+      - name: Clone gateway-api
+        uses: actions/checkout@v2
+        with:
+          repository: "hashicorp/gateway-api"
+          ref: "conformance/v0.5.0-skipped-tests"
+          path: "gateway-api"
+
+      - name: Setup Goenv
+        uses: ./consul-api-gateway/.github/actions/goenv
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build binary
+        env:
+          CGO_ENABLED: "0"
+          GOARCH: "amd64"
+          GOOS: "linux"
+        working-directory: "consul-api-gateway"
+        run: go build -o ./consul-api-gateway
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # docker build -f Dockerfile.local -t consul-api-gateway:test --platform linux/amd64 .
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: "./consul-api-gateway"
+          platforms: "linux/amd64"
+          file: "./consul-api-gateway/Dockerfile.local"
+          load: true
+          push: false
+          tags: "consul-api-gateway:test"
+
+      - name: Setup Kind cluster
+        uses: ./consul-api-gateway/.github/actions/setup-kind
+        with:
+          load-docker-image: "consul-api-gateway:test"
+          metallb-config-path: "./consul-api-gateway/internal/testing/conformance/metallb-config.yaml"
+
+      - name: Install Consul API Gateway CRDs
+        working-directory: "consul-api-gateway"
+        run: kubectl apply --kustomize="./config/crd"
+
+      - name: Install Consul
+        working-directory: "consul-api-gateway/internal/testing/conformance"
+        run: |
+          helm repo add hashicorp https://helm.releases.hashicorp.com
+          helm install --values ./consul-config.yaml consul hashicorp/consul --version "${{ matrix.config.consul-k8s-version }}" --set global.image=${{ matrix.config.consul-image }} --set global.imageEnvoy=${{ matrix.config.envoy-image }} --create-namespace --namespace=consul
+          kubectl wait --for=condition=Ready --timeout=60s --namespace=consul pods --all
+
+      - name: Patch testing resources
+        working-directory: "consul-api-gateway/internal/testing/conformance"
+        run: |
+          cp kustomization.yaml proxydefaults.yaml $GITHUB_WORKSPACE/gateway-api/conformance/
+          cd $GITHUB_WORKSPACE/gateway-api/conformance/
+          kubectl kustomize ./ --output ./base/manifests.yaml
+
+      - name: Run tests
+        working-directory: "gateway-api/conformance"
+        run: go test -v -timeout 10m ./ --gateway-class=consul-api-gateway
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true'
+        timeout-minutes: ${{ fromJSON(github.event.inputs.debug_timeout_minutes) }}

--- a/.github/workflows/conformance_with_build.yml
+++ b/.github/workflows/conformance_with_build.yml
@@ -31,14 +31,14 @@ jobs:
     strategy:
       matrix:
         config:
-          - name: "consul@v1.11.5 + consul-k8s@v0.44.0"
+          - name: "consul@v1.11 + consul-k8s@v0.45.0"
             consul-image: "hashicorp/consul:1.11"
             envoy-image: "envoyproxy/envoy:v1.20-latest"
-            consul-k8s-version: "0.44.0"
-          - name: "consul@v1.12.2 + consul-k8s@v0.44.0"
+            consul-k8s-version: "0.45.0"
+          - name: "consul@v1.12 + consul-k8s@v0.45.0"
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
-            consul-k8s-version: "0.44.0"
+            consul-k8s-version: "0.45.0"
       fail-fast: true
     name: "${{ matrix.config.name }}"
 

--- a/internal/testing/conformance/consul-config.yaml
+++ b/internal/testing/conformance/consul-config.yaml
@@ -12,4 +12,3 @@ controller:
 apiGateway:
   enabled: true
   logLevel: info
-  image: "hashicorppreview/consul-api-gateway:0.4.0-dev"


### PR DESCRIPTION
### Changes proposed in this PR:
Our heavy conformance workflow that targets EKS and, in the future, GCP and Azure, can only test builds from our main branch. Due to this, it's misleading if triggered on a PR via a label.

This workflow uses the same "building blocks" we use in our normal workflow; however, it will build the branch being run against and target that build for conformance tests. We will use this for PRs and runs against specific branches.

### How I've tested this PR:
🤖  tests pass

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
