### PR TITLE
Refactor deploy logic out of K8sGateway

### DIFF
--- a/internal/k8s/reconciler/deployer.go
+++ b/internal/k8s/reconciler/deployer.go
@@ -1,0 +1,128 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/builder"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
+	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
+)
+
+// GatewayDeployer creates gateway deployments and services and ensures that they exist
+type GatewayDeployer struct {
+	client   gatewayclient.Client
+	consulCA string
+	sdsHost  string
+	sdsPort  int
+
+	logger hclog.Logger
+}
+
+type DeployerConfig struct {
+	ConsulCA string
+	SDSHost  string
+	SDSPort  int
+	Logger   hclog.Logger
+	Client   gatewayclient.Client
+}
+
+func NewDeployer(config DeployerConfig) *GatewayDeployer {
+	return &GatewayDeployer{
+		client:   config.Client,
+		consulCA: config.ConsulCA,
+		sdsHost:  config.SDSHost,
+		sdsPort:  config.SDSPort,
+		logger:   config.Logger,
+	}
+}
+
+func (d *GatewayDeployer) Deploy(ctx context.Context, namespace string, config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) error {
+	if err := d.ensureServiceAccount(ctx, config, gateway); err != nil {
+		return err
+	}
+
+	if err := d.ensureDeployment(ctx, namespace, config, gateway); err != nil {
+		return err
+	}
+
+	return d.ensureService(ctx, config, gateway)
+}
+
+func (d *GatewayDeployer) ensureServiceAccount(ctx context.Context, config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) error {
+	// Create service account for the gateway
+	if serviceAccount := config.ServiceAccountFor(gateway); serviceAccount != nil {
+		if err := d.client.EnsureServiceAccount(ctx, gateway, serviceAccount); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *GatewayDeployer) ensureDeployment(ctx context.Context, namespace string, config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) error {
+	deployment := d.Deployment(namespace, config, gateway)
+	mutated := deployment.DeepCopy()
+
+	updated, err := d.client.CreateOrUpdateDeployment(ctx, mutated, func() error {
+		mutated = apigwv1alpha1.MergeDeployment(deployment, mutated)
+		return d.client.SetControllerOwnership(gateway, mutated)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create or update gateway deployment: %w", err)
+	}
+
+	if updated && d.logger.IsTrace() {
+		data, err := json.MarshalIndent(mutated, "", "  ")
+		if err == nil {
+			d.logger.Trace("created or updated gateway deployment", "deployment", string(data))
+		}
+	}
+
+	return nil
+}
+
+func (d *GatewayDeployer) ensureService(ctx context.Context, config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) error {
+	service := d.Service(config, gateway)
+	if service == nil {
+		return nil
+	}
+
+	mutated := service.DeepCopy()
+	updated, err := d.client.CreateOrUpdateService(ctx, mutated, func() error {
+		mutated = apigwv1alpha1.MergeService(service, mutated)
+		return d.client.SetControllerOwnership(gateway, mutated)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create or update gateway service: %w", err)
+	}
+
+	if updated && d.logger.IsTrace() {
+		data, err := json.MarshalIndent(mutated, "", "  ")
+		if err == nil {
+			d.logger.Trace("created or updated gateway service", "service", string(data))
+		}
+	}
+
+	return nil
+}
+
+func (d *GatewayDeployer) Deployment(namespace string, config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) *apps.Deployment {
+	deploymentBuilder := builder.NewGatewayDeployment(gateway)
+	deploymentBuilder.WithSDS(d.sdsHost, d.sdsPort)
+	deploymentBuilder.WithClassConfig(config)
+	deploymentBuilder.WithConsulCA(d.consulCA)
+	deploymentBuilder.WithConsulGatewayNamespace(namespace)
+	return deploymentBuilder.Build(nil) // TODO?
+}
+
+func (d *GatewayDeployer) Service(config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) *core.Service {
+	serviceBuilder := builder.NewGatewayService(gateway)
+	serviceBuilder.WithClassConfig(config)
+	return serviceBuilder.Build()
+}

--- a/internal/k8s/reconciler/deployer.go
+++ b/internal/k8s/reconciler/deployer.go
@@ -58,12 +58,12 @@ func (d *GatewayDeployer) Deploy(ctx context.Context, namespace string, config a
 
 func (d *GatewayDeployer) ensureServiceAccount(ctx context.Context, config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) error {
 	// Create service account for the gateway
-	if serviceAccount := config.ServiceAccountFor(gateway); serviceAccount != nil {
-		if err := d.client.EnsureServiceAccount(ctx, gateway, serviceAccount); err != nil {
-			return err
-		}
+	serviceAccount := config.ServiceAccountFor(gateway)
+	if serviceAccount == nil {
+		return nil
 	}
-	return nil
+
+	return d.client.EnsureServiceAccount(ctx, gateway, serviceAccount)
 }
 
 func (d *GatewayDeployer) ensureDeployment(ctx context.Context, namespace string, config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) error {

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -496,7 +496,7 @@ func (g *K8sGateway) ensureDeploymentExists(ctx context.Context) error {
 	mutated := deployment.DeepCopy()
 
 	if updated, err := g.client.CreateOrUpdateDeployment(ctx, mutated, func() error {
-		mutated = apigwv1alpha1.MergeDeployment(deployment, mutated, currentReplicas)
+		mutated = apigwv1alpha1.MergeDeployment(deployment, mutated)
 		return g.client.SetControllerOwnership(g.gateway, mutated)
 	}); err != nil {
 		return fmt.Errorf("failed to create or update gateway deployment: %w", err)

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -479,6 +479,10 @@ func TestGatewayTrackSync(t *testing.T) {
 			Level:  hclog.Trace,
 		}),
 		Client: client,
+		Deployer: NewDeployer(DeployerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		}),
 	})
 	gateway.gateway.Status = gateway.Status()
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -501,6 +505,10 @@ func TestGatewayTrackSync(t *testing.T) {
 				},
 			},
 		},
+		Deployer: NewDeployer(DeployerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		}),
 	})
 
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -518,6 +526,10 @@ func TestGatewayTrackSync(t *testing.T) {
 			Level:  hclog.Trace,
 		}),
 		Client: client,
