### PR TITLE
Bump version to next minor release

### DIFF
--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -92,7 +92,7 @@ spec:
         - cp
         - /bin/consul-api-gateway
         - /bootstrap/consul-api-gateway
-        image: hashicorp/consul-api-gateway:0.4.0
+        image: hashicorp/consul-api-gateway:0.5.0
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -92,7 +92,7 @@ spec:
         - cp
         - /bin/consul-api-gateway
         - /bootstrap/consul-api-gateway
-        image: hashicorp/consul-api-gateway:0.4.0
+        image: hashicorp/consul-api-gateway:0.5.0
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -95,7 +95,7 @@ spec:
         - cp
         - /bin/consul-api-gateway
         - /bootstrap/consul-api-gateway
-        image: hashicorp/consul-api-gateway:0.4.0
+        image: hashicorp/consul-api-gateway:0.5.0
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -95,7 +95,7 @@ spec:
         - cp
         - /bin/consul-api-gateway
         - /bootstrap/consul-api-gateway
-        image: hashicorp/consul-api-gateway:0.4.0
+        image: hashicorp/consul-api-gateway:0.5.0
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.4.0"
+	Version = "0.5.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
This allows work in progress to be correctly tagged as v0.5.0-dev

### Changes proposed in this PR:
Bump version to reflect next minor release

### How I've tested this PR:
```
$ make version
```

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
