### PR TITLE
referencepolicy: finish backwards compatibility support and tests

### DIFF
--- a/internal/k8s/controllers/gateway_controller_test.go
+++ b/internal/k8s/controllers/gateway_controller_test.go
@@ -5,10 +5,15 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
 	reconcilerMocks "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/mocks"
 	"github.com/hashicorp/go-hclog"
@@ -75,4 +80,148 @@ func TestGateway(t *testing.T) {
 			require.Equal(t, test.result, result)
 		})
 	}
+}
+
+func TestGatewayReferenceGrantToGatewayRequests(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	secretNamespace := gwv1beta1.Namespace("namespace3")
+
+	gatewayTLSConfig := gwv1beta1.GatewayTLSConfig{
+		CertificateRefs: []gwv1beta1.SecretObjectReference{{
+			Name:      gwv1beta1.ObjectName("secret"),
+			Namespace: &secretNamespace,
+		}},
+	}
+
+	gatewaySpec := gwv1beta1.GatewaySpec{
+		Listeners: []gwv1beta1.Listener{{
+			TLS: &gatewayTLSConfig,
+		}},
+	}
+
+	refGrant := gwv1alpha2.ReferenceGrant{
+		TypeMeta:   metav1.TypeMeta{Kind: "ReferenceGrant"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace3"},
+		Spec: gwv1alpha2.ReferenceGrantSpec{
+			From: []gwv1alpha2.ReferenceGrantFrom{{
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "Gateway",
+				Namespace: "namespace1",
+			}},
+			To: []gwv1alpha2.ReferenceGrantTo{{
+				Kind: "Secret",
+			}},
+		},
+	}
+
+	client := gatewayclient.NewTestClient(
+		nil,
+		&gwv1beta1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway",
+				Namespace: "namespace1",
+			},
+			Spec: gatewaySpec,
+		},
+		&gwv1beta1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway",
+				Namespace: "namespace2",
+			},
+			Spec: gatewaySpec,
+		},
+		&refGrant,
+	)
+
+	controller := &GatewayReconciler{
+		Client:         client,
+		Log:            hclog.NewNullLogger(),
+		ControllerName: mockControllerName,
+		Manager:        reconcilerMocks.NewMockReconcileManager(ctrl),
+	}
+
+	requests := controller.referenceGrantToGatewayRequests(&refGrant)
+
+	assert.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Name:      "gateway",
+			Namespace: "namespace1",
+		},
+	}}, requests)
+}
+
+func TestGatewayReferencePolicyToGatewayRequests(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	secretNamespace := gwv1beta1.Namespace("namespace3")
+
+	gatewayTLSConfig := gwv1beta1.GatewayTLSConfig{
+		CertificateRefs: []gwv1beta1.SecretObjectReference{{
+			Name:      gwv1beta1.ObjectName("secret"),
+			Namespace: &secretNamespace,
+		}},
+	}
+
+	gatewaySpec := gwv1beta1.GatewaySpec{
+		Listeners: []gwv1beta1.Listener{{
+			TLS: &gatewayTLSConfig,
+		}},
+	}
+
+	refPolicy := gwv1alpha2.ReferencePolicy{
+		TypeMeta:   metav1.TypeMeta{Kind: "ReferencePolicy"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "namespace3"},
+		Spec: gwv1alpha2.ReferenceGrantSpec{
+			From: []gwv1alpha2.ReferenceGrantFrom{{
+				Group:     "gateway.networking.k8s.io",
+				Kind:      "Gateway",
+				Namespace: "namespace1",
+			}},
+			To: []gwv1alpha2.ReferenceGrantTo{{
+				Kind: "Secret",
+			}},
+		},
+	}
+
+	client := gatewayclient.NewTestClient(
+		nil,
+		&gwv1beta1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway",
+				Namespace: "namespace1",
+			},
+			Spec: gatewaySpec,
+		},
+		&gwv1beta1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gateway",
+				Namespace: "namespace2",
+			},
+			Spec: gatewaySpec,
+		},
+		&refPolicy,
+	)
+
+	controller := &GatewayReconciler{
+		Client:         client,
+		Log:            hclog.NewNullLogger(),
+		ControllerName: mockControllerName,
+		Manager:        reconcilerMocks.NewMockReconcileManager(ctrl),
+	}
+
+	requests := controller.referencePolicyToGatewayRequests(&refPolicy)
+
+	assert.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Name:      "gateway",
+			Namespace: "namespace1",
+		},
+	}}, requests)
 }

