### PR TITLE
Consume kubernetes-sigs/gateway-api v0.5.0

### DIFF
--- a/.changelog/283.txt
+++ b/.changelog/283.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+gateway-api: update to the [v0.5.0](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.5.0) release with v1beta1 resource support
+```

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.0-rc2
+- github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.0
 - bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
 - bases/api-gateway.consul.hashicorp.com_meshservices.yaml

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/klog/v2 v2.70.1
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/e2e-framework v0.0.7
-	sigs.k8s.io/gateway-api v0.5.0-rc2
+	sigs.k8s.io/gateway-api v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1549,8 +1549,8 @@ sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98
 sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/e2e-framework v0.0.7 h1:nMv2oSPBLWARse2aBoqX5Wq3ox67w8jrhTGWGpccWDQ=
 sigs.k8s.io/e2e-framework v0.0.7/go.mod h1:hdwYGVQg4bvDAah5eidNf2/qkG35qHjzuyMVr2A3oiY=
-sigs.k8s.io/gateway-api v0.5.0-rc2 h1:jzcILFbW0b7EFTk1SRpOi3dDnrkC2D69WYj+Yjh9PJY=
-sigs.k8s.io/gateway-api v0.5.0-rc2/go.mod h1:x0AP6gugkFV8fC/oTlnOMU0pnmuzIR8LfIPRVUjxSqA=
+sigs.k8s.io/gateway-api v0.5.0 h1:ze+k9fJqvmL8s1t3e4q1ST8RnN+f09dEv+gfacahlAE=
+sigs.k8s.io/gateway-api v0.5.0/go.mod h1:x0AP6gugkFV8fC/oTlnOMU0pnmuzIR8LfIPRVUjxSqA=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=


### PR DESCRIPTION
### Changes proposed in this PR:
Consume latest release of https://github.com/kubernetes-sigs/gateway-api.
Code is largely identical to the RC2 release consumed in #279 .

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
