### PR TITLE
Use pattern matching for release_branches

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -66,17 +66,6 @@ jobs:
         with:
           go-version: 1.18
 
-      - name: Update release_branches config
-        # TODO Make more robust in the future, could currently be a major or minor release
-        if: endsWith(env.NEW_API_GATEWAY_VERSION, '.0')
-        run: |
-          sudo apt-get -y install jq
-          go install github.com/mattolenik/hclq@latest
-          MINOR_VERSION=${NEW_API_GATEWAY_VERSION%.*}
-          NEW_RELEASE_BRANCH=release/$MINOR_VERSION.x
-          export NV=$(cat .release/ci.hcl | hclq get 'project.consul-api-gateway.github.release_branches[]' | jq -c ". += [\"$NEW_RELEASE_BRANCH\"]")
-          hclq --in=.release/ci.hcl --out=.release/ci.hcl set 'project.consul-api-gateway.github.release_branches[]' $NV
-
       - name: Regenerate golden files
         run: make generate-golden-files
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -13,9 +13,7 @@ project "consul-api-gateway" {
 
     release_branches = [
       "main",
-      "release/0.1.x",
-      "release/0.2.x",
-      "release/0.3.x",
+      "release/**",
     ]
   }
 }


### PR DESCRIPTION
### Changes proposed in this PR:
Pattern matching was recently added to our release tooling so that we no longer have to explicitly list every branch that should trigger release workflows. This simplifies our release preparation because we don't have to programmatically go in and add a new entry to `release_branches`.

### How I've tested this PR:
Confirmed that patterns in `release_branches` match the patterns used in our [build workflow](https://github.com/hashicorp/consul-api-gateway/blob/4d9bb77e40f3488e127f33b433dfa435bfa6d1f6/.github/workflows/build.yml#L6-L7). The contract for pattern matching in our release tooling is the same as GitHub's pattern matching.

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
