### PR TITLE
Implement BackendNotFound reason for backendRef that does not exist

### DIFF
--- a/.changelog/291.txt
+++ b/.changelog/291.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Assign BackendNotFound reason to ResolvedRefs condition on routes where the backend reference is a supported kind but does not exist
+```

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -930,7 +930,7 @@ func TestHTTPMeshService(t *testing.T) {
 
 			// Verify HTTPRoute has updated its status
 			check := createConditionsCheck([]meta.Condition{{
-				Type: reconciler.RouteConditionResolvedRefs, Status: "False", Reason: reconciler.RouteConditionReasonServiceNotFound},
+				Type: reconciler.RouteConditionResolvedRefs, Status: "False", Reason: reconciler.RouteConditionReasonBackendNotFound},
 			})
 			require.Eventually(t, httpRouteStatusCheck(ctx, resources, gatewayName, routeName, namespace, check), checkTimeout, checkInterval, "route status not set in allotted time")
 

--- a/internal/k8s/reconciler/config/statuses.yaml
+++ b/internal/k8s/reconciler/config/statuses.yaml
@@ -157,7 +157,9 @@
         - name: InvalidKind
           description: >
             This reason is used when a Route references a backend with an unsupported group or kind.
-
+        - name: BackendNotFound
+          description: >
+            This reason is used when a Route references a backend with a supported kind but that does not exist.
 
 
 - kind: Listener

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -210,6 +210,8 @@ func (r *K8sRoute) OnBindFailed(err error, gateway store.Gateway) {
 				status.ResolvedRefs.RefNotPermitted = err
 			case service.InvalidKindErrorType:
 				status.ResolvedRefs.InvalidKind = err
+			case service.BackendNotFoundErrorType:
+				status.ResolvedRefs.BackendNotFound = err
 			}
 
 			r.parentStatuses[id] = status

--- a/internal/k8s/reconciler/zz_generated_status.go
+++ b/internal/k8s/reconciler/zz_generated_status.go
@@ -614,6 +614,11 @@ type RouteResolvedRefsStatus struct {
 	//
 	// [spec]
 	InvalidKind error
+	// This reason is used when a Route references a backend with a supported kind
+	// but that does not exist.
+	//
+	// [spec]
+	BackendNotFound error
 }
 
 const (
@@ -655,6 +660,11 @@ const (
 	//
 	// [spec]
 	RouteConditionReasonInvalidKind = "InvalidKind"
+	// RouteConditionReasonBackendNotFound - This reason is used when a Route
+	// references a backend with a supported kind but that does not exist.
+	//
+	// [spec]
+	RouteConditionReasonBackendNotFound = "BackendNotFound"
 )
 
 // Condition returns the status condition of the RouteResolvedRefsStatus based
@@ -715,6 +725,17 @@ func (s RouteResolvedRefsStatus) Condition(generation int64) meta.Condition {
 		}
 	}
 
+	if s.BackendNotFound != nil {
+		return meta.Condition{
+			Type:               RouteConditionResolvedRefs,
+			Status:             meta.ConditionFalse,
+			Reason:             RouteConditionReasonBackendNotFound,
+			Message:            s.BackendNotFound.Error(),
+			ObservedGeneration: generation,
+			LastTransitionTime: meta.Now(),
+		}
+	}
+
 	return meta.Condition{
 		Type:               RouteConditionResolvedRefs,
 		Status:             meta.ConditionTrue,
@@ -727,7 +748,7 @@ func (s RouteResolvedRefsStatus) Condition(generation int64) meta.Condition {
 
 // HasError returns whether any of the RouteResolvedRefsStatus errors are set.
 func (s RouteResolvedRefsStatus) HasError() bool {
-	return s.Errors != nil || s.ServiceNotFound != nil || s.ConsulServiceNotFound != nil || s.RefNotPermitted != nil || s.InvalidKind != nil
+	return s.Errors != nil || s.ServiceNotFound != nil || s.ConsulServiceNotFound != nil || s.RefNotPermitted != nil || s.InvalidKind != nil || s.BackendNotFound != nil
 }
 
 // RouteStatus - The status associated with a Route with respect to a given

--- a/internal/k8s/reconciler/zz_generated_status_test.go
+++ b/internal/k8s/reconciler/zz_generated_status_test.go
@@ -216,6 +216,11 @@ func TestRouteResolvedRefsStatus(t *testing.T) {
 	require.Equal(t, "expected", status.Condition(0).Message)
 	require.Equal(t, RouteConditionReasonInvalidKind, status.Condition(0).Reason)
 	require.True(t, status.HasError())
+
+	status = RouteResolvedRefsStatus{BackendNotFound: expected}
+	require.Equal(t, "expected", status.Condition(0).Message)
+	require.Equal(t, RouteConditionReasonBackendNotFound, status.Condition(0).Reason)
+	require.True(t, status.HasError())
 }
 
 func TestRouteStatus(t *testing.T) {

--- a/internal/k8s/service/resolver_test.go
+++ b/internal/k8s/service/resolver_test.go
@@ -28,6 +28,9 @@ func TestResolutionErrors_Add(t *testing.T) {
 
 	r.Add(NewInvalidKindError("invalidkind error"))
 	assert.Equal(t, getLengthAtErrorType(r, InvalidKindErrorType), 1)
+
+	r.Add(NewBackendNotFoundError("backendnotfound error"))
+	assert.Equal(t, getLengthAtErrorType(r, BackendNotFoundErrorType), 1)
 }
 
 func TestResolutionErrors_Flatten(t *testing.T) {
@@ -65,6 +68,18 @@ func TestResolutionErrors_Flatten(t *testing.T) {
 				errors: map[ServiceResolutionErrorType][]ResolutionError{
 					InvalidKindErrorType: {
 						NewInvalidKindError("expected"),
+					},
+				},
+			},
+		},
+		{
+			name:    "backendnotfound error",
+			want:    BackendNotFoundErrorType,
+			wantErr: true,
+			fields: fields{
+				errors: map[ServiceResolutionErrorType][]ResolutionError{
+					BackendNotFoundErrorType: {
+						NewBackendNotFoundError("expected"),
 					},
 				},
 			},
@@ -155,6 +170,17 @@ func TestResolutionErrors_Empty(t *testing.T) {
 				errors: map[ServiceResolutionErrorType][]ResolutionError{
 					InvalidKindErrorType: {
 						NewInvalidKindError("expected"),
+					},
+				},
+			},
+		},
+		{
+			name: "backendnotfound error",
+			want: false,
+			fields: fields{
+				errors: map[ServiceResolutionErrorType][]ResolutionError{
+					BackendNotFoundErrorType: {
+						NewBackendNotFoundError("expected"),
 					},
 				},
 			},


### PR DESCRIPTION
> Will want to review + merge #290 first which this PR is based on

### Changes proposed in this PR:
The contract for `HTTPBackendRef` has changed to include a new reason, `BackendNotFound`, for the `ResolvedRefs` condition when a known backendRef kind is used but the backend does not exist ([docs](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPBackendRef)). This change set implements that reason.

### How I've tested this PR:
Created HTTPRoute w/ non-existent `Service` for `backendRef`, verifying that the new `BackendNotFound` reason is assigned to the status.
<details>
<summary>Example</summary>

By making a small change to the `backendRef` on this HTTPRoute from the Learn guide:
```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: example-route-2
  namespace: consul
spec:
  parentRefs:
  - name: api-gateway
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
    backendRefs:
    - kind: Service
      name: nginx-not-here
      namespace: consul
      port: 80
```
</details>
### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
