### PR TITLE
Fix substitution error setting minor version output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,10 @@ jobs:
         id: get-product-version
         run: |
           make version
-          echo "::set-output name=product-version::$(make version)"
-          echo "::set-output name=product-minor-version::${$(make version)%.*}"
+          VERSION=$(make version)
+          MINOR_VERSION=${VERSION%.*}
+          echo "::set-output name=product-version::$VERSION"
+          echo "::set-output name=product-minor-version::$MINOR_VERSION"
   generate-metadata-file:
     needs: get-product-version
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'release/**'
+      - 'substitution-error'
 
 env:
   CGO_ENABLED: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - 'release/**'
-      - 'substitution-error'
 
 env:
   CGO_ENABLED: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
+      product-minor-version: ${{ steps.get-product-version.outputs.product-minor-version }}
     steps:
       - uses: actions/checkout@v2
       - name: get product version

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -16,7 +16,6 @@ project "consul-api-gateway" {
       "release/0.1.x",
       "release/0.2.x",
       "release/0.3.x",
-      "substitution-error",
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -16,6 +16,7 @@ project "consul-api-gateway" {
       "release/0.1.x",
       "release/0.2.x",
       "release/0.3.x",
+      "substitution-error",
     ]
   }
 }


### PR DESCRIPTION
> **Note**: Followup to https://github.com/hashicorp/consul-api-gateway/pull/241

### Changes proposed in this PR:
Though the previous command works on my shell, GitHub Actions encounters a substitution error (visible [here](https://github.com/hashicorp/consul-api-gateway/runs/7011860269?check_suite_focus=true)). This makes the setting of the minor version output simpler.

### How I've tested this PR:
Can't really test this code directly as it only runs on release branches; however, risk is not a concern since we just released, and this code follows GitHub's own examples for outputting

```shell
echo "::set-output name=my_value::$MY_VAR"
```

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
