### PR TITLE
Restore inclusion of ReferencePolicy in Grant lookup

### DIFF
--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -538,31 +538,30 @@ func (g *gatewayClient) GetReferenceGrantsInNamespace(ctx context.Context, names
 	}
 	refGrants := refGrantList.Items
 
-	// TODO: this can't be enabled until the ReferencePolicy object is restored
-	// lookup ReferencePolicies here too for backwards compatibility, create
-	// ReferenceGrants from them and add to list
-	// refPolicyList := &gwv1alpha2.ReferencePolicyList{}
-	// if err := g.Client.List(ctx, refPolicyList, client.InNamespace(namespace)); err != nil {
-	// 	return nil, NewK8sError(err)
-	// }
-	// for _, refPolicy := range refPolicyList {
-	// 	refGrant := gwv1alpha2.ReferenceGrant{}
-	// 	for _, refPolicyFrom := range refPolicy.Spec.From {
-	// 		refGrant.Spec.From = append(refGrant.Spec.From, gwv1alpha2.ReferenceGrantFrom{
-	// 			Group:     refPolicyFrom.Group,
-	// 			Kind:      refPolicyFrom.Kind,
-	// 			Namespace: refPolicyFrom.Namespace,
-	// 		})
-	// 	}
-	// 	for _, refPolicyTo := range refPolicy.Spec.To {
-	// 		refGrant.Spec.To = append(refGrant.Spec.To, gwv1alpha2.ReferenceGrantTo{
-	// 			Group: refPolicyTo.Group,
-	// 			Kind:  refPolicyTo.Kind,
-	// 			Name:  refPolicyTo.Name,
-	// 		})
-	// 	}
-	// 	refGrants = append(refGrants, refGrant)
-	// }
+	// Lookup ReferencePolicies here too for backwards compatibility, create
+	// ReferenceGrants from them, and add them to list
+	refPolicyList := &gwv1alpha2.ReferencePolicyList{}
+	if err := g.Client.List(ctx, refPolicyList, client.InNamespace(namespace)); err != nil {
+		return nil, NewK8sError(err)
+	}
+	for _, refPolicy := range refPolicyList.Items {
+		refGrant := gwv1alpha2.ReferenceGrant{}
+		for _, refPolicyFrom := range refPolicy.Spec.From {
+			refGrant.Spec.From = append(refGrant.Spec.From, gwv1alpha2.ReferenceGrantFrom{
+				Group:     refPolicyFrom.Group,
+				Kind:      refPolicyFrom.Kind,
+				Namespace: refPolicyFrom.Namespace,
+			})
+		}
+		for _, refPolicyTo := range refPolicy.Spec.To {
+			refGrant.Spec.To = append(refGrant.Spec.To, gwv1alpha2.ReferenceGrantTo{
+				Group: refPolicyTo.Group,
+				Kind:  refPolicyTo.Kind,
+				Name:  refPolicyTo.Name,
+			})
+		}
+		refGrants = append(refGrants, refGrant)
+	}
 
 	return refGrants, nil
 }


### PR DESCRIPTION
### Changes proposed in this PR:
The ReferencePolicy needs to be included for backward compatibility; however, it couldn't be included until v0.5.0-rc2 of kubernetes-sigs/gateway-api which restored the ReferencePolicy CRD to the default set and fixed a listing bug.

v0.5.0-rc2 was consumed in #279, but I wasn't aware of this related TODO until I attempted the [Learn guide](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway) which still uses the deprecated `ReferencePolicy` instead of the new `ReferenceGrant`.

### How I've tested this PR:
- [x] 🤖 tests pass
- [x] [Learn guide](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway) works

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
