### PR TITLE
Drop patch release version from dev_tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           make version
           echo "::set-output name=product-version::$(make version)"
+          echo "::set-output name=product-minor-version::${$(make version)%.*}"
   generate-metadata-file:
     needs: get-product-version
     runs-on: ubuntu-latest
@@ -101,6 +102,7 @@ jobs:
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
+      minor-version: ${{needs.get-product-version.outputs.product-minor-version}}
 
     steps:
       - uses: actions/checkout@v2
@@ -119,5 +121,5 @@ jobs:
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
           dev_tags: |
-            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}-dev
-            docker.io/hashicorppreview/${{env.repo}}:${{env.version}}-${{github.sha}}-dev
+            docker.io/hashicorppreview/${{env.repo}}:${{env.minor-version}}-dev
+            docker.io/hashicorppreview/${{env.repo}}:${{env.minor-version}}-dev-${{github.sha}}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,12 +31,12 @@ jobs:
           - eks
         config:
           - name: "consul@v1.11 + consul-k8s@v0.45.0"
-            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4.0-dev"
+            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
             consul-image: "hashicorp/consul:1.11"
             envoy-image: "envoyproxy/envoy:v1.20-latest"
             consul-k8s-version: "0.45.0"
           - name: "consul@v1.12 + consul-k8s@v0.45.0"
-            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4.0-dev"
+            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
             consul-k8s-version: "0.45.0"


### PR DESCRIPTION
### Changes proposed in this PR:
Drop patch version from `dev_tags` mirroring new standard from https://github.com/hashicorp/consul/pull/13541

### How I've tested this PR:

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
