### PR TITLE
Refactor K8sGateway state into serializable struct

### DIFF
--- a/internal/k8s/reconciler/common/utils.go
+++ b/internal/k8s/reconciler/common/utils.go
@@ -24,12 +24,13 @@ var (
 	}
 )
 
-// SupportedKindsFor --
+// SupportedKindsFor returns the list of xRoute Kinds that support a given protocol
 func SupportedKindsFor(protocol gwv1beta1.ProtocolType) []gwv1beta1.RouteGroupKind {
 	return supportedKindsForProtocol[protocol]
 }
 
-// AsJSON --
+// AsJSON serializes a given item into a JSON string. The item is assumed to be
+// JSON-serializable as this function will panic otherwise.
 func AsJSON(item interface{}) string {
 	data, err := json.Marshal(item)
 	if err != nil {
@@ -42,7 +43,8 @@ func AsJSON(item interface{}) string {
 	return string(data)
 }
 
-// ParseParent --
+// ParseParent deserializes a JSON string into a gwv1alpha2.ParentReference. The string
+// is assumed to be a valid JSON representation as this function will panic otherwise.
 func ParseParent(stringified string) gwv1alpha2.ParentReference {
 	var ref gwv1alpha2.ParentReference
 	if err := json.Unmarshal([]byte(stringified), &ref); err != nil {

--- a/internal/k8s/reconciler/common/utils.go
+++ b/internal/k8s/reconciler/common/utils.go
@@ -1,6 +1,9 @@
 package common
 
 import (
+	"encoding/json"
+
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -24,4 +27,30 @@ var (
 // SupportedKindsFor --
 func SupportedKindsFor(protocol gwv1beta1.ProtocolType) []gwv1beta1.RouteGroupKind {
 	return supportedKindsForProtocol[protocol]
+}
+
+// AsJSON --
+func AsJSON(item interface{}) string {
+	data, err := json.Marshal(item)
+	if err != nil {
+		// everything passed to this internally should be
+		// serializable, if something is passed to it that
+		// isn't, just panic since it's a usage error at
+		// that point
+		panic(err)
+	}
+	return string(data)
+}
+
+// ParseParent --
+func ParseParent(stringified string) gwv1alpha2.ParentReference {
+	var ref gwv1alpha2.ParentReference
+	if err := json.Unmarshal([]byte(stringified), &ref); err != nil {
+		// everything passed to this internally should be
+		// deserializable, if something is passed to it that
+		// isn't, just panic since it's a usage error at
+		// that point
+		panic(err)
+	}
+	return ref
 }

--- a/internal/k8s/reconciler/common/utils.go
+++ b/internal/k8s/reconciler/common/utils.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+var (
+	supportedKindsForProtocol = map[gwv1beta1.ProtocolType][]gwv1beta1.RouteGroupKind{
+		gwv1beta1.HTTPProtocolType: {{
+			Group: (*gwv1beta1.Group)(&gwv1beta1.GroupVersion.Group),
+			Kind:  "HTTPRoute",
+		}},
+		gwv1beta1.HTTPSProtocolType: {{
+			Group: (*gwv1beta1.Group)(&gwv1beta1.GroupVersion.Group),
+			Kind:  "HTTPRoute",
+		}},
+		gwv1beta1.TCPProtocolType: {{
+			Group: (*gwv1beta1.Group)(&gwv1beta1.GroupVersion.Group),
+			Kind:  "TCPRoute",
+		}},
+	}
+)
+
+// SupportedKindsFor --
+func SupportedKindsFor(protocol gwv1beta1.ProtocolType) []gwv1beta1.RouteGroupKind {
+	return supportedKindsForProtocol[protocol]
+}

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -462,7 +462,7 @@ func TestGatewayOutputStatus(t *testing.T) {
 	}, K8sGatewayConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	gateway.gateway.Status = gateway.Status()
+	gateway.Gateway.Status = gateway.Status()
 	gateway.Status()
 }
 
@@ -484,7 +484,7 @@ func TestGatewayTrackSync(t *testing.T) {
 			Client: client,
 		}),
 	})
-	gateway.gateway.Status = gateway.Status()
+	gateway.Gateway.Status = gateway.Status()
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
 	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	require.NoError(t, gateway.TrackSync(context.Background(), func() (bool, error) {
@@ -513,7 +513,7 @@ func TestGatewayTrackSync(t *testing.T) {
 
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
 	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	client.EXPECT().UpdateStatus(gomock.Any(), gateway.gateway).Return(nil)
+	client.EXPECT().UpdateStatus(gomock.Any(), gateway.Gateway).Return(nil)
 	require.NoError(t, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return false, nil
 	}))
@@ -550,7 +550,7 @@ func TestGatewayTrackSync(t *testing.T) {
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
 	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	client.EXPECT().UpdateStatus(gomock.Any(), gateway.gateway).Return(expected)
+	client.EXPECT().UpdateStatus(gomock.Any(), gateway.Gateway).Return(expected)
 	require.Equal(t, expected, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return false, nil
 	}))
@@ -569,7 +569,7 @@ func TestGatewayTrackSync(t *testing.T) {
 
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
 	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	client.EXPECT().UpdateStatus(gomock.Any(), gateway.gateway).Return(nil)
+	client.EXPECT().UpdateStatus(gomock.Any(), gateway.Gateway).Return(nil)
 	require.NoError(t, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return true, nil
 	}))
@@ -587,7 +587,7 @@ func TestGatewayTrackSync(t *testing.T) {
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
 	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
-	client.EXPECT().UpdateStatus(gomock.Any(), gateway.gateway).Return(nil)
+	client.EXPECT().UpdateStatus(gomock.Any(), gateway.Gateway).Return(nil)
 	require.NoError(t, gateway.TrackSync(context.Background(), func() (bool, error) {
 		return false, expected
 	}))
@@ -605,28 +605,28 @@ func TestGatewayShouldUpdate(t *testing.T) {
 	})
 
 	// Have equal resource version
-	gateway.gateway.ObjectMeta.ResourceVersion = `0`
-	other.gateway.ObjectMeta.ResourceVersion = `0`
+	gateway.Gateway.ObjectMeta.ResourceVersion = `0`
+	other.Gateway.ObjectMeta.ResourceVersion = `0`
 	assert.True(t, gateway.ShouldUpdate(other))
 
 	// Have greater resource version
-	gateway.gateway.ObjectMeta.ResourceVersion = `1`
-	other.gateway.ObjectMeta.ResourceVersion = `0`
+	gateway.Gateway.ObjectMeta.ResourceVersion = `1`
+	other.Gateway.ObjectMeta.ResourceVersion = `0`
 	assert.False(t, gateway.ShouldUpdate(other))
 
 	// Have lesser resource version
-	gateway.gateway.ObjectMeta.ResourceVersion = `0`
-	other.gateway.ObjectMeta.ResourceVersion = `1`
+	gateway.Gateway.ObjectMeta.ResourceVersion = `0`
+	other.Gateway.ObjectMeta.ResourceVersion = `1`
 	assert.True(t, gateway.ShouldUpdate(other))
 
 	// Have non-numeric resource version
-	gateway.gateway.ObjectMeta.ResourceVersion = `a`
-	other.gateway.ObjectMeta.ResourceVersion = `0`
+	gateway.Gateway.ObjectMeta.ResourceVersion = `a`
+	other.Gateway.ObjectMeta.ResourceVersion = `0`
 	assert.True(t, gateway.ShouldUpdate(other))
 
 	// Other gateway non-numeric resource version
-	gateway.gateway.ObjectMeta.ResourceVersion = `0`
-	other.gateway.ObjectMeta.ResourceVersion = `a`
+	gateway.Gateway.ObjectMeta.ResourceVersion = `0`
+	other.Gateway.ObjectMeta.ResourceVersion = `a`
 	assert.False(t, gateway.ShouldUpdate(other))
 
 	// Other gateway nil
@@ -643,7 +643,7 @@ func TestGatewayShouldBind(t *testing.T) {
 	gateway := NewK8sGateway(&gwv1beta1.Gateway{}, K8sGatewayConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	gateway.gateway.Name = "name"
+	gateway.Gateway.Name = "name"
 
 	require.False(t, gateway.ShouldBind(storeMocks.NewMockRoute(nil)))
 

--- a/internal/k8s/reconciler/listener.go
+++ b/internal/k8s/reconciler/listener.go
@@ -17,27 +17,11 @@ import (
 	"github.com/hashicorp/consul-api-gateway/internal/common"
 	"github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
+	rcommon "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/common"
 	rerrors "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/errors"
 	rstatus "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/status"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/utils"
 	"github.com/hashicorp/consul-api-gateway/internal/store"
-)
-
-var (
-	supportedProtocols = map[gwv1beta1.ProtocolType][]gwv1beta1.RouteGroupKind{
-		gwv1beta1.HTTPProtocolType: {{
-			Group: (*gwv1beta1.Group)(&gwv1beta1.GroupVersion.Group),
-			Kind:  "HTTPRoute",
-		}},
-		gwv1beta1.HTTPSProtocolType: {{
-			Group: (*gwv1beta1.Group)(&gwv1beta1.GroupVersion.Group),
-			Kind:  "HTTPRoute",
-		}},
-		gwv1beta1.TCPProtocolType: {{
-			Group: (*gwv1beta1.Group)(&gwv1alpha2.GroupVersion.Group),
-			Kind:  "TCPRoute",
-		}},
-	}
 )
 
 const (
@@ -231,8 +215,8 @@ func (l *K8sListener) validateUnsupported() {
 }
 
 func (l *K8sListener) validateProtocols() {
-	supportedKinds, found := supportedProtocols[l.listener.Protocol]
-	if !found {
+	supportedKinds := rcommon.SupportedKindsFor(l.listener.Protocol)
+	if supportedKinds == nil {
 		l.status.Detached.UnsupportedProtocol = fmt.Errorf("unsupported protocol: %s", l.listener.Protocol)
 	}
 	l.supportedKinds = supportedKinds

--- a/internal/k8s/reconciler/listener.go
+++ b/internal/k8s/reconciler/listener.go
@@ -25,11 +25,7 @@ import (
 )
 
 const (
-	defaultListenerName          = "default"
-	annotationKeyPrefix          = "api-gateway.consul.hashicorp.com/"
-	tlsMinVersionAnnotationKey   = annotationKeyPrefix + "tls_min_version"
-	tlsMaxVersionAnnotationKey   = annotationKeyPrefix + "tls_max_version"
-	tlsCipherSuitesAnnotationKey = annotationKeyPrefix + "tls_cipher_suites"
+	defaultListenerName = "default"
 )
 
 type K8sListener struct {
@@ -39,7 +35,7 @@ type K8sListener struct {
 	listener        gwv1beta1.Listener
 	client          gatewayclient.Client
 
-	status         rstatus.ListenerStatus
+	status         *rstatus.ListenerStatus
 	tls            core.TLSParams
 	routeCount     int32
 	supportedKinds []gwv1beta1.RouteGroupKind
@@ -62,6 +58,7 @@ func NewK8sListener(gateway *gwv1beta1.Gateway, listener gwv1beta1.Listener, con
 		client:          config.Client,
 		gateway:         gateway,
 		listener:        listener,
+		status:          &rstatus.ListenerStatus{},
 	}
 }
 
@@ -185,24 +182,6 @@ func (l *K8sListener) validateTLS(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-var supportedTlsVersions = map[string]struct{}{
-	"TLS_AUTO": {},
-	"TLSv1_0":  {},
-	"TLSv1_1":  {},
-	"TLSv1_2":  {},
-	"TLSv1_3":  {},
-}
-
-var tlsVersionsWithConfigurableCipherSuites = map[string]struct{}{
-	// Remove these two if Envoy ever sets TLS 1.3 as default minimum
-	"":         {},
-	"TLS_AUTO": {},
-
-	"TLSv1_0": {},
-	"TLSv1_1": {},
-	"TLSv1_2": {},
 }
 
 func (l *K8sListener) validateUnsupported() {

--- a/internal/k8s/reconciler/listener_test.go
+++ b/internal/k8s/reconciler/listener_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
+	rcommon "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/common"
 	rstatus "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/status"
 	"github.com/hashicorp/consul-api-gateway/internal/store"
 	storeMocks "github.com/hashicorp/consul-api-gateway/internal/store/mocks"
@@ -579,7 +580,7 @@ func TestListenerCanBind_RouteKind(t *testing.T) {
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	listener.supportedKinds = supportedProtocols[gwv1beta1.HTTPProtocolType]
+	listener.supportedKinds = rcommon.SupportedKindsFor(gwv1beta1.HTTPProtocolType)
 	_, err = listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.TCPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.TCPRouteSpec{
@@ -627,7 +628,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	listener.supportedKinds = supportedProtocols[gwv1beta1.HTTPProtocolType]
+	listener.supportedKinds = rcommon.SupportedKindsFor(gwv1beta1.HTTPProtocolType)
 	_, err := listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{
@@ -681,7 +682,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	listener.supportedKinds = supportedProtocols[gwv1beta1.HTTPProtocolType]
+	listener.supportedKinds = rcommon.SupportedKindsFor(gwv1beta1.HTTPProtocolType)
 	_, err = listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{
@@ -736,7 +737,7 @@ func TestListenerCanBind_HostnameMatch(t *testing.T) {
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	listener.supportedKinds = supportedProtocols[gwv1beta1.HTTPProtocolType]
+	listener.supportedKinds = rcommon.SupportedKindsFor(gwv1beta1.HTTPProtocolType)
 	_, err := listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -161,7 +161,7 @@ func (r *K8sRoute) NeedsStatusUpdate() bool {
 func (r *K8sRoute) OnBindFailed(err error, gateway store.Gateway) {
 	k8sGateway, ok := gateway.(*K8sGateway)
 	if ok {
-		id, found := r.parentKeyForGateway(utils.NamespacedName(k8sGateway.gateway))
+		id, found := r.parentKeyForGateway(utils.NamespacedName(k8sGateway.Gateway))
 		if found {
 			status, statusFound := r.parentStatuses[id]
 			if !statusFound {
@@ -208,7 +208,7 @@ func (r *K8sRoute) OnBindFailed(err error, gateway store.Gateway) {
 func (r *K8sRoute) OnBound(gateway store.Gateway) {
 	k8sGateway, ok := gateway.(*K8sGateway)
 	if ok {
-		id, found := r.parentKeyForGateway(utils.NamespacedName(k8sGateway.gateway))
+		id, found := r.parentKeyForGateway(utils.NamespacedName(k8sGateway.Gateway))
 		if found {
 			// clear out any existing errors on our statuses
 			if status, statusFound := r.parentStatuses[id]; statusFound {
@@ -224,7 +224,7 @@ func (r *K8sRoute) OnBound(gateway store.Gateway) {
 func (r *K8sRoute) OnGatewayRemoved(gateway store.Gateway) {
 	k8sGateway, ok := gateway.(*K8sGateway)
 	if ok {
-		id, found := r.parentKeyForGateway(utils.NamespacedName(k8sGateway.gateway))
+		id, found := r.parentKeyForGateway(utils.NamespacedName(k8sGateway.Gateway))
 		if found {
 			delete(r.parentStatuses, id)
 		}

--- a/internal/k8s/reconciler/state/gateway.go
+++ b/internal/k8s/reconciler/state/gateway.go
@@ -1,0 +1,105 @@
+package state
+
+import (
+	"errors"
+
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-api-gateway/internal/core"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/common"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/status"
+)
+
+// GatewayState holds ephemeral state for gateways
+type GatewayState struct {
+	ConsulNamespace string
+	Status          status.GatewayStatus
+	PodReady        bool
+	ServiceReady    bool
+	Generation      int64
+	Addresses       []string
+
+	Listeners []*ListenerState
+}
+
+func InitialGatewayState(g *gwv1beta1.Gateway) *GatewayState {
+	state := &GatewayState{
+		Generation: g.GetGeneration(),
+	}
+	for _, listener := range g.Spec.Listeners {
+		state.Listeners = append(state.Listeners, &ListenerState{
+			Name:     listener.Name,
+			Protocol: listener.Protocol,
+			Routes:   make(map[string]core.ResolvedRoute),
+		})
+	}
+	return state
+}
+
+func (g *GatewayState) GetStatus(gateway *gwv1beta1.Gateway) gwv1beta1.GatewayStatus {
+	listenerStatuses := []gwv1beta1.ListenerStatus{}
+	for _, state := range g.Listeners {
+		listenerStatuses = append(listenerStatuses, state.getStatus(g.Generation))
+	}
+
+	conditions := g.Status.Conditions(g.Generation)
+
+	// prefer to not update to not mess up timestamps
+	if status.ListenerStatusesEqual(listenerStatuses, gateway.Status.Listeners) {
+		listenerStatuses = gateway.Status.Listeners
+	}
+	if status.ConditionsEqual(conditions, gateway.Status.Conditions) {
+		conditions = gateway.Status.Conditions
+	}
+
+	ipType := gwv1beta1.IPAddressType
+	addresses := make([]gwv1beta1.GatewayAddress, 0, len(g.Addresses))
+	for _, address := range g.Addresses {
+		addresses = append(addresses, gwv1beta1.GatewayAddress{
+			Type:  &ipType,
+			Value: address,
+		})
+	}
+
+	return gwv1beta1.GatewayStatus{
+		Addresses:  addresses,
+		Conditions: conditions,
+		Listeners:  listenerStatuses,
+	}
+}
+
+// ListenerState holds ephemeral state for listeners
+type ListenerState struct {
+	Routes   map[string]core.ResolvedRoute
+	Protocol gwv1beta1.ProtocolType
+	Name     gwv1beta1.SectionName
+	TLS      core.TLSParams
+	Status   status.ListenerStatus
+}
+
+func (l *ListenerState) Valid() bool {
+	routeCount := len(l.Routes)
+	if l.Protocol == gwv1beta1.TCPProtocolType {
+		if routeCount > 1 {
+			return false
+		}
+	}
+	return l.Status.Valid()
+}
+
+func (l *ListenerState) getStatus(generation int64) gwv1beta1.ListenerStatus {
+	routeCount := len(l.Routes)
+	if l.Protocol == gwv1beta1.TCPProtocolType {
+		if routeCount > 1 {
+			l.Status.Conflicted.RouteConflict = errors.New("only a single TCP route can be bound to a TCP listener")
+		} else {
+			l.Status.Conflicted.RouteConflict = nil
+		}
+	}
+	return gwv1beta1.ListenerStatus{
+		Name:           l.Name,
+		SupportedKinds: common.SupportedKindsFor(l.Protocol),
+		AttachedRoutes: int32(routeCount),
+		Conditions:     l.Status.Conditions(generation),
+	}
+}

--- a/internal/k8s/reconciler/status/equality.go
+++ b/internal/k8s/reconciler/status/equality.go
@@ -1,0 +1,98 @@
+package status
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/common"
+)
+
+func conditionEqual(a, b metav1.Condition) bool {
+	if a.Type != b.Type ||
+		a.ObservedGeneration != b.ObservedGeneration ||
+		a.Status != b.Status ||
+		a.Reason != b.Reason ||
+		a.Message != b.Message {
+		return false
+	}
+	return true
+}
+
+func ConditionsEqual(a, b []metav1.Condition) bool {
+	if len(a) != len(b) {
+		// we have a different number of conditions, so they aren't the same
+		return false
+	}
+
+	for i, newCondition := range a {
+		if !conditionEqual(newCondition, b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func listenerStatusEqual(a, b gwv1beta1.ListenerStatus) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if !reflect.DeepEqual(a.SupportedKinds, b.SupportedKinds) {
+		return false
+	}
+	if a.AttachedRoutes != b.AttachedRoutes {
+		return false
+	}
+	return ConditionsEqual(a.Conditions, b.Conditions)
+}
+
+func ListenerStatusesEqual(a, b []gwv1beta1.ListenerStatus) bool {
+	if len(a) != len(b) {
+		// we have a different number of conditions, so they aren't the same
+		return false
+	}
+	for i, newStatus := range a {
+		if !listenerStatusEqual(newStatus, b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func parentStatusEqual(a, b gwv1alpha2.RouteParentStatus) bool {
+	if a.ControllerName != b.ControllerName {
+		return false
+	}
+	if common.AsJSON(a.ParentRef) != common.AsJSON(b.ParentRef) {
+		return false
+	}
+
+	return ConditionsEqual(a.Conditions, b.Conditions)
+}
+
+func RouteStatusEqual(a, b gwv1alpha2.RouteStatus) bool {
+	if len(a.Parents) != len(b.Parents) {
+		return false
+	}
+
+	for i, oldParent := range a.Parents {
+		if !parentStatusEqual(oldParent, b.Parents[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func GatewayStatusEqual(a, b gwv1beta1.GatewayStatus) bool {
+	if !ConditionsEqual(a.Conditions, b.Conditions) {
+		return false
+	}
+
+	if !ListenerStatusesEqual(a.Listeners, b.Listeners) {
+		return false
+	}
+
+	return true
+}

--- a/internal/k8s/reconciler/tls.go
+++ b/internal/k8s/reconciler/tls.go
@@ -1,0 +1,26 @@
+package reconciler
+
+const (
+	annotationKeyPrefix          = "api-gateway.consul.hashicorp.com/"
+	tlsMinVersionAnnotationKey   = annotationKeyPrefix + "tls_min_version"
+	tlsMaxVersionAnnotationKey   = annotationKeyPrefix + "tls_max_version"
+	tlsCipherSuitesAnnotationKey = annotationKeyPrefix + "tls_cipher_suites"
+)
+
+var supportedTlsVersions = map[string]struct{}{
+	"TLS_AUTO": {},
+	"TLSv1_0":  {},
+	"TLSv1_1":  {},
+	"TLSv1_2":  {},
+	"TLSv1_3":  {},
+}
+
+var tlsVersionsWithConfigurableCipherSuites = map[string]struct{}{
+	// Remove these two if Envoy ever sets TLS 1.3 as default minimum
+	"":         {},
+	"TLS_AUTO": {},
+
+	"TLSv1_0": {},
+	"TLSv1_1": {},
+	"TLSv1_2": {},
+}


### PR DESCRIPTION
### Changes proposed in this PR:
In working to get the store refactor merged, this was one chunk of changes that I noticed could be broken out of https://github.com/hashicorp/consul-api-gateway/pull/160 to make reviews less taxing. This simply moves the state of the `K8sGateway` into a separate struct that can be serialized (important in the future).

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
