### PR TITLE
Prepare for release of v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## UNRELEASED
 
+## 0.4.0 (August 16, 2022)
+DEPRECATIONS:
+
+* gateway-api: ReferencePolicy is deprecated and will be removed in a future release. The functionally identical ReferenceGrant should be used instead. [[GH-224](https://github.com/hashicorp/consul-api-gateway/issues/224)]
+
+FEATURES:
+
+* Assign BackendNotFound reason to ResolvedRefs condition on routes where the backend reference is a supported kind but does not exist [[GH-291](https://github.com/hashicorp/consul-api-gateway/issues/291)]
+* Assign InvalidKind reason to ResolvedRefs condition on routes where the backend reference is an unknown or unsupported kind [[GH-290](https://github.com/hashicorp/consul-api-gateway/issues/290)]
+* Support prefix replacement URLRewrite filter ([docs](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPPathModifier)) [[GH-282](https://github.com/hashicorp/consul-api-gateway/issues/282)]
+* gateway-api: update to the [v0.5.0-rc1](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.5.0-rc1) release with v1beta1 resource support [[GH-224](https://github.com/hashicorp/consul-api-gateway/issues/224)]
+* gateway-api: update to the [v0.5.0-rc2](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.5.0-rc2) release with v1beta1 resource support [[GH-279](https://github.com/hashicorp/consul-api-gateway/issues/279)]
+* gateway-api: update to the [v0.5.0](https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.5.0) release with v1beta1 resource support [[GH-283](https://github.com/hashicorp/consul-api-gateway/issues/283)]
+
+BUG FIXES:
+
+* Fix intentions syncing for multiple gateways bound to a single route. [[GH-308](https://github.com/hashicorp/consul-api-gateway/issues/308)]
+* Revalidate HTTPRoutes and TCPRoutes and update status when the Kubernetes Service(s) that they reference are modified [[GH-247](https://github.com/hashicorp/consul-api-gateway/issues/247)]
+* Sync in-memory store to Consul at a regular interval in the background [[GH-278](https://github.com/hashicorp/consul-api-gateway/issues/278)]
+
 ## 0.3.0 (June 21, 2022)
 BREAKING CHANGES:
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Consul API Gateway implements the Kubernetes [Gateway API Specification](https:/
 ## Prerequisites  
 
 The Consul API Gateway must be installed on a Kubernetes cluster with the [Consul K8s](https://github.com/hashicorp/consul-k8s) service
-mesh deployed on it. The installed version of Consul must be `v1.12.2` or greater.
+mesh deployed on it. The installed version of Consul must be `v1.11.2` or greater.
 
 The Consul Helm chart must be used, with specific settings, to install Consul on the Kubernetes
-cluster. The Consul Helm chart must be version `0.45.0` or greater.  See the Consul API Gateway documentation for the required settings.
+cluster. The Consul Helm chart must be version `0.47.1` or greater.  See the Consul API Gateway documentation for the required settings.
 
 # Documentation
 

--- a/config/deployment/deployment.yaml
+++ b/config/deployment/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: consul-api-gateway-controller
       containers:
-      - image: hashicorp/consul-api-gateway:0.3.0
+      - image: hashicorp/consul-api-gateway:0.4.0
         command: ["consul-api-gateway", "server", "-consul-address", "$(HOST_IP):8501", "-ca-file", "/ca/tls.crt", "-sds-server-host", "$(IP)", "-k8s-namespace", "$(CONSUL_K8S_NAMESPACE)", "-log-level", "$(LOG_LEVEL)"]
         name: consul-api-gateway-controller
         ports:

--- a/dev/docs/example-setup.md
+++ b/dev/docs/example-setup.md
@@ -72,8 +72,8 @@ We have provided a set of `kustomize` manifests for installing the Consul API Ga
 Apply them to your cluster using the following commands.
 
 ```bash
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.3.0"
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.3.0"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.4.0"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.4.0"
 ```
 
 ## Installing the demo Gateway and Mesh Service
@@ -116,7 +116,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.3.0
+- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.4.0
 
 patches:
 - target:

--- a/dev/docs/supported-features.md
+++ b/dev/docs/supported-features.md
@@ -2,8 +2,8 @@
 Below is a list of the Kubernetes Gateway API features supported in the current release of the
 Consul API Gateway.
 
-Consul API Gateway version: **v0.2.0**
-Suppoorted K8s Gateway API version: **v1alpha2**
+Consul API Gateway version: **v0.4.0**
+Suppoorted K8s Gateway API version: **v1beta1**
 
 Supported features are marked with a grey checkbox
 
@@ -129,6 +129,8 @@ Supported features are marked with a grey checkbox
         - [x] *ServiceNotFound* weren't able to find the referenced Kubernetes service
         - [x] *ConsulServiceNotFound* weren't able to find the referenced Consul mesh service
         - [x] *RefNotPermitted* weren't able to route across namespaces due to a missing ReferenceGrant
+        - [x] *InvalidKind* backend reference is an unknown or unsupported kind
+        - [x] *BackendNotFound* backend reference is a supported kind but does not exist
 
 - [x] TCPRoute - we are limited by Consul's ability to only route to a single TCP-based upstream, so TCP-based Gateway listeners only support a single TCPRoute with a single rule with a single backend; otherwise, either the TCPRoute is considered invalid or the Gateway status is set as having conflicting routes.
 - [ ] TLSRoute - TODO

--- a/dev/docs/supported-features.md
+++ b/dev/docs/supported-features.md
@@ -3,7 +3,7 @@ Below is a list of the Kubernetes Gateway API features supported in the current 
 Consul API Gateway.
 
 Consul API Gateway version: **v0.4.0**
-Suppoorted K8s Gateway API version: **v1beta1**
+Supported K8s Gateway API version: **v1beta1**
 
 Supported features are marked with a grey checkbox
 


### PR DESCRIPTION
Consul API Gateway version being released: `0.4.0`
Now requires:
- consul: `1.11.2`
- consul-k8s: `0.47.1`