### PR TITLE
Prepare for release of v0.4.0

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -16,6 +16,7 @@ project "consul-api-gateway" {
       "release/0.1.x",
       "release/0.2.x",
       "release/0.3.x",
+      "release/0.4.x",
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## UNRELEASED
 
+## 0.4.0 (July 06, 2022)
+DEPRECATIONS:
+
+* gateway-api: ReferencePolicy is deprecated and will be removed in a future release. The functionally identical ReferenceGrant should be used instead. [[GH-224](https://github.com/hashicorp/consul-api-gateway/issues/224)]
+
+FEATURES:
+
+* gateway-api: update to the [v0.5.0-rc1](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.5.0-rc1) release with v1beta1 resource support [[GH-224](https://github.com/hashicorp/consul-api-gateway/issues/224)]
+
+BUG FIXES:
+
+* Revalidate HTTPRoutes and TCPRoutes and update status when the Kubernetes Service(s) that they reference are modified [[GH-247](https://github.com/hashicorp/consul-api-gateway/issues/247)]
+
 ## 0.3.0 (June 21, 2022)
 BREAKING CHANGES:
 

--- a/config/deployment/deployment.yaml
+++ b/config/deployment/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: consul-api-gateway-controller
       containers:
-      - image: hashicorp/consul-api-gateway:0.3.0
+      - image: hashicorp/consul-api-gateway:0.4.0
         command: ["consul-api-gateway", "server", "-consul-address", "$(HOST_IP):8501", "-ca-file", "/ca/tls.crt", "-sds-server-host", "$(IP)", "-k8s-namespace", "$(CONSUL_K8S_NAMESPACE)", "-log-level", "$(LOG_LEVEL)"]
         name: consul-api-gateway-controller
         ports:

--- a/dev/docs/example-setup.md
+++ b/dev/docs/example-setup.md
@@ -72,8 +72,8 @@ We have provided a set of `kustomize` manifests for installing the Consul API Ga
 Apply them to your cluster using the following commands.
 
 ```bash
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.3.0"
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.3.0"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.4.0"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.4.0"
 ```
 
 ## Installing the demo Gateway and Mesh Service
@@ -116,7 +116,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.3.0
+- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.4.0
 
 patches:
 - target:


### PR DESCRIPTION
Prepare for release of v0.4.0
Consul API Gateway version being released: `0.4.0`
Now requires:
- consul: `1.12.2`
- consul-k8s: `0.45.0`