### PR TITLE
Implement InvalidKind reason for unknown/unsupported backendRef kind

### DIFF
--- a/.changelog/290.txt
+++ b/.changelog/290.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Assign InvalidKind reason to ResolvedRefs condition on routes where the backend reference is an unknown or unsupported kind
+```

--- a/internal/k8s/reconciler/config/statuses.yaml
+++ b/internal/k8s/reconciler/config/statuses.yaml
@@ -154,6 +154,9 @@
             This reason is used with the “ResolvedRefs” condition when one of the Listener’s Routes has a BackendRef
             to an object in another namespace, where the object in the other namespace does not have a ReferenceGrant
             explicitly allowing the reference.
+        - name: InvalidKind
+          description: >
+            This reason is used when a Route references a backend with an unsupported group or kind.
 
 
 

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -208,6 +208,8 @@ func (r *K8sRoute) OnBindFailed(err error, gateway store.Gateway) {
 				status.ResolvedRefs.ServiceNotFound = err
 			case service.RefNotPermittedErrorType:
 				status.ResolvedRefs.RefNotPermitted = err
+			case service.InvalidKindErrorType:
+				status.ResolvedRefs.InvalidKind = err
 			}
 
 			r.parentStatuses[id] = status

--- a/internal/k8s/reconciler/zz_generated_status.go
+++ b/internal/k8s/reconciler/zz_generated_status.go
@@ -609,6 +609,11 @@ type RouteResolvedRefsStatus struct {
 	//
 	// [spec]
 	RefNotPermitted error
+	// This reason is used when a Route references a backend with an unsupported
+	// group or kind.
+	//
+	// [spec]
+	InvalidKind error
 }
 
 const (
@@ -645,6 +650,11 @@ const (
 	//
 	// [spec]
 	RouteConditionReasonRefNotPermitted = "RefNotPermitted"
+	// RouteConditionReasonInvalidKind - This reason is used when a Route references
+	// a backend with an unsupported group or kind.
+	//
+	// [spec]
+	RouteConditionReasonInvalidKind = "InvalidKind"
 )
 
 // Condition returns the status condition of the RouteResolvedRefsStatus based
@@ -694,6 +704,17 @@ func (s RouteResolvedRefsStatus) Condition(generation int64) meta.Condition {
 		}
 	}
 
+	if s.InvalidKind != nil {
+		return meta.Condition{
+			Type:               RouteConditionResolvedRefs,
+			Status:             meta.ConditionFalse,
+			Reason:             RouteConditionReasonInvalidKind,
+			Message:            s.InvalidKind.Error(),
+			ObservedGeneration: generation,
+			LastTransitionTime: meta.Now(),
+		}
+	}
+
 	return meta.Condition{
 		Type:               RouteConditionResolvedRefs,
 		Status:             meta.ConditionTrue,
@@ -706,7 +727,7 @@ func (s RouteResolvedRefsStatus) Condition(generation int64) meta.Condition {
 
 // HasError returns whether any of the RouteResolvedRefsStatus errors are set.
 func (s RouteResolvedRefsStatus) HasError() bool {
-	return s.Errors != nil || s.ServiceNotFound != nil || s.ConsulServiceNotFound != nil || s.RefNotPermitted != nil
+	return s.Errors != nil || s.ServiceNotFound != nil || s.ConsulServiceNotFound != nil || s.RefNotPermitted != nil || s.InvalidKind != nil
 }
 
 // RouteStatus - The status associated with a Route with respect to a given

--- a/internal/k8s/reconciler/zz_generated_status_test.go
+++ b/internal/k8s/reconciler/zz_generated_status_test.go
@@ -211,6 +211,11 @@ func TestRouteResolvedRefsStatus(t *testing.T) {
 	require.Equal(t, "expected", status.Condition(0).Message)
 	require.Equal(t, RouteConditionReasonRefNotPermitted, status.Condition(0).Reason)
 	require.True(t, status.HasError())
+
+	status = RouteResolvedRefsStatus{InvalidKind: expected}
+	require.Equal(t, "expected", status.Condition(0).Message)
+	require.Equal(t, RouteConditionReasonInvalidKind, status.Condition(0).Reason)
+	require.True(t, status.HasError())
 }
 
 func TestRouteStatus(t *testing.T) {

--- a/internal/k8s/service/resolver.go
+++ b/internal/k8s/service/resolver.go
@@ -30,6 +30,7 @@ const (
 	K8sServiceResolutionErrorType ServiceResolutionErrorType = iota
 	ConsulServiceResolutionErrorType
 	GenericResolutionErrorType
+	InvalidKindErrorType
 	NoResolutionErrorType
 	RefNotPermittedErrorType
 )
@@ -54,6 +55,10 @@ func NewK8sResolutionError(inner string) ResolutionError {
 
 func NewConsulResolutionError(inner string) ResolutionError {
 	return ResolutionError{inner, ConsulServiceResolutionErrorType}
+}
+
+func NewInvalidKindError(inner string) ResolutionError {
+	return ResolutionError{inner, InvalidKindErrorType}
 }
 
 func NewRefNotPermittedError(inner string) ResolutionError {
@@ -217,7 +222,7 @@ func (r *backendResolver) Resolve(ctx context.Context, ref gwv1alpha2.BackendObj
 	case group == apigwv1alpha1.GroupVersion.Group && kind == apigwv1alpha1.MeshServiceKind:
 		return r.consulServiceForMeshService(ctx, namespacedName)
 	default:
-		return nil, NewResolutionError("unsupported reference type")
+		return nil, NewInvalidKindError("unsupported reference type")
 	}
 }
 

--- a/internal/k8s/service/resolver.go
+++ b/internal/k8s/service/resolver.go
@@ -222,7 +222,7 @@ func (r *backendResolver) Resolve(ctx context.Context, ref gwv1alpha2.BackendObj
 	case group == apigwv1alpha1.GroupVersion.Group && kind == apigwv1alpha1.MeshServiceKind:
 		return r.consulServiceForMeshService(ctx, namespacedName)
 	default:
-		return nil, NewInvalidKindError("unsupported reference type")
+		return nil, NewInvalidKindError(fmt.Sprintf("unsupported reference kind %s", kind))
 	}
 }
 

--- a/internal/k8s/service/resolver_test.go
+++ b/internal/k8s/service/resolver_test.go
@@ -3,27 +3,31 @@ package service
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func getLengthAtErrorType(r *ResolutionErrors, errType ServiceResolutionErrorType) int {
 	return len(r.errors[errType])
 }
-func TestResolutionErrors_Add(t *testing.T) {
 
+func TestResolutionErrors_Add(t *testing.T) {
 	r := NewResolutionErrors()
+
 	r.Add(NewConsulResolutionError("consul error"))
-	require.Equal(t, getLengthAtErrorType(r, ConsulServiceResolutionErrorType), 1)
+	assert.Equal(t, getLengthAtErrorType(r, ConsulServiceResolutionErrorType), 1)
 
 	r.Add(NewK8sResolutionError("k8s error"))
-	require.Equal(t, getLengthAtErrorType(r, K8sServiceResolutionErrorType), 1)
+	assert.Equal(t, getLengthAtErrorType(r, K8sServiceResolutionErrorType), 1)
 
 	r.Add(NewResolutionError("generic error"))
-	require.Equal(t, getLengthAtErrorType(r, GenericResolutionErrorType), 1)
+	assert.Equal(t, getLengthAtErrorType(r, GenericResolutionErrorType), 1)
 
 	r.Add(NewRefNotPermittedError("refnotpermitted error"))
-	require.Equal(t, getLengthAtErrorType(r, RefNotPermittedErrorType), 1)
+	assert.Equal(t, getLengthAtErrorType(r, RefNotPermittedErrorType), 1)
 
+	r.Add(NewInvalidKindError("invalidkind error"))
+	assert.Equal(t, getLengthAtErrorType(r, InvalidKindErrorType), 1)
 }
 
 func TestResolutionErrors_Flatten(t *testing.T) {
@@ -49,6 +53,18 @@ func TestResolutionErrors_Flatten(t *testing.T) {
 				errors: map[ServiceResolutionErrorType][]ResolutionError{
 					RefNotPermittedErrorType: {
 						NewRefNotPermittedError("expected"),
+					},
+				},
+			},
+		},
+		{
+			name:    "invalidkind error",
+			want:    InvalidKindErrorType,
+			wantErr: true,
+			fields: fields{
+				errors: map[ServiceResolutionErrorType][]ResolutionError{
+					InvalidKindErrorType: {
+						NewInvalidKindError("expected"),
 					},
 				},
 			},
@@ -128,6 +144,17 @@ func TestResolutionErrors_Empty(t *testing.T) {
 				errors: map[ServiceResolutionErrorType][]ResolutionError{
 					RefNotPermittedErrorType: {
 						NewRefNotPermittedError("expected"),
+					},
+				},
+			},
+		},
+		{
+			name: "invalidkind error",
+			want: false,
+			fields: fields{
+				errors: map[ServiceResolutionErrorType][]ResolutionError{
+					InvalidKindErrorType: {
+						NewInvalidKindError("expected"),
 					},
 				},
 			},


### PR DESCRIPTION
### Changes proposed in this PR:
The contract for `HTTPBackendRef` has changed to include a new reason, `InvalidKind`, for the `ResolvedRefs` condition when an unknown or unsupported backendRef kind is used ([docs](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPBackendRef)). This change set implements that reason.

### How I've tested this PR:
Created HTTPRoute w/ unknown/unsupported kind for `backendRef`, verifying that the new `InvalidKind` reason is assigned to the status.
<details>
<summary>Example</summary>

By making a small change to the `backendRef` on this HTTPRoute from the Learn guide:
```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: example-route-2
  namespace: consul
spec:
  parentRefs:
  - name: api-gateway
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
    backendRefs:
    - kind: Nonsense
      name: nginx
      namespace: consul
      port: 80
```
</details>

### How I expect reviewers to test this PR:

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
