### PR TITLE
Add missing package for `make generate-golden-files`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ test:
 	go test ./...
 
 generate-golden-files:
+	GENERATE=true go test ./internal/adapters/consul
 	GENERATE=true go test ./internal/envoy
 	GENERATE=true go test ./internal/k8s/builder
 


### PR DESCRIPTION
### Changes proposed in this PR:
Adding the third of three packages containing golden files [here](https://github.com/hashicorp/consul-api-gateway/tree/main/internal/adapters/consul/testdata) that occasionally need to be regenerated

### How I've tested this PR:
After making a change to a source file in this package's `testdata`:
```shell
$ make generate-golden-files
```

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
