### PR TITLE
Use Terraform for conformance tests on EKS

### DIFF
--- a/.github/actions/setup-eks/action.yml
+++ b/.github/actions/setup-eks/action.yml
@@ -22,12 +22,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install eksctl
-      shell: bash
-      run: |
-        curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-        sudo mv /tmp/eksctl /usr/local/bin
-        eksctl version
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v2
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2
@@ -42,5 +38,12 @@ runs:
       shell: bash
       env:
         AWS_EC2_METADATA_DISABLED: true
+        TF_VAR_cluster_name: ${{ inputs.cluster_name }}
+        TF_VAR_region: ${{ inputs.region }}
       run: |
-        eksctl create cluster --name ${{ inputs.cluster_name }} --region ${{ inputs.region}} --managed --node-type t2.small --nodes 3
+        terraform -chdir=$GITHUB_ACTION_PATH init
+        terraform -chdir=$GITHUB_ACTION_PATH apply --auto-approve
+
+    - name: Update kubeconfig
+      shell: bash
+      run: aws eks --region ${{ inputs.region }} update-kubeconfig --name ${{ inputs.cluster_name }}

--- a/.github/actions/setup-eks/cluster.tf
+++ b/.github/actions/setup-eks/cluster.tf
@@ -1,0 +1,75 @@
+variable "cluster_name" {
+  type = string
+  nullable = false
+}
+
+variable "region" {
+  type = string
+  nullable = false
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_id
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.11.0"
+
+  name             = "${var.cluster_name}-vpc"
+  cidr             = "10.0.0.0/16"
+  azs              = data.aws_availability_zones.available.names
+  private_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets   = ["10.0.4.0/24", "10.0.5.0/24"]
+
+  manage_default_route_table = true
+  default_route_table_tags   = { DefaultRouteTable = true }
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.22.0"
+
+  cluster_name    = var.cluster_name
+  cluster_version = "1.21"
+  subnets         = module.vpc.public_subnets
+  vpc_id          = module.vpc.vpc_id
+
+  node_groups = {
+    nodes = {
+      name_prefix      = "${var.cluster_name}-node"
+      instance_types   = ["t3a.medium"]
+      desired_capacity = 3
+      max_capacity     = 3
+      min_capacity     = 3
+    }
+  }
+}

--- a/.github/actions/setup-eks/cluster.tf
+++ b/.github/actions/setup-eks/cluster.tf
@@ -35,8 +35,8 @@ module "vpc" {
   name             = "${var.cluster_name}-vpc"
   cidr             = "10.0.0.0/16"
   azs              = data.aws_availability_zones.available.names
-  private_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
-  public_subnets   = ["10.0.4.0/24", "10.0.5.0/24"]
+  private_subnets  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets   = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true
@@ -46,12 +46,12 @@ module "vpc" {
   }
 
   public_subnet_tags = {
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/cluster/${var.cluster_name}"   = "shared"
     "kubernetes.io/role/elb"                      = "1"
   }
 
   private_subnet_tags = {
-    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/cluster/${var.cluster_name}"   = "shared"
     "kubernetes.io/role/internal-elb"             = "1"
   }
 }
@@ -59,6 +59,7 @@ module "vpc" {
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "17.24.0"
+
   cluster_name    = var.cluster_name
   cluster_version = "1.22"
   subnets         = module.vpc.private_subnets
@@ -67,11 +68,11 @@ module "eks" {
 
   node_groups = {
     nodes = {
-      name_prefix      = "${var.cluster_name}-node"
-      instance_types   = ["t3a.medium"]
       desired_capacity = 3
       max_capacity     = 3
       min_capacity     = 3
+
+      instance_type = "m5.large"
     }
   }
 }

--- a/.github/actions/setup-eks/cluster.tf
+++ b/.github/actions/setup-eks/cluster.tf
@@ -68,6 +68,7 @@ module "eks" {
 
   node_groups = {
     nodes = {
+      name = "${var.cluster_name}-nodegroup"
       desired_capacity = 3
       max_capacity     = 3
       min_capacity     = 3

--- a/.github/actions/setup-eks/cluster.tf
+++ b/.github/actions/setup-eks/cluster.tf
@@ -10,22 +10,15 @@ variable "region" {
 
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster.token
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
 }
 
 provider "aws" {
   region = var.region
 }
 
-data "aws_availability_zones" "available" {
-  state = "available"
-
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
+data "aws_availability_zones" "available" {}
 
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
@@ -44,23 +37,32 @@ module "vpc" {
   azs              = data.aws_availability_zones.available.names
   private_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
   public_subnets   = ["10.0.4.0/24", "10.0.5.0/24"]
-
-  manage_default_route_table = true
-  default_route_table_tags   = { DefaultRouteTable = true }
-
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true
-  enable_dns_support   = true
+
+  tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = "1"
+  }
 }
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "17.22.0"
-
+  version = "17.24.0"
   cluster_name    = var.cluster_name
-  cluster_version = "1.21"
-  subnets         = module.vpc.public_subnets
+  cluster_version = "1.22"
+  subnets         = module.vpc.private_subnets
+
   vpc_id          = module.vpc.vpc_id
 
   node_groups = {

--- a/.github/actions/teardown-eks/action.yml
+++ b/.github/actions/teardown-eks/action.yml
@@ -15,16 +15,12 @@ runs:
       shell: bash
       env:
         AWS_EC2_METADATA_DISABLED: true
+        TF_VAR_cluster_name: ${{ inputs.cluster_name }}
+        TF_VAR_region: ${{ inputs.region }}
       run: |
+        terraform -chdir=$GITHUB_ACTION_PATH/../setup-eks/ destroy --auto-approve
 
-        for each in $(kubectl get ns -o jsonpath="{.items[*].metadata.name}" | grep -v kube-system);
-        do
-          kubectl delete --all svc --namespace $each
-        done
-
-        eksctl delete cluster --name ${{ inputs.cluster_name }} --region ${{ inputs.region}} --parallel 3 --force --wait
-
-        #if unsuccesful, run delete again to account for race condition
+        #if unsuccessful, run destroy again to account for race condition
         if [[$? -eq 1]]; then
-          eksctl delete cluster --name ${{ inputs.cluster_name }} --region ${{ inputs.region}} --parallel 3 --force --wait
+          terraform -chdir=$GITHUB_ACTION_PATH/../setup-eks/ destroy --auto-approve
         fi

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,6 +1,9 @@
 name: Conformance (Main)
 
 on:
+  push:
+    branches: ["tf-conformance"]
+
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,9 +1,6 @@
 name: Conformance (Main)
 
 on:
-  push:
-    branches: [ 'tf-conformance']
-
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,6 +1,9 @@
 name: Conformance (Main)
 
 on:
+  push:
+    branches: [ 'tf-conformance']
+
   schedule:
     - cron:  '0 0 * * *'
 


### PR DESCRIPTION
### Changes proposed in this PR:
Use Terraform instead of eksctl to manage our EKS cluster for conformance tests.
The main driver here is that eksctl frequently leaves orphaned resources that we have to manually clean up.
In addition, this gives us a workflow that's easily adaptable for GKE and AKS in the near future.

### How I've tested this PR:
See successful conformance EKS run on 0898eefcada0180e18cc4ee78ce4ed86f3824300

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
