### PR TITLE
Introduce Factory for creating Gateways + Routes

### DIFF
--- a/internal/k8s/reconciler/factory.go
+++ b/internal/k8s/reconciler/factory.go
@@ -62,6 +62,7 @@ func (f *Factory) NewGateway(config NewGatewayConfig) *K8sGateway {
 	gateway.GatewayState = config.State
 	if config.State == nil {
 		gateway.GatewayState = state.InitialGatewayState(config.Gateway)
+		gateway.GatewayState.ConsulNamespace = config.ConsulNamespace
 	}
 
 	return gateway

--- a/internal/k8s/reconciler/factory.go
+++ b/internal/k8s/reconciler/factory.go
@@ -5,7 +5,6 @@ import (
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
-	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/service"
 	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 )
@@ -61,12 +60,7 @@ func (f *Factory) NewGateway(config NewGatewayConfig) *K8sGateway {
 }
 
 func (f *Factory) NewRoute(route Route) *K8sRoute {
-	return f.NewRouteWithState(route, state.NewRouteState())
-}
-
-func (f *Factory) NewRouteWithState(route Route, state *state.RouteState) *K8sRoute {
 	return NewK8sRoute(route, K8sRouteConfig{
-		State:          state,
 		Logger:         f.logger.Named("route").With("name", route.GetName()),
 		Client:         f.client,
 		ControllerName: f.controllerName,

--- a/internal/k8s/reconciler/factory.go
+++ b/internal/k8s/reconciler/factory.go
@@ -1,0 +1,79 @@
+package reconciler
+
+import (
+	"github.com/hashicorp/go-hclog"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/service"
+	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
+)
+
+type Factory struct {
+	controllerName string
+	logger         hclog.Logger
+	client         gatewayclient.Client
+	deployer       *GatewayDeployer
+
+	resolver service.BackendResolver
+}
+
+type FactoryConfig struct {
+	ControllerName string
+	Logger         hclog.Logger
+	Client         gatewayclient.Client
+	Deployer       *GatewayDeployer
+
+	// get rid of this when validators are added
+	Resolver service.BackendResolver
+}
+
+func NewFactory(config FactoryConfig) *Factory {
+	return &Factory{
+		controllerName: config.ControllerName,
+		logger:         config.Logger,
+		client:         config.Client,
+		deployer:       config.Deployer,
+		resolver:       config.Resolver,
+	}
+}
+
+type NewGatewayConfig struct {
+	Gateway         *gwv1beta1.Gateway
+	Config          apigwv1alpha1.GatewayClassConfig
+	State           *state.GatewayState
+	ConsulNamespace string
+}
+
+func (f *Factory) NewGateway(config NewGatewayConfig) *K8sGateway {
+	gateway := NewK8sGateway(config.Gateway, K8sGatewayConfig{
+		ConsulNamespace: config.ConsulNamespace,
+		ConsulCA:        "",
+		SDSHost:         "",
+		SDSPort:         0,
+		Config:          config.Config,
+		Deployer:        f.deployer,
+		Logger:          f.logger.Named("gateway").With("name", config.Gateway.Name, "namespace", config.Gateway.Namespace),
+		Client:          f.client,
+	})
+
+	// TODO Consider moving into K8sGatewayConfig
+	gateway.GatewayState = config.State
+	if config.State == nil {
+		gateway.GatewayState = state.InitialGatewayState(config.Gateway)
+	}
+
+	return gateway
+}
+
+func (f *Factory) NewRoute(route Route, state *state.RouteState) *K8sRoute {
+	return &K8sRoute{
+		Route:          route,
+		RouteState:     state,
+		logger:         f.logger.Named("route").With("name", route.GetName()),
+		client:         f.client,
+		controllerName: f.controllerName,
+		resolver:       f.resolver,
+	}
+}

--- a/internal/k8s/reconciler/factory.go
+++ b/internal/k8s/reconciler/factory.go
@@ -42,7 +42,6 @@ func NewFactory(config FactoryConfig) *Factory {
 type NewGatewayConfig struct {
 	Gateway         *gwv1beta1.Gateway
 	Config          apigwv1alpha1.GatewayClassConfig
-	State           *state.GatewayState
 	ConsulNamespace string
 }
 
@@ -57,13 +56,6 @@ func (f *Factory) NewGateway(config NewGatewayConfig) *K8sGateway {
 		Logger:          f.logger.Named("gateway").With("name", config.Gateway.Name, "namespace", config.Gateway.Namespace),
 		Client:          f.client,
 	})
-
-	// TODO Consider moving into K8sGatewayConfig
-	gateway.GatewayState = config.State
-	if config.State == nil {
-		gateway.GatewayState = state.InitialGatewayState(config.Gateway)
-		gateway.GatewayState.ConsulNamespace = config.ConsulNamespace
-	}
 
 	return gateway
 }

--- a/internal/k8s/reconciler/factory.go
+++ b/internal/k8s/reconciler/factory.go
@@ -67,7 +67,11 @@ func (f *Factory) NewGateway(config NewGatewayConfig) *K8sGateway {
 	return gateway
 }
 
-func (f *Factory) NewRoute(route Route, state *state.RouteState) *K8sRoute {
+func (f *Factory) NewRoute(route Route) *K8sRoute {
+	return f.NewRouteWithState(route, state.NewRouteState())
+}
+
+func (f *Factory) NewRouteWithState(route Route, state *state.RouteState) *K8sRoute {
 	return &K8sRoute{
 		Route:          route,
 		RouteState:     state,

--- a/internal/k8s/reconciler/factory.go
+++ b/internal/k8s/reconciler/factory.go
@@ -72,12 +72,11 @@ func (f *Factory) NewRoute(route Route) *K8sRoute {
 }
 
 func (f *Factory) NewRouteWithState(route Route, state *state.RouteState) *K8sRoute {
-	return &K8sRoute{
-		Route:          route,
-		RouteState:     state,
-		logger:         f.logger.Named("route").With("name", route.GetName()),
-		client:         f.client,
-		controllerName: f.controllerName,
-		resolver:       f.resolver,
-	}
+	return NewK8sRoute(route, K8sRouteConfig{
+		State:          state,
+		Logger:         f.logger.Named("route").With("name", route.GetName()),
+		Client:         f.client,
+		ControllerName: f.controllerName,
+		Resolver:       f.resolver,
+	})
 }

--- a/internal/k8s/reconciler/factory.go
+++ b/internal/k8s/reconciler/factory.go
@@ -45,7 +45,7 @@ type NewGatewayConfig struct {
 }
 
 func (f *Factory) NewGateway(config NewGatewayConfig) *K8sGateway {
-	gateway := NewK8sGateway(config.Gateway, K8sGatewayConfig{
+	gateway := newK8sGateway(config.Gateway, K8sGatewayConfig{
 		ConsulNamespace: config.ConsulNamespace,
 		ConsulCA:        "",
 		SDSHost:         "",
@@ -60,7 +60,7 @@ func (f *Factory) NewGateway(config NewGatewayConfig) *K8sGateway {
 }
 
 func (f *Factory) NewRoute(route Route) *K8sRoute {
-	return NewK8sRoute(route, K8sRouteConfig{
+	return newK8sRoute(route, K8sRouteConfig{
 		Logger:         f.logger.Named("route").With("name", route.GetName()),
 		Client:         f.client,
 		ControllerName: f.controllerName,

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -48,7 +48,7 @@ type K8sGatewayConfig struct {
 	Client          gatewayclient.Client
 }
 
-func NewK8sGateway(gateway *gwv1beta1.Gateway, config K8sGatewayConfig) *K8sGateway {
+func newK8sGateway(gateway *gwv1beta1.Gateway, config K8sGatewayConfig) *K8sGateway {
 	// FUTURE (nathancoleman) See if we can avoid setting ConsulNamespace out of band
 	gwState := state.InitialGatewayState(gateway)
 	gwState.ConsulNamespace = config.ConsulNamespace

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -381,7 +381,6 @@ func TestGatewayID(t *testing.T) {
 
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	require.Equal(t, internalCore.GatewayID{Service: "name", ConsulNamespace: "consul"}, gateway.ID())

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -686,13 +686,13 @@ func TestGatewayShouldBind(t *testing.T) {
 
 	require.False(t, gateway.ShouldBind(storeMocks.NewMockRoute(nil)))
 
-	route := NewK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
+	route := newK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	})
 	route.RouteState.ResolutionErrors.Add(service.NewConsulResolutionError("test"))
 	require.False(t, gateway.ShouldBind(route))
 
-	require.True(t, gateway.ShouldBind(NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	require.True(t, gateway.ShouldBind(newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
 				ParentRefs: []gwv1alpha2.ParentReference{{
@@ -704,7 +704,7 @@ func TestGatewayShouldBind(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})))
 
-	require.False(t, gateway.ShouldBind(NewK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
+	require.False(t, gateway.ShouldBind(newK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	})))
 }

--- a/internal/k8s/reconciler/gateway_test.go
+++ b/internal/k8s/reconciler/gateway_test.go
@@ -19,7 +19,6 @@ import (
 
 	internalCore "github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
-	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
 	rstatus "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/status"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/service"
 	storeMocks "github.com/hashicorp/consul-api-gateway/internal/store/mocks"
@@ -53,7 +52,6 @@ func TestGatewayValidate(t *testing.T) {
 
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway: g,
-		State:   state.InitialGatewayState(g),
 		Config: apigwv1alpha1.GatewayClassConfig{
 			Spec: apigwv1alpha1.GatewayClassConfigSpec{
 
@@ -165,7 +163,6 @@ func TestGatewayValidateGatewayIP(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			gateway := factory.NewGateway(NewGatewayConfig{
 				Gateway: gwDef,
-				State:   state.InitialGatewayState(gwDef),
 				Config: apigwv1alpha1.GatewayClassConfig{
 					Spec: apigwv1alpha1.GatewayClassConfigSpec{
 						ServiceType: tc.serviceType,
@@ -216,7 +213,6 @@ func TestGatewayValidate_ListenerProtocolConflicts(t *testing.T) {
 
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway: gw,
-		State:   state.InitialGatewayState(gw),
 		Config: apigwv1alpha1.GatewayClassConfig{
 			Spec: apigwv1alpha1.GatewayClassConfigSpec{
 				ServiceType: serviceType(core.ServiceTypeNodePort),
@@ -261,7 +257,6 @@ func TestGatewayValidate_ListenerHostnameConflicts(t *testing.T) {
 
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway: gw,
-		State:   state.InitialGatewayState(gw),
 		Config: apigwv1alpha1.GatewayClassConfig{
 			Spec: apigwv1alpha1.GatewayClassConfigSpec{
 				ServiceType: serviceType(core.ServiceTypeNodePort),
@@ -294,7 +289,6 @@ func TestGatewayValidate_Pods(t *testing.T) {
 
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway: gw,
-		State:   state.InitialGatewayState(gw),
 		Config: apigwv1alpha1.GatewayClassConfig{
 			Spec: apigwv1alpha1.GatewayClassConfigSpec{
 				ServiceType: serviceType(core.ServiceTypeNodePort),
@@ -401,7 +395,6 @@ func TestGatewayMeta(t *testing.T) {
 	}
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	require.NotNil(t, gateway.Meta())
@@ -421,7 +414,6 @@ func TestGatewayListeners(t *testing.T) {
 	}
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	require.Len(t, gateway.Listeners(), 1)
@@ -445,7 +437,6 @@ func TestGatewayOutputStatus(t *testing.T) {
 
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	gateway.GatewayState.Addresses = []string{"127.0.0.1"}
@@ -464,7 +455,6 @@ func TestGatewayOutputStatus(t *testing.T) {
 
 	gateway = factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	gateway.GatewayState.PodReady = false
@@ -484,7 +474,6 @@ func TestGatewayOutputStatus(t *testing.T) {
 
 	gateway = factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	gateway.GatewayState.PodReady = true
@@ -505,7 +494,6 @@ func TestGatewayOutputStatus(t *testing.T) {
 
 	gateway = factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	gateway.GatewayState.PodReady = true
@@ -524,7 +512,6 @@ func TestGatewayOutputStatus(t *testing.T) {
 
 	gateway = factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	gateway.Gateway.Status = gateway.Status()
@@ -551,7 +538,6 @@ func TestGatewayTrackSync(t *testing.T) {
 
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	gateway.Gateway.Status = gateway.Status()
@@ -572,7 +558,6 @@ func TestGatewayTrackSync(t *testing.T) {
 			},
 		},
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 
@@ -588,7 +573,6 @@ func TestGatewayTrackSync(t *testing.T) {
 	gw = &gwv1beta1.Gateway{}
 	gateway = factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -600,7 +584,6 @@ func TestGatewayTrackSync(t *testing.T) {
 	gw = &gwv1beta1.Gateway{}
 	gateway = factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -613,7 +596,6 @@ func TestGatewayTrackSync(t *testing.T) {
 	gw = &gwv1beta1.Gateway{}
 	gateway = factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -626,7 +608,6 @@ func TestGatewayTrackSync(t *testing.T) {
 	gw = &gwv1beta1.Gateway{}
 	gateway = factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -647,14 +628,12 @@ func TestGatewayShouldUpdate(t *testing.T) {
 	gw := &gwv1beta1.Gateway{}
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 
 	otherGW := &gwv1beta1.Gateway{}
 	other := factory.NewGateway(NewGatewayConfig{
 		Gateway:         otherGW,
-		State:           state.InitialGatewayState(otherGW),
 		ConsulNamespace: "consul",
 	})
 
@@ -701,7 +680,6 @@ func TestGatewayShouldBind(t *testing.T) {
 	gw := &gwv1beta1.Gateway{}
 	gateway := factory.NewGateway(NewGatewayConfig{
 		Gateway:         gw,
-		State:           state.InitialGatewayState(gw),
 		ConsulNamespace: "consul",
 	})
 	gateway.Gateway.Name = "name"

--- a/internal/k8s/reconciler/listener_test.go
+++ b/internal/k8s/reconciler/listener_test.go
@@ -480,7 +480,7 @@ func TestListenerCanBind(t *testing.T) {
 	listener = NewK8sListener(&gwv1beta1.Gateway{}, gwv1beta1.Listener{}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	canBind, err = listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
+	canBind, err = listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	}))
 	require.NoError(t, err)
@@ -494,7 +494,7 @@ func TestListenerCanBind(t *testing.T) {
 	}, gwv1beta1.Listener{}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	canBind, err = listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	canBind, err = listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
 				ParentRefs: []gwv1alpha2.ParentReference{{
@@ -517,7 +517,7 @@ func TestListenerCanBind(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.status.Ready.Invalid = errors.New("invalid")
-	canBind, err = listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	canBind, err = listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
 				ParentRefs: []gwv1alpha2.ParentReference{{
@@ -555,7 +555,7 @@ func TestListenerCanBind_RouteKind(t *testing.T) {
 	})
 	require.NoError(t, listener.Validate(context.Background()))
 
-	canBind, err := listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.UDPRoute{
+	canBind, err := listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.UDPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.UDPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
@@ -581,7 +581,7 @@ func TestListenerCanBind_RouteKind(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.supportedKinds = rcommon.SupportedKindsFor(gwv1beta1.HTTPProtocolType)
-	_, err = listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.TCPRoute{
+	_, err = listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.TCPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.TCPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
@@ -629,7 +629,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.supportedKinds = rcommon.SupportedKindsFor(gwv1beta1.HTTPProtocolType)
-	_, err := listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	_, err := listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
@@ -644,7 +644,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	}))
 	require.Error(t, err)
-	canBind, err := listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	canBind, err := listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
@@ -683,7 +683,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.supportedKinds = rcommon.SupportedKindsFor(gwv1beta1.HTTPProtocolType)
-	_, err = listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	_, err = listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
@@ -698,7 +698,7 @@ func TestListenerCanBind_AllowedNamespaces(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	}))
 	require.Error(t, err)
-	_, err = listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	_, err = listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
@@ -738,7 +738,7 @@ func TestListenerCanBind_HostnameMatch(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	})
 	listener.supportedKinds = rcommon.SupportedKindsFor(gwv1beta1.HTTPProtocolType)
-	_, err := listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	_, err := listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
@@ -754,7 +754,7 @@ func TestListenerCanBind_HostnameMatch(t *testing.T) {
 	}))
 	require.Error(t, err)
 
-	canBind, err := listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	canBind, err := listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		TypeMeta: routeMeta,
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
@@ -786,7 +786,7 @@ func TestListenerCanBind_NameMatch(t *testing.T) {
 	}, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})
-	canBind, err := listener.CanBind(context.Background(), NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	canBind, err := listener.CanBind(context.Background(), newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
 				ParentRefs: []gwv1alpha2.ParentReference{{

--- a/internal/k8s/reconciler/manager.go
+++ b/internal/k8s/reconciler/manager.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/consul-api-gateway/internal/common"
 	"github.com/hashicorp/consul-api-gateway/internal/core"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
-	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/service"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/utils"
 	"github.com/hashicorp/consul-api-gateway/internal/store"
@@ -184,7 +183,6 @@ func (m *GatewayReconcileManager) UpsertGateway(ctx context.Context, g *gwv1beta
 	gateway := m.factory.NewGateway(NewGatewayConfig{
 		Gateway:         g,
 		Config:          config,
-		State:           state.InitialGatewayState(g),
 		ConsulNamespace: consulNamespace,
 	})
 

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -199,7 +199,7 @@ func (r *K8sRoute) Validate(ctx context.Context) error {
 					continue
 				}
 
-				reference, err := r.resolver.Resolve(ctx, ref.BackendObjectReference)
+				reference, err := r.resolver.Resolve(ctx, r.GetNamespace(), ref.BackendObjectReference)
 				if err != nil {
 					var resolutionError service.ResolutionError
 					if !errors.As(err, &resolutionError) {
@@ -242,7 +242,7 @@ func (r *K8sRoute) Validate(ctx context.Context) error {
 			return nil
 		}
 
-		reference, err := r.resolver.Resolve(ctx, ref.BackendObjectReference)
+		reference, err := r.resolver.Resolve(ctx, r.GetNamespace(), ref.BackendObjectReference)
 		if err != nil {
 			var resolutionError service.ResolutionError
 			if !errors.As(err, &resolutionError) {

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -46,7 +46,7 @@ type K8sRouteConfig struct {
 	Resolver       service.BackendResolver
 }
 
-func NewK8sRoute(route Route, config K8sRouteConfig) *K8sRoute {
+func newK8sRoute(route Route, config K8sRouteConfig) *K8sRoute {
 	return &K8sRoute{
 		Route:          route,
 		RouteState:     state.NewRouteState(),

--- a/internal/k8s/reconciler/route_test.go
+++ b/internal/k8s/reconciler/route_test.go
@@ -31,13 +31,13 @@ func TestRouteID(t *testing.T) {
 		Namespace: "namespace",
 	}
 
-	require.Equal(t, "http-namespace/name", NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	require.Equal(t, "http-namespace/name", newK8sRoute(&gwv1alpha2.HTTPRoute{
 		ObjectMeta: meta,
 	}, config).ID())
-	require.Equal(t, "tcp-namespace/name", NewK8sRoute(&gwv1alpha2.TCPRoute{
+	require.Equal(t, "tcp-namespace/name", newK8sRoute(&gwv1alpha2.TCPRoute{
 		ObjectMeta: meta,
 	}, config).ID())
-	require.Equal(t, "", NewK8sRoute(&core.Pod{
+	require.Equal(t, "", newK8sRoute(&core.Pod{
 		ObjectMeta: meta,
 	}, config).ID())
 }
@@ -55,17 +55,17 @@ func TestRouteCommonRouteSpec(t *testing.T) {
 		}},
 	}
 
-	require.Equal(t, expected, NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	require.Equal(t, expected, newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			CommonRouteSpec: expected,
 		},
 	}, config).CommonRouteSpec())
-	require.Equal(t, expected, NewK8sRoute(&gwv1alpha2.TCPRoute{
+	require.Equal(t, expected, newK8sRoute(&gwv1alpha2.TCPRoute{
 		Spec: gwv1alpha2.TCPRouteSpec{
 			CommonRouteSpec: expected,
 		},
 	}, config).CommonRouteSpec())
-	require.Equal(t, gwv1alpha2.CommonRouteSpec{}, NewK8sRoute(&core.Pod{}, config).CommonRouteSpec())
+	require.Equal(t, gwv1alpha2.CommonRouteSpec{}, newK8sRoute(&core.Pod{}, config).CommonRouteSpec())
 }
 
 func TestRouteSetStatus(t *testing.T) {
@@ -84,18 +84,18 @@ func TestRouteSetStatus(t *testing.T) {
 	}
 
 	httpRoute := &gwv1alpha2.HTTPRoute{}
-	route := NewK8sRoute(httpRoute, config)
+	route := newK8sRoute(httpRoute, config)
 	route.SetStatus(expected)
 	require.Equal(t, expected, httpRoute.Status.RouteStatus)
 	require.Equal(t, expected, route.routeStatus())
 
 	tcpRoute := &gwv1alpha2.TCPRoute{}
-	route = NewK8sRoute(tcpRoute, config)
+	route = newK8sRoute(tcpRoute, config)
 	route.SetStatus(expected)
 	require.Equal(t, expected, tcpRoute.Status.RouteStatus)
 	require.Equal(t, expected, route.routeStatus())
 
-	route = NewK8sRoute(&core.Pod{}, config)
+	route = newK8sRoute(&core.Pod{}, config)
 	route.SetStatus(expected)
 	require.Equal(t, gwv1alpha2.RouteStatus{}, route.routeStatus())
 }
@@ -113,13 +113,13 @@ func TestRouteParents(t *testing.T) {
 		}},
 	}
 
-	parents := NewK8sRoute(&gwv1alpha2.HTTPRoute{Spec: gwv1alpha2.HTTPRouteSpec{CommonRouteSpec: expected}}, config).Parents()
+	parents := newK8sRoute(&gwv1alpha2.HTTPRoute{Spec: gwv1alpha2.HTTPRouteSpec{CommonRouteSpec: expected}}, config).Parents()
 	require.Equal(t, expected.ParentRefs, parents)
 
-	parents = NewK8sRoute(&gwv1alpha2.TCPRoute{Spec: gwv1alpha2.TCPRouteSpec{CommonRouteSpec: expected}}, config).Parents()
+	parents = newK8sRoute(&gwv1alpha2.TCPRoute{Spec: gwv1alpha2.TCPRouteSpec{CommonRouteSpec: expected}}, config).Parents()
 	require.Equal(t, expected.ParentRefs, parents)
 
-	require.Nil(t, NewK8sRoute(&core.Pod{}, config).Parents())
+	require.Nil(t, newK8sRoute(&core.Pod{}, config).Parents())
 }
 
 func TestRouteMatchesHostname(t *testing.T) {
@@ -127,7 +127,7 @@ func TestRouteMatchesHostname(t *testing.T) {
 
 	hostname := gwv1beta1.Hostname("domain.test")
 
-	require.True(t, NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	require.True(t, newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			Hostnames: []gwv1alpha2.Hostname{"*"},
 		},
@@ -135,7 +135,7 @@ func TestRouteMatchesHostname(t *testing.T) {
 		Logger: hclog.NewNullLogger(),
 	}).MatchesHostname(&hostname))
 
-	require.False(t, NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	require.False(t, newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			Hostnames: []gwv1alpha2.Hostname{"other.text"},
 		},
@@ -145,7 +145,7 @@ func TestRouteMatchesHostname(t *testing.T) {
 
 	// check where the underlying route doesn't implement
 	// a matching routine
-	require.True(t, NewK8sRoute(&gwv1alpha2.TCPRoute{}, K8sRouteConfig{
+	require.True(t, newK8sRoute(&gwv1alpha2.TCPRoute{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	}).MatchesHostname(&hostname))
 }
@@ -153,11 +153,11 @@ func TestRouteMatchesHostname(t *testing.T) {
 func TestRouteValidate(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, NewK8sRoute(&core.Pod{}, K8sRouteConfig{
+	require.NoError(t, newK8sRoute(&core.Pod{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	}).Validate(context.Background()))
 
-	require.True(t, NewK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
+	require.True(t, newK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	}).IsValid())
 
@@ -173,7 +173,7 @@ func TestRouteValidate(t *testing.T) {
 		Reference: &service.BackendReference{},
 	}
 
-	route := NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	route := newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			Rules: []gwv1alpha2.HTTPRouteRule{{
 				BackendRefs: []gwv1alpha2.HTTPBackendRef{{
@@ -211,7 +211,7 @@ func TestRouteValidateDontAllowCrossNamespace(t *testing.T) {
 
 	//set up backend ref with a different namespace
 	namespace := gwv1alpha2.Namespace("test")
-	route := NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	route := newK8sRoute(&gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			Rules: []gwv1alpha2.HTTPRouteRule{{
 				BackendRefs: []gwv1alpha2.HTTPBackendRef{{
@@ -260,7 +260,7 @@ func TestRouteValidateAllowCrossNamespaceWithReferenceGrant(t *testing.T) {
 	backendKind := gwv1alpha2.Kind("Service")
 	backendNamespace := gwv1alpha2.Namespace("namespace2")
 	backendName := gwv1alpha2.ObjectName("backend2")
-	route := NewK8sRoute(&gwv1alpha2.HTTPRoute{
+	route := newK8sRoute(&gwv1alpha2.HTTPRoute{
 		ObjectMeta: meta.ObjectMeta{Namespace: "namespace1"},
 		TypeMeta:   meta.TypeMeta{APIVersion: "gateway.networking.k8s.io/v1alpha2", Kind: "HTTPRoute"},
 		Spec: gwv1alpha2.HTTPRouteSpec{
@@ -321,17 +321,17 @@ func TestRouteResolve(t *testing.T) {
 	}
 	listener := gwv1beta1.Listener{}
 
-	require.Nil(t, NewK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
+	require.Nil(t, newK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	}).Resolve(nil))
 
-	require.Nil(t, NewK8sRoute(&core.Pod{}, K8sRouteConfig{
+	require.Nil(t, newK8sRoute(&core.Pod{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	}).Resolve(NewK8sListener(gateway, listener, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
 	})))
 
-	require.NotNil(t, NewK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
+	require.NotNil(t, newK8sRoute(&gwv1alpha2.HTTPRoute{}, K8sRouteConfig{
 		Logger: hclog.NewNullLogger(),
 	}).Resolve(NewK8sListener(gateway, listener, K8sListenerConfig{
 		Logger: hclog.NewNullLogger(),
@@ -341,7 +341,7 @@ func TestRouteResolve(t *testing.T) {
 func TestRouteSyncStatus(t *testing.T) {
 	t.Parallel()
 
-	gateway := NewK8sGateway(&gwv1beta1.Gateway{
+	gateway := newK8sGateway(&gwv1beta1.Gateway{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "expected",
 		},
@@ -387,7 +387,7 @@ func TestRouteSyncStatus(t *testing.T) {
 		Output: io.Discard,
 	})
 	logger.SetLevel(hclog.Trace)
-	route := NewK8sRoute(inner, K8sRouteConfig{
+	route := newK8sRoute(inner, K8sRouteConfig{
 		ControllerName: "expected",
 		Logger:         logger,
 		Client:         client,

--- a/internal/k8s/service/mocks/resolver.go
+++ b/internal/k8s/service/mocks/resolver.go
@@ -37,16 +37,16 @@ func (m *MockBackendResolver) EXPECT() *MockBackendResolverMockRecorder {
 }
 
 // Resolve mocks base method.
-func (m *MockBackendResolver) Resolve(ctx context.Context, ref v1alpha2.BackendObjectReference) (*service.ResolvedReference, error) {
+func (m *MockBackendResolver) Resolve(ctx context.Context, namespace string, ref v1alpha2.BackendObjectReference) (*service.ResolvedReference, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resolve", ctx, ref)
+	ret := m.ctrl.Call(m, "Resolve", ctx, namespace, ref)
 	ret0, _ := ret[0].(*service.ResolvedReference)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Resolve indicates an expected call of Resolve.
-func (mr *MockBackendResolverMockRecorder) Resolve(ctx, ref interface{}) *gomock.Call {
+func (mr *MockBackendResolverMockRecorder) Resolve(ctx, namespace, ref interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockBackendResolver)(nil).Resolve), ctx, ref)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockBackendResolver)(nil).Resolve), ctx, namespace, ref)
 }

--- a/internal/k8s/service/resolver.go
+++ b/internal/k8s/service/resolver.go
@@ -182,31 +182,28 @@ func (r *ResolvedReference) Item() client.Object {
 }
 
 type BackendResolver interface {
-	Resolve(ctx context.Context, ref gwv1alpha2.BackendObjectReference) (*ResolvedReference, error)
+	Resolve(ctx context.Context, namespace string, ref gwv1alpha2.BackendObjectReference) (*ResolvedReference, error)
 }
 
 type backendResolver struct {
-	namespace string
-	client    gatewayclient.Client
-	consul    *api.Client
-	logger    hclog.Logger
-	mapper    common.ConsulNamespaceMapper
+	client gatewayclient.Client
+	consul *api.Client
+	logger hclog.Logger
+	mapper common.ConsulNamespaceMapper
 }
 
-func NewBackendResolver(logger hclog.Logger, namespace string, mapper common.ConsulNamespaceMapper, client gatewayclient.Client, consul *api.Client) BackendResolver {
+func NewBackendResolver(logger hclog.Logger, mapper common.ConsulNamespaceMapper, client gatewayclient.Client, consul *api.Client) *backendResolver {
 	return &backendResolver{
-		namespace: namespace,
-		client:    client,
-		consul:    consul,
-		mapper:    mapper,
-		logger:    logger,
+		client: client,
+		consul: consul,
+		mapper: mapper,
+		logger: logger,
 	}
 }
 
-func (r *backendResolver) Resolve(ctx context.Context, ref gwv1alpha2.BackendObjectReference) (*ResolvedReference, error) {
+func (r *backendResolver) Resolve(ctx context.Context, namespace string, ref gwv1alpha2.BackendObjectReference) (*ResolvedReference, error) {
 	group := corev1.GroupName
 	kind := "Service"
-	namespace := r.namespace
 	if ref.Group != nil {
 		group = string(*ref.Group)
 	}


### PR DESCRIPTION
### Changes proposed in this PR:
In working to get the store refactor merged, this was one chunk of changes that I noticed could be broken out of https://github.com/hashicorp/consul-api-gateway/pull/160 to make reviews less taxing. This introduces a factory for creating Gateways and Routes.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
