### PR TITLE
ci: update Consul versions in test matrices, bump consul-k8s to v0.47.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       matrix:
         goos: ["linux"]
         goarch: ["arm", "arm64", "386", "amd64"]
-        go: ["1.18.3"]
+        go: ["1.18.5"]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       # we currently have the +ent as part of the verion string so removing it here
-      # we should separate this from the version going forward 
+      # we should separate this from the version going forward
       - name: Remove + from version
         run: |
           echo "version=$(echo $version | sed 's/+ent//g')" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.11.5
-        - 1.12.2
-        - 1.11.5+ent
-        - 1.12.2+ent
+        - 1.11.8
+        - 1.11.8+ent
+        - 1.12.4
+        - 1.12.4+ent
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/consul@${{ matrix.consul-version }}
@@ -92,10 +92,10 @@ jobs:
     strategy:
       matrix:
         consul-image:
-        - 'hashicorp/consul:1.11.5'
-        - 'hashicorp/consul-enterprise:1.11.5-ent'
-        - 'hashicorp/consul:1.12.2'
-        - 'hashicorp/consul-enterprise:1.12.2-ent'
+        - 'hashicorp/consul:1.11.8'
+        - 'hashicorp/consul-enterprise:1.11.8-ent'
+        - 'hashicorp/consul:1.12.4'
+        - 'hashicorp/consul-enterprise:1.12.4-ent'
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -29,16 +29,16 @@ jobs:
           - kind
           - eks
         config:
-          - name: "consul@v1.11 + consul-k8s@v0.45.0"
+          - name: "consul@v1.11 + consul-k8s@v0.47.1"
             api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
             consul-image: "hashicorp/consul:1.11"
             envoy-image: "envoyproxy/envoy:v1.20-latest"
-            consul-k8s-version: "charts/capigw-controller-clusterrole-referencegrants"
-          - name: "consul@v1.12 + consul-k8s@v0.45.0"
+            consul-k8s-version: "v0.47.1"
+          - name: "consul@v1.12 + consul-k8s@v0.47.1"
             api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
-            consul-k8s-version: "charts/capigw-controller-clusterrole-referencegrants"
+            consul-k8s-version: "v0.47.1"
       fail-fast: true
     name: "${{ matrix.cluster-type }} - ${{ matrix.config.name }}"
     concurrency:

--- a/.github/workflows/conformance_with_build.yml
+++ b/.github/workflows/conformance_with_build.yml
@@ -31,16 +31,16 @@ jobs:
     strategy:
       matrix:
         config:
-          - name: "consul@v1.11 + consul-k8s@v0.45.0"
+          - name: "consul@v1.11 + consul-k8s@v0.47.1"
             api-gateway-image: "consul-api-gateway:local-build"
             consul-image: "hashicorp/consul:1.11"
             envoy-image: "envoyproxy/envoy:v1.20-latest"
-            consul-k8s-version: "charts/capigw-controller-clusterrole-referencegrants"
-          - name: "consul@v1.12 + consul-k8s@v0.45.0"
+            consul-k8s-version: "v0.47.1"
+          - name: "consul@v1.12 + consul-k8s@v0.47.1"
             api-gateway-image: "consul-api-gateway:local-build"
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
-            consul-k8s-version: "charts/capigw-controller-clusterrole-referencegrants"
+            consul-k8s-version: "v0.47.1"
       fail-fast: true
     name: "${{ matrix.config.name }}"
 

--- a/internal/testing/conformance/consul-config.yaml
+++ b/internal/testing/conformance/consul-config.yaml
@@ -1,5 +1,4 @@
 global:
-  imageK8S: "docker.mirror.hashicorp.services/hashicorpdev/consul-k8s-control-plane:latest"
   tls:
     enabled: true
 server:


### PR DESCRIPTION
### Changes proposed in this PR:
- Update consul-k8s version in conformance tests from pin of now-merged https://github.com/hashicorp/consul-k8s/pull/1299, adding RBAC for ReferenceGrant, to v0.47.0.
- Bump Consul v1.11 and v1.12 to latest patch releases in test matrices
- ~~Add Consul v1.13 to test matrices~~

### How I've tested this PR:
Running CI unit, e2e and conformance tests for all supported versions.

### How I expect reviewers to test this PR:
Confirm that all new or updated CI tests are passing.

### Checklist:
- [x] Tests added
- [ ] ~~CHANGELOG entry added~~
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
