### PR TITLE
ci: add Consul v1.13 and 1.14-dev edge builds to test matrices

### DIFF
--- a/.changelog/307.txt
+++ b/.changelog/307.txt
@@ -1,0 +1,3 @@
+```release-note:note
+When attempting to bind an HTTPRoute to multiple Consul API Gateway deployments (functionality that is not currently supported), a deployment with Consul v1.13+ may return a 403 response instead of the prior 503.
+```

--- a/.changelog/307.txt
+++ b/.changelog/307.txt
@@ -1,3 +1,0 @@
-```release-note:note
-When attempting to bind an HTTPRoute to multiple Consul API Gateway deployments (functionality that is not currently supported), a deployment with Consul v1.13+ may return a 403 response instead of the prior 503.
-```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         - 1.11.8+ent
         - 1.12.4
         - 1.12.4+ent
+        - 1.13.1
+        - 1.13.1+ent
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/consul@${{ matrix.consul-version }}
@@ -96,6 +98,10 @@ jobs:
         - 'hashicorp/consul-enterprise:1.11.8-ent'
         - 'hashicorp/consul:1.12.4'
         - 'hashicorp/consul-enterprise:1.12.4-ent'
+        - 'hashicorp/consul:1.13.1'
+        - 'hashicorp/consul-enterprise:1.13.1-ent'
+        - 'hashicorppreview/consul:1.14-dev'
+        # - 'hashicorppreview/consul-enterprise:1.14-dev'
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,8 @@ jobs:
         - 'hashicorp/consul:1.13.1'
         - 'hashicorp/consul-enterprise:1.13.1-ent'
         - 'hashicorppreview/consul:1.14-dev'
-        # - 'hashicorppreview/consul-enterprise:1.14-dev'
+        # Currently no preview builds for consul-enterprise
+        # - 'hashicorppreview/consul-enterprise:1.14-ent'
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -39,6 +39,16 @@ jobs:
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
             consul-k8s-version: "v0.47.1"
+          - name: "consul@v1.13 + consul-k8s@v0.47.1"
+            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
+            consul-image: "hashicorp/consul:1.13"
+            envoy-image: "envoyproxy/envoy:v1.22-latest"
+            consul-k8s-version: "v0.47.1"
+          - name: "consul@v1.14-dev + consul-k8s@v0.47.1"
+            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
+            consul-image: "hashicorppreview/consul:1.14-dev"
+            envoy-image: "envoyproxy/envoy:v1.22-latest"
+            consul-k8s-version: "v0.47.1"
       fail-fast: true
     name: "${{ matrix.cluster-type }} - ${{ matrix.config.name }}"
     concurrency:

--- a/.github/workflows/conformance_with_build.yml
+++ b/.github/workflows/conformance_with_build.yml
@@ -41,6 +41,16 @@ jobs:
             consul-image: "hashicorp/consul:1.12"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
             consul-k8s-version: "v0.47.1"
+          - name: "consul@v1.13 + consul-k8s@v0.47.1"
+            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
+            consul-image: "hashicorp/consul:1.13"
+            envoy-image: "envoyproxy/envoy:v1.22-latest"
+            consul-k8s-version: "v0.47.1"
+          - name: "consul@v1.14-dev + consul-k8s@v0.47.1"
+            api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
+            consul-image: "hashicorppreview/consul:1.14-dev"
+            envoy-image: "envoyproxy/envoy:v1.22-latest"
+            consul-k8s-version: "v0.47.1"
       fail-fast: true
     name: "${{ matrix.config.name }}"
 


### PR DESCRIPTION
### Changes proposed in this PR:
Refs https://github.com/hashicorp/consul-api-gateway/pull/303#issuecomment-1211339214

### How I've tested this PR:
Running CI unit, e2e and conformance tests for all supported versions.

### How I expect reviewers to test this PR:
Confirm that mitigations for new behavior are understood and acceptable. Do we want to check upstream Consul core per-commit builds in regular CI, or only nightly conformance?

### Checklist:
- [x] Tests added
- [ ] ~~CHANGELOG entry added~~
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
