### PR TITLE
Add initial Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 5
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "pr/no-changelog"
+    schedule:
+      interval: daily


### PR DESCRIPTION
### Changes proposed in this PR:
Add initial Dependabot configuration to keep our dependencies up-to-date. This is a best practice and should lower the amount of CVEs we have to PR a remediation for if they're always updated.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
