### PR TITLE
Sync in-memory store w/ Consul at constant interval

### DIFF
--- a/.changelog/278.txt
+++ b/.changelog/278.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Sync in-memory store to Consul at a regular interval in the background
+```

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -64,7 +64,10 @@ func RunServer(config ServerConfig) int {
 		Adapter: consulAdapters.NewSyncAdapter(config.Logger.Named("consul-adapter"), consulClient),
 		Logger:  config.Logger.Named("state"),
 	})
-	store.SyncAtInterval(groupCtx)
+	group.Go(func() error {
+		store.SyncAtInterval(groupCtx)
+		return nil
+	})
 
 	controller.SetConsul(consulClient)
 	controller.SetStore(store)

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -9,6 +9,9 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-hclog"
+
 	consulAdapters "github.com/hashicorp/consul-api-gateway/internal/adapters/consul"
 	"github.com/hashicorp/consul-api-gateway/internal/consul"
 	"github.com/hashicorp/consul-api-gateway/internal/envoy"
@@ -16,8 +19,6 @@ import (
 	"github.com/hashicorp/consul-api-gateway/internal/metrics"
 	"github.com/hashicorp/consul-api-gateway/internal/profiling"
 	"github.com/hashicorp/consul-api-gateway/internal/store/memory"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-hclog"
 )
 
 type ServerConfig struct {
@@ -34,21 +35,10 @@ type ServerConfig struct {
 
 func RunServer(config ServerConfig) int {
 	// Set up signal handlers and global context
-	ctx, cancel := context.WithCancel(config.Context)
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
-	defer func() {
-		signal.Stop(interrupt)
-		cancel()
-	}()
-	go func() {
-		select {
-		case <-interrupt:
-			config.Logger.Debug("received shutdown signal")
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
+	ctx, cancel := signal.NotifyContext(config.Context, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	group, groupCtx := errgroup.WithContext(ctx)
 
 	secretClient := envoy.NewMultiSecretClient()
 	k8sSecretClient, err := k8s.NewK8sSecretClient(config.Logger.Named("cert-fetcher"), config.K8sConfig.RestConfig)
@@ -74,6 +64,7 @@ func RunServer(config ServerConfig) int {
 		Adapter: consulAdapters.NewSyncAdapter(config.Logger.Named("consul-adapter"), consulClient),
 		Logger:  config.Logger.Named("state"),
 	})
+	store.SyncAtInterval(groupCtx)
 
 	controller.SetConsul(consulClient)
 	controller.SetStore(store)
@@ -85,7 +76,6 @@ func RunServer(config ServerConfig) int {
 		"consul-api-gateway-controller",
 		options,
 	)
-	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		return certManager.Manage(groupCtx)
 	})
@@ -100,26 +90,32 @@ func RunServer(config ServerConfig) int {
 	}
 	config.Logger.Trace("initial certificates written")
 
+	// Run SDS server
 	server := envoy.NewSDSServer(config.Logger.Named("sds-server"), certManager, secretClient, store)
 	group.Go(func() error {
 		return server.Run(groupCtx)
 	})
+
+	// Run controller
 	group.Go(func() error {
 		return controller.Start(groupCtx)
 	})
 
+	// Run metrics server if configured
 	if config.MetricsPort != 0 {
 		group.Go(func() error {
 			return metrics.RunServer(groupCtx, config.Logger.Named("metrics"), fmt.Sprintf("127.0.0.1:%d", config.MetricsPort))
 		})
 	}
 
+	// Run profiling server if configured
 	if config.ProfilingPort != 0 {
 		group.Go(func() error {
 			return profiling.RunServer(groupCtx, config.Logger.Named("pprof"), fmt.Sprintf("127.0.0.1:%d", config.ProfilingPort))
 		})
 	}
 
+	// Wait for any of the above to exit
 	if err := group.Wait(); err != nil {
 		config.Logger.Error("unexpected error", "error", err)
 		return 1

--- a/internal/consul/intentions.go
+++ b/internal/consul/intentions.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/cenkalti/backoff"
 
-	"github.com/hashicorp/consul-api-gateway/internal/common"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
+
+	"github.com/hashicorp/consul-api-gateway/internal/common"
 )
 
 //go:generate mockgen -source ./intentions.go -destination ./mocks/intentions.go -package mocks consulDiscoveryChains,consulConfigEntries
@@ -152,7 +153,7 @@ func (r *IntentionsReconciler) sourceIntention() *api.SourceIntention {
 //      reconciler is stopped.
 //   2. A discoChainWatcher sends a discoChainWatchResult which will compute and added or removed discovery chain
 //      targets and synchronize intentions.
-//   3. The intentionSyncInterval is met, triggering the a ticker to fire and synchronize intentions.
+//   3. The intentionSyncInterval is met, triggering the ticker to fire and synchronize intentions.
 //
 // The loop stops and returns if the struct context is cancelled.
 func (r *IntentionsReconciler) reconcileLoop() {

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -173,11 +173,13 @@ func (s *Store) SyncAtInterval(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				s.mutex.RLock()
 				if err := s.sync(ctx); err != nil {
 					s.logger.Warn("An error occurred during memory store sync, some changes may be out of sync", "error", err)
 				} else {
 					s.logger.Trace("Synced memory store in background")
 				}
+				s.mutex.RUnlock()
 			}
 		}
 	})

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -173,13 +173,20 @@ func (s *Store) SyncAtInterval(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				s.mutex.RLock()
+				s.mutex.Lock()
+
+				// Force each gateway to sync its state even though listeners
+				// on the gateway may not be marked as needing a sync right now
+				for _, gateway := range s.gateways {
+					gateway.needsSync = true
+				}
+
 				if err := s.sync(ctx); err != nil {
 					s.logger.Warn("An error occurred during memory store sync, some changes may be out of sync", "error", err)
 				} else {
 					s.logger.Trace("Synced memory store in background")
 				}
-				s.mutex.RUnlock()
+				s.mutex.Unlock()
 			}
 		}
 	})

--- a/internal/store/memory/store.go
+++ b/internal/store/memory/store.go
@@ -2,20 +2,22 @@ package memory
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul-api-gateway/internal/metrics"
 	"github.com/hashicorp/consul-api-gateway/internal/store"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-multierror"
 )
 
 var (
-	ErrCannotBindListener = errors.New("cannot bind listener")
+	consulSyncInterval = 60 * time.Second
+	startSyncLoopOnce  sync.Once
 )
 
 type Store struct {
@@ -25,14 +27,10 @@ type Store struct {
 	gateways map[core.GatewayID]*gatewayState
 	routes   map[string]store.Route
 
-	// This mutex acts as a stop-the-world type
-	// global mutex, as the store is a singleton
-	// what this means is that once a lock on the
-	// mutex is acquired, any mutable operations
-	// on the gateway interfaces wrapped by our
-	// state-building structures can happen
-	// concerns of thread-safety (unless they)
-	// spin up additional goroutines.
+	// This mutex acts as a stop-the-world type global mutex, as the store is a singleton.
+	// What this means is that once a lock on the mutex is acquired, any mutable operations
+	// on the gateway interfaces wrapped by our state-building structures can happen without
+	// concerns of thread-safety (unless they) spin up additional goroutines.
 	mutex sync.RWMutex
 
 	activeGateways int64
@@ -160,6 +158,29 @@ func (s *Store) sync(ctx context.Context, gateways ...*gatewayState) error {
 
 func (s *Store) Sync(ctx context.Context) error {
 	return s.sync(ctx)
+}
+
+// SyncAtInterval syncs the objects in the store w/ Consul at a constant interval
+// until the provided context is cancelled. Calling SyncAtInterval multiple times
+// will only result in a single sync loop as it should only be called during startup.
+func (s *Store) SyncAtInterval(ctx context.Context) {
+	startSyncLoopOnce.Do(func() {
+		ticker := time.NewTicker(consulSyncInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := s.sync(ctx); err != nil {
+					s.logger.Warn("An error occurred during memory store sync, some changes may be out of sync", "error", err)
+				} else {
+					s.logger.Trace("Synced memory store in background")
+				}
+			}
+		}
+	})
 }
 
 func (s *Store) DeleteRoute(ctx context.Context, id string) error {

--- a/internal/testing/e2e/gateway.go
+++ b/internal/testing/e2e/gateway.go
@@ -10,12 +10,13 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
+	"github.com/hashicorp/go-hclog"
+
 	consulAdapters "github.com/hashicorp/consul-api-gateway/internal/adapters/consul"
 	"github.com/hashicorp/consul-api-gateway/internal/consul"
 	"github.com/hashicorp/consul-api-gateway/internal/envoy"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s"
 	"github.com/hashicorp/consul-api-gateway/internal/store/memory"
-	"github.com/hashicorp/go-hclog"
 )
 
 type gatewayTestContext struct{}
@@ -103,6 +104,10 @@ func (p *gatewayTestEnvironment) run(ctx context.Context, namespace string, cfg 
 	})
 	group.Go(func() error {
 		return controller.Start(groupCtx)
+	})
+	group.Go(func() error {
+		store.SyncAtInterval(groupCtx)
+		return nil
 	})
 	p.cancel = cancel
 	p.group = group


### PR DESCRIPTION
This is longer-term followup based on https://github.com/hashicorp/consul-api-gateway/issues/230#issuecomment-1157976119

### Changes proposed in this PR:
Trigger a sync for our in-memory store at a constant interval in the background

### How I've tested this PR:
_Still working on how to test this in a programmatic fasion_

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