+		Deployer: NewDeployer(DeployerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		}),
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
 	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, expected)
@@ -531,6 +543,10 @@ func TestGatewayTrackSync(t *testing.T) {
 			Level:  hclog.Trace,
 		}),
 		Client: client,
+		Deployer: NewDeployer(DeployerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		}),
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
 	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
@@ -545,6 +561,10 @@ func TestGatewayTrackSync(t *testing.T) {
 			Level:  hclog.Trace,
 		}),
 		Client: client,
+		Deployer: NewDeployer(DeployerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		}),
 	})
 
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -560,6 +580,10 @@ func TestGatewayTrackSync(t *testing.T) {
 			Level:  hclog.Trace,
 		}),
 		Client: client,
+		Deployer: NewDeployer(DeployerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		}),
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
 	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)

--- a/internal/k8s/reconciler/manager.go
+++ b/internal/k8s/reconciler/manager.go
@@ -49,6 +49,7 @@ type GatewayReconcileManager struct {
 	sdsHost        string
 	sdsPort        int
 
+	deployer       *GatewayDeployer
 	store          store.Store
 	gatewayClasses *K8sGatewayClasses
 
@@ -74,6 +75,14 @@ type ManagerConfig struct {
 }
 
 func NewReconcileManager(config ManagerConfig) *GatewayReconcileManager {
+	deployer := NewDeployer(DeployerConfig{
+		ConsulCA: config.ConsulCA,
+		SDSHost:  config.SDSHost,
+		SDSPort:  config.SDSPort,
+		Logger:   config.Logger,
+		Client:   config.Client,
+	})
+
 	return &GatewayReconcileManager{
 		controllerName:        config.ControllerName,
 		logger:                config.Logger,
@@ -85,6 +94,7 @@ func NewReconcileManager(config ManagerConfig) *GatewayReconcileManager {
 		gatewayClasses:        NewK8sGatewayClasses(config.Logger.Named("gatewayclasses"), config.Client),
 		namespaceMap:          make(map[types.NamespacedName]string),
 		consulNamespaceMapper: config.ConsulNamespaceMapper,
+		deployer:              deployer,
 		store:                 config.Store,
 	}
 }
@@ -169,6 +179,7 @@ func (m *GatewayReconcileManager) UpsertGateway(ctx context.Context, g *gwv1beta
 		SDSHost:         m.sdsHost,
 		SDSPort:         m.sdsPort,
 		Config:          config,
+		Deployer:        m.deployer,
 	})
 
 	// Calling validate outside of the upsert process allows us to re-resolve any

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -215,7 +215,7 @@ func compareServices(a, b *corev1.Service) bool {
 // MergeDeployment merges a gateway deployment a onto b and returns b, overriding all of
 // the fields that we'd normally set for a service deployment. It does not attempt
 // to change the service type
-func MergeDeployment(a, b *appsv1.Deployment, currentReplicas *int32) *appsv1.Deployment {
+func MergeDeployment(a, b *appsv1.Deployment) *appsv1.Deployment {
 	if !compareDeployments(a, b) {
 		b.Spec.Template = a.Spec.Template
 		b.Spec.Replicas = a.Spec.Replicas

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -131,7 +131,7 @@ type GatewayClassConfigList struct {
 	Items []GatewayClassConfig `json:"items"`
 }
 
-// ServicesAccountFor returns the service account to be created for the given gateway.
+// ServiceAccountFor returns the service account to be created for the given gateway.
 func (c *GatewayClassConfig) ServiceAccountFor(gw *gwv1beta1.Gateway) *corev1.ServiceAccount {
 	if !c.Spec.ConsulSpec.AuthSpec.Managed {
 		return nil


### PR DESCRIPTION
### Changes proposed in this PR:
In working to get the store refactor merged, this was one chunk of changes that I noticed could be broken out of https://github.com/hashicorp/consul-api-gateway/pull/160 to make reviews less taxing. This simply moves the logic for `Deployment`, `Service`, etc. creation into a new `GatewayDeployer`. This narrows the scope of responsibility for `K8sGateway`.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
