### PR TITLE
TLS Watch and Rotate

### DIFF
--- a/internal/envoy/mocks/secrets.go
+++ b/internal/envoy/mocks/secrets.go
@@ -128,15 +128,15 @@ func (m *MockSecretManager) EXPECT() *MockSecretManagerMockRecorder {
 }
 
 // Manage mocks base method.
-func (m *MockSecretManager) Manage(ctx context.Context) {
+func (m *MockSecretManager) Manage(ctx context.Context, forceInterval time.Duration) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Manage", ctx)
+	m.ctrl.Call(m, "Manage", ctx, forceInterval)
 }
 
 // Manage indicates an expected call of Manage.
-func (mr *MockSecretManagerMockRecorder) Manage(ctx interface{}) *gomock.Call {
+func (mr *MockSecretManagerMockRecorder) Manage(ctx, forceInterval interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Manage", reflect.TypeOf((*MockSecretManager)(nil).Manage), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Manage", reflect.TypeOf((*MockSecretManager)(nil).Manage), ctx, forceInterval)
 }
 
 // SetResourcesForNode mocks base method.

--- a/internal/envoy/secrets.go
+++ b/internal/envoy/secrets.go
@@ -311,7 +311,7 @@ func (s *secretManager) Manage(ctx context.Context, forceInterval time.Duration)
 		case <-time.After(s.loopTimeout):
 			force := false
 			now := time.Now()
-			if now.Sub(lastForce) > forceInterval {
+			if now.Sub(lastForce) >= forceInterval {
 				force = true
 				lastForce = now
 			}

--- a/internal/envoy/secrets.go
+++ b/internal/envoy/secrets.go
@@ -307,7 +307,7 @@ func (s *secretManager) Manage(ctx context.Context, forceInterval time.Duration)
 	for {
 		select {
 		case <-time.After(s.loopTimeout):
-			s.manage(ctx, force)
+			s.manage(ctx, false)
 		case <-time.After(forceInterval):
 			s.manage(ctx, true)
 		case <-ctx.Done():

--- a/internal/envoy/secrets.go
+++ b/internal/envoy/secrets.go
@@ -300,22 +300,16 @@ func (s *secretManager) unwatch(names []string, node string) error {
 	return nil
 }
 
-// Manage is used for re-fetching expiring TLS certificates and updating them
+// Manage is used for re-fetching expiring TLS certificates and updating them, additionally will force re-fetch all certificates every force intercal
 func (s *secretManager) Manage(ctx context.Context, forceInterval time.Duration) {
 	s.logger.Trace("running secrets manager")
-
-	lastForce := time.Now()
 
 	for {
 		select {
 		case <-time.After(s.loopTimeout):
-			force := false
-			now := time.Now()
-			if now.Sub(lastForce) >= forceInterval {
-				force = true
-				lastForce = now
-			}
 			s.manage(ctx, force)
+		case <-time.After(forceInterval):
+			s.manage(ctx, true)
 		case <-ctx.Done():
 			// we finished the context, just return
 			return

--- a/internal/envoy/secrets.go
+++ b/internal/envoy/secrets.go
@@ -300,7 +300,7 @@ func (s *secretManager) unwatch(names []string, node string) error {
 	return nil
 }
 
-// Manage is used for re-fetching expiring TLS certificates and updating them, additionally will force re-fetch all certificates every force intercal
+// Manage is used for re-fetching expiring TLS certificates and updating them, additionally will force re-fetch all certificates every force interval
 func (s *secretManager) Manage(ctx context.Context, forceInterval time.Duration) {
 	s.logger.Trace("running secrets manager")
 


### PR DESCRIPTION
### Changes proposed in this PR:
- To account for the fact that certs can technically be rotated at any time, after a set interval force a repull of all certificates being watched. 

### How I've tested this PR:
- Tests pass
- Locally using Hashiqube to run vault and kind to run api gateway

### How I expect reviewers to test this PR:
- Tests pass

### Checklist:
- [ X ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
