### PR TITLE
Modify release prep workflow to create PR w/ changes

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -107,17 +107,27 @@ jobs:
             ${{ env.CHANGELOG_PATCH }}
           regex: false
 
-      - name: Create branch
-        uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80
+      - name: Create pull request
+        id: create-pr
+        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27
         with:
-          branch: 'v${{ env.NEW_API_GATEWAY_VERSION }}-release-prep'
-          commit_message: |
+          body: |
             Prepare for release of v${{ env.NEW_API_GATEWAY_VERSION }}
             Consul API Gateway version being released: `${{ env.NEW_API_GATEWAY_VERSION }}`
             Now requires:
             - consul: `${{ env.NEW_CONSUL_REQ }}`
             - consul-k8s: `${{ env.NEW_CONSUL_K8S_REQ }}`
-          create_branch: true
+          branch: 'v${{ env.NEW_API_GATEWAY_VERSION }}-release-prep'
+          commit-message: |
+            Prepare for release of v${{ env.NEW_API_GATEWAY_VERSION }}
+            Consul API Gateway version being released: `${{ env.NEW_API_GATEWAY_VERSION }}`
+            Now requires:
+            - consul: `${{ env.NEW_CONSUL_REQ }}`
+            - consul-k8s: `${{ env.NEW_CONSUL_K8S_REQ }}`
+          delete-branch: true
+          labels: 'pr/no-changelog'
+          title: 'Prepare for release of v${{ env.NEW_API_GATEWAY_VERSION }}'
+          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
-      - name: Output link to status
-        run: echo '[Create a Pull Request with these changes ](https://github.com/hashicorp/consul-api-gateway/pull/new/v${{ env.NEW_API_GATEWAY_VERSION }}-release-prep)' >> $GITHUB_STEP_SUMMARY
+      - name: Output link to PR
+        run: echo '[Resulting PR](${{ steps.create-pr.outputs.pull-request-url }})' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -112,7 +112,6 @@ jobs:
         uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27
         with:
           body: |
-            Prepare for release of v${{ env.NEW_API_GATEWAY_VERSION }}
             Consul API Gateway version being released: `${{ env.NEW_API_GATEWAY_VERSION }}`
             Now requires:
             - consul: `${{ env.NEW_CONSUL_REQ }}`

--- a/internal/adapters/consul/sync_test.go
+++ b/internal/adapters/consul/sync_test.go
@@ -12,10 +12,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul-api-gateway/internal/common"
-	"github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
+
+	"github.com/hashicorp/consul-api-gateway/internal/common"
+	"github.com/hashicorp/consul-api-gateway/internal/core"
 )
 
 var (
@@ -151,6 +152,10 @@ func TestHTTPRouteDiscoveryChain(t *testing.T) {
 }
 
 func TestConsulSyncAdapter_Sync(t *testing.T) {
+	if generate {
+		t.Skip("Skipping for generate due to consul binary dependency")
+	}
+
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
### Changes proposed in this PR:
We now have a service account that has permissions to create PRs. By having our release prep workflow create a PR using this service account, we save ourselves one more manual step.

### How I've tested this PR:
Ran w/ this branch [here](https://github.com/hashicorp/consul-api-gateway/actions/runs/2624390159) resulting in the following test PR:
https://github.com/hashicorp/consul-api-gateway/pull/273

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
