### PR TITLE
Add link to create PR to job output for release prep workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -118,3 +118,6 @@ jobs:
             - consul: `${{ env.NEW_CONSUL_REQ }}`
             - consul-k8s: `${{ env.NEW_CONSUL_K8S_REQ }}`
           create_branch: true
+
+      - name: Output link to status
+        run: echo '[Create a Pull Request with these changes ](https://github.com/hashicorp/consul-api-gateway/pull/new/v${{ env.NEW_API_GATEWAY_VERSION }}-release-prep)' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Changes proposed in this PR:
Taking advantage of the new [job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) feature and output a link to PR changes so we don't have to dig into logs.

### How I've tested this PR:

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
