### PR TITLE
Fix intention syncing CAS index

### DIFF
--- a/.changelog/308.txt
+++ b/.changelog/308.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix intentions syncing for multiple gateways bound to a single route.
+```

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -2000,12 +2000,9 @@ func TestRouteParentRefChange(t *testing.T) {
 				Body:       serviceOne.Name,
 			}, nil, "service one not routable from first gateway in allotted time")
 
-			// TODO: Routing from multiple gateways is not yet supported.
-			// When implemented, this check should be updated to wait for
-			// http.StatusOK and serviceOne.Name as the body content prefix.
 			checkRoute(t, secondGatewayCheckPort, "/", httpResponse{
-				StatusCode: http.StatusServiceUnavailable,
-				Body:       "no healthy upstream",
+				StatusCode: http.StatusOK,
+				Body:       serviceOne.Name,
 			}, nil, "service one not returning expected error from second gateway in allotted time")
 
 			// Update httpRoute from remote, then remove first gateway ParentRef

--- a/internal/consul/intentions.go
+++ b/internal/consul/intentions.go
@@ -331,10 +331,10 @@ func (r *IntentionsReconciler) updateIntentionSources(name api.CompoundServiceNa
 }
 
 func (r *IntentionsReconciler) getOrInitIntention(name api.CompoundServiceName) (intention *api.ServiceIntentionsConfigEntry, idx uint64, err error) {
-	entry, meta, err := r.consulConfig.Get(api.ServiceIntentions, name.Name, &api.QueryOptions{Namespace: name.Namespace})
+	entry, _, err := r.consulConfig.Get(api.ServiceIntentions, name.Name, &api.QueryOptions{Namespace: name.Namespace})
 	if err == nil {
 		intention = entry.(*api.ServiceIntentionsConfigEntry)
-		return intention, meta.LastIndex, nil
+		return intention, entry.GetModifyIndex(), nil
 	}
 
 	if strings.Contains(err.Error(), "Unexpected response code: 404") {


### PR DESCRIPTION
### Changes proposed in this PR:

Our CAS operation for updating intentions was broken because it was using the wrong config entry index. The result is that if multiple gateways bound to a single service then intentions for the second gateway weren't being properly created. This changes the sync code to use the proper index.

### How I've tested this PR:

Manually and updated tests.

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