--- a/internal/k8s/controllers/tcp_route_controller.go
+++ b/internal/k8s/controllers/tcp_route_controller.go
@@ -168,9 +168,9 @@ func (r *TCPRouteReconciler) getRouteRequestsFromReferenceGrant(refGrant *gwv1al
 	return requests
 }
 
-// getRoutesAffectedByReferencePolicy retrieves all TCPRoutes potentially impacted
-// by the ReferencePolicy being modified. Currently, this is unfiltered and so returns
-// all TCPRoutes in the namespace referenced by the ReferencePolicy.
+// getRoutesAffectedByReferenceGrant retrieves all TCPRoutes potentially impacted
+// by the ReferenceGrant being modified. Currently, this is unfiltered and so returns
+// all TCPRoutes in the namespace referenced by the ReferenceGrant.
 func (r *TCPRouteReconciler) getRoutesAffectedByReferenceGrant(refGrant *gwv1alpha2.ReferenceGrant) []gwv1alpha2.TCPRoute {
 	var matches []gwv1alpha2.TCPRoute
 

--- a/internal/k8s/gatewayclient/gatewayclient.go
+++ b/internal/k8s/gatewayclient/gatewayclient.go
@@ -545,22 +545,7 @@ func (g *gatewayClient) GetReferenceGrantsInNamespace(ctx context.Context, names
 		return nil, NewK8sError(err)
 	}
 	for _, refPolicy := range refPolicyList.Items {
-		refGrant := gwv1alpha2.ReferenceGrant{}
-		for _, refPolicyFrom := range refPolicy.Spec.From {
-			refGrant.Spec.From = append(refGrant.Spec.From, gwv1alpha2.ReferenceGrantFrom{
-				Group:     refPolicyFrom.Group,
-				Kind:      refPolicyFrom.Kind,
-				Namespace: refPolicyFrom.Namespace,
-			})
-		}
-		for _, refPolicyTo := range refPolicy.Spec.To {
-			refGrant.Spec.To = append(refGrant.Spec.To, gwv1alpha2.ReferenceGrantTo{
-				Group: refPolicyTo.Group,
-				Kind:  refPolicyTo.Kind,
-				Name:  refPolicyTo.Name,
-			})
-		}
-		refGrants = append(refGrants, refGrant)
+		refGrants = append(refGrants, gwv1alpha2.ReferenceGrant{Spec: refPolicy.Spec})
 	}
 
 	return refGrants, nil


### PR DESCRIPTION
### Changes proposed in this PR:

- [x] Simplify ReferencePolicy to ReferenceGrant conversion logic in gateway client
  - To match https://github.com/hashicorp/consul-api-gateway/blob/main/internal/k8s/controllers/http_route_controller.go#L141, possible since ReferencePolicy now uses ReferenceGrantSpec internally as the type of its `Spec` field.
- [x] Fixup comment to properly refer to ReferenceGrant instead of ReferencePolicy
- [x] Add tests for Gateway certificateRefs ReferenceGrant, and tests for ReferencePolicy backwards compatibility
- [x] Add e2e tests for ReferencePolicy backwards compatibility

### How I've tested this PR:

CI tests should still be passing after changes.

### How I expect reviewers to test this PR:

Verify changes make sense and sufficiently cover support.

### Checklist:
- [x] Tests added
- [ ] ~~CHANGELOG entry added~~
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
