### PR TITLE
(dark) Add storage "backend" interface, in-memory implementation

### DIFF
--- a/internal/store/interfaces.go
+++ b/internal/store/interfaces.go
@@ -58,3 +58,27 @@ type Store interface {
 	UpsertRoute(ctx context.Context, route Route, updateConditionFn func(current Route) bool) error
 	Sync(ctx context.Context) error
 }
+
+// Backend is used for persisting and querying gateways and routes
+type Backend interface {
+	GetGateway(ctx context.Context, id core.GatewayID) ([]byte, error)
+	ListGateways(ctx context.Context) ([][]byte, error)
+	DeleteGateway(ctx context.Context, id core.GatewayID) error
+	UpsertGateways(ctx context.Context, gateways ...GatewayRecord) error
+	GetRoute(ctx context.Context, id string) ([]byte, error)
+	ListRoutes(ctx context.Context) ([][]byte, error)
+	DeleteRoute(ctx context.Context, id string) error
+	UpsertRoutes(ctx context.Context, routes ...RouteRecord) error
+}
+
+// GatewayRecord represents a serialized Gateway
+type GatewayRecord struct {
+	ID   core.GatewayID
+	Data []byte
+}
+
+// RouteRecord represents a serialized Route
+type RouteRecord struct {
+	ID   string
+	Data []byte
+}

--- a/internal/store/memory/backend.go
+++ b/internal/store/memory/backend.go
@@ -1,0 +1,103 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/consul-api-gateway/internal/core"
+	"github.com/hashicorp/consul-api-gateway/internal/store"
+)
+
+type Backend struct {
+	gateways map[core.GatewayID][]byte
+	routes   map[string][]byte
+
+	mutex sync.RWMutex
+}
+
+var _ store.Backend = &Backend{}
+
+func NewBackend() *Backend {
+	return &Backend{
+		gateways: make(map[core.GatewayID][]byte),
+		routes:   make(map[string][]byte),
+	}
+}
+
+func (b *Backend) GetGateway(_ context.Context, id core.GatewayID) ([]byte, error) {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	if data, found := b.gateways[id]; found {
+		return data, nil
+	}
+	return nil, store.ErrNotFound
+}
+
+func (b *Backend) ListGateways(_ context.Context) ([][]byte, error) {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	gateways := make([][]byte, 0, len(b.gateways))
+	for _, data := range b.gateways {
+		gateways = append(gateways, data)
+	}
+	return gateways, nil
+}
+
+func (b *Backend) DeleteGateway(_ context.Context, id core.GatewayID) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	delete(b.gateways, id)
+	return nil
+}
+
+func (b *Backend) UpsertGateways(_ context.Context, gateways ...store.GatewayRecord) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	for _, gateway := range gateways {
+		b.gateways[gateway.ID] = gateway.Data
+	}
+	return nil
+}
+
+func (b *Backend) GetRoute(_ context.Context, id string) ([]byte, error) {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	if data, found := b.routes[id]; found {
+		return data, nil
+	}
+	return nil, store.ErrNotFound
+}
+
+func (b *Backend) ListRoutes(_ context.Context) ([][]byte, error) {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+
+	routes := make([][]byte, 0, len(b.routes))
+	for _, data := range b.routes {
+		routes = append(routes, data)
+	}
+	return routes, nil
+}
+
+func (b *Backend) DeleteRoute(_ context.Context, id string) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	delete(b.routes, id)
+	return nil
+}
+
+func (b *Backend) UpsertRoutes(_ context.Context, routes ...store.RouteRecord) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	for _, route := range routes {
+		b.routes[route.ID] = route.Data
+	}
+	return nil
+}

--- a/internal/store/memory/backend_test.go
+++ b/internal/store/memory/backend_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/hashicorp/consul-api-gateway/internal/store"
 )
 
-func TestBackend_GetGateway(t *testing.T) {
+func TestBackend_UpsertGateways(t *testing.T) {
+	t.Parallel()
+
 	backend := NewBackend()
 
 	gatewayID := core.GatewayID{
@@ -19,7 +21,26 @@ func TestBackend_GetGateway(t *testing.T) {
 		Service:         t.Name(),
 	}
 
-	// Non-existent GatewayID should return error
+	assert.NoError(t, backend.UpsertGateways(context.Background(), store.GatewayRecord{
+		ID:   gatewayID,
+		Data: []byte(t.Name()),
+	}))
+
+	require.Contains(t, backend.gateways, gatewayID)
+	assert.Equal(t, []byte(t.Name()), backend.gateways[gatewayID])
+}
+
+func TestBackend_GetGateway(t *testing.T) {
+	t.Parallel()
+
+	backend := NewBackend()
+
+	gatewayID := core.GatewayID{
+		ConsulNamespace: "default",
+		Service:         t.Name(),
+	}
+
+	// Empty backend should return error
 	gateway, err := backend.GetGateway(context.Background(), gatewayID)
 	assert.EqualError(t, err, store.ErrNotFound.Error())
 	assert.Nil(t, gateway)
@@ -33,6 +54,8 @@ func TestBackend_GetGateway(t *testing.T) {
 }
 
 func TestBackend_ListGateways(t *testing.T) {
+	t.Parallel()
+
 	backend := NewBackend()
 
 	// Empty backend should return no Gateways
@@ -46,17 +69,19 @@ func TestBackend_ListGateways(t *testing.T) {
 
 	gateways, err = backend.ListGateways(context.Background())
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, gateways, [][]byte{gateway1.Data})
+	assert.ElementsMatch(t, [][]byte{gateway1.Data}, gateways)
 
 	gateway2 := store.GatewayRecord{ID: core.GatewayID{ConsulNamespace: "default2", Service: t.Name() + "_2"}, Data: []byte(t.Name() + "_2")}
 	backend.gateways[gateway2.ID] = gateway2.Data
 
 	gateways, err = backend.ListGateways(context.Background())
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, gateways, [][]byte{gateway1.Data, gateway2.Data})
+	assert.ElementsMatch(t, [][]byte{gateway1.Data, gateway2.Data}, gateways)
 }
 
 func TestBackend_DeleteGateway(t *testing.T) {
+	t.Parallel()
+
 	backend := NewBackend()
 
 	// Empty backend should no-op
@@ -75,4 +100,89 @@ func TestBackend_DeleteGateway(t *testing.T) {
 
 	require.Contains(t, backend.gateways, gateway2.ID)
 	assert.Equal(t, gateway2.Data, backend.gateways[gateway2.ID])
+}
+
+func TestBackend_UpsertRoutes(t *testing.T) {
+	t.Parallel()
+
+	backend := NewBackend()
+
+	routeID := t.Name()
+
+	assert.NoError(t, backend.UpsertRoutes(context.Background(), store.RouteRecord{
+		ID:   routeID,
+		Data: []byte(t.Name()),
+	}))
+
+	require.Contains(t, backend.routes, routeID)
+	assert.Equal(t, []byte(t.Name()), backend.routes[routeID])
+}
+
+func TestBackend_GetRoute(t *testing.T) {
+	t.Parallel()
+
+	backend := NewBackend()
+
+	routeID := t.Name()
+
+	//Empty backend should return error
+	route, err := backend.GetRoute(context.Background(), routeID)
+	assert.EqualError(t, err, store.ErrNotFound.Error())
+	assert.Nil(t, route)
+
+	// Existing Route ID should return the corresponding Route
+	backend.routes[routeID] = []byte(t.Name())
+
+	route, err = backend.GetRoute(context.Background(), routeID)
+	assert.NoError(t, err)
+	assert.Equal(t, route, []byte(t.Name()))
+}
+
+func TestBackend_ListRoutes(t *testing.T) {
+	t.Parallel()
+
+	backend := NewBackend()
+
+	// Empty backend should return no Routes
+	routes, err := backend.ListRoutes(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, routes)
+
+	// Backend should return all inserted Routes
+	route1 := store.RouteRecord{ID: t.Name() + "_1", Data: []byte(t.Name())}
+	backend.routes[route1.ID] = route1.Data
+
+	routes, err = backend.ListRoutes(context.Background())
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, [][]byte{route1.Data}, routes)
+
+	route2 := store.RouteRecord{ID: t.Name() + "_2", Data: []byte(t.Name())}
+	backend.routes[route2.ID] = route2.Data
+
+	routes, err = backend.ListRoutes(context.Background())
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, [][]byte{route1.Data, route2.Data}, routes)
+}
+
+func TestBackend_DeleteRoute(t *testing.T) {
+	t.Parallel()
+
+	backend := NewBackend()
+
+	// Empty backend should no-op
+	assert.NoError(t, backend.DeleteRoute(context.Background(), t.Name()))
+
+	// Delete should remove targeted Route from backend and leave others
+	route1 := store.RouteRecord{ID: t.Name() + "_1", Data: []byte(t.Name() + "_1")}
+	backend.routes[route1.ID] = route1.Data
+
+	route2 := store.RouteRecord{ID: t.Name() + "_2", Data: []byte(t.Name() + "_2")}
+	backend.routes[route2.ID] = route2.Data
+
+	err := backend.DeleteRoute(context.Background(), route1.ID)
+	assert.NoError(t, err)
+	assert.NotContains(t, backend.routes, route1.ID)
+
+	require.Contains(t, backend.routes, route2.ID)
+	assert.Equal(t, route2.Data, backend.routes[route2.ID])
 }

--- a/internal/store/memory/backend_test.go
+++ b/internal/store/memory/backend_test.go
@@ -1,0 +1,78 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul-api-gateway/internal/core"
+	"github.com/hashicorp/consul-api-gateway/internal/store"
+)
+
+func TestBackend_GetGateway(t *testing.T) {
+	backend := NewBackend()
+
+	gatewayID := core.GatewayID{
+		ConsulNamespace: "default",
+		Service:         t.Name(),
+	}
+
+	// Non-existent GatewayID should return error
+	gateway, err := backend.GetGateway(context.Background(), gatewayID)
+	assert.EqualError(t, err, store.ErrNotFound.Error())
+	assert.Nil(t, gateway)
+
+	// Existing GatewayID should return the corresponding Gateway
+	backend.gateways[gatewayID] = []byte(t.Name())
+
+	gateway, err = backend.GetGateway(context.Background(), gatewayID)
+	assert.NoError(t, err)
+	assert.Equal(t, gateway, []byte(t.Name()))
+}
+
+func TestBackend_ListGateways(t *testing.T) {
+	backend := NewBackend()
+
+	// Empty backend should return no Gateways
+	gateways, err := backend.ListGateways(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, gateways)
+
+	// Backend should return all upserted Gateways
+	gateway1 := store.GatewayRecord{ID: core.GatewayID{ConsulNamespace: "default1", Service: t.Name() + "_1"}, Data: []byte(t.Name() + "_1")}
+	backend.gateways[gateway1.ID] = gateway1.Data
+
+	gateways, err = backend.ListGateways(context.Background())
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, gateways, [][]byte{gateway1.Data})
+
+	gateway2 := store.GatewayRecord{ID: core.GatewayID{ConsulNamespace: "default2", Service: t.Name() + "_2"}, Data: []byte(t.Name() + "_2")}
+	backend.gateways[gateway2.ID] = gateway2.Data
+
+	gateways, err = backend.ListGateways(context.Background())
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, gateways, [][]byte{gateway1.Data, gateway2.Data})
+}
+
+func TestBackend_DeleteGateway(t *testing.T) {
+	backend := NewBackend()
+
+	// Empty backend should no-op
+	assert.NoError(t, backend.DeleteGateway(context.Background(), core.GatewayID{ConsulNamespace: "default", Service: t.Name()}))
+
+	// Delete should remove targeted Gateway from backend and leave others
+	gateway1 := store.GatewayRecord{ID: core.GatewayID{ConsulNamespace: "default1", Service: t.Name() + "_1"}, Data: []byte(t.Name() + "_1")}
+	backend.gateways[gateway1.ID] = gateway1.Data
+
+	gateway2 := store.GatewayRecord{ID: core.GatewayID{ConsulNamespace: "default2", Service: t.Name() + "_2"}, Data: []byte(t.Name() + "_2")}
+	backend.gateways[gateway2.ID] = gateway2.Data
+
+	err := backend.DeleteGateway(context.Background(), gateway1.ID)
+	assert.NoError(t, err)
+	assert.NotContains(t, backend.gateways, gateway1.ID)
+
+	require.Contains(t, backend.gateways, gateway2.ID)
+	assert.Equal(t, gateway2.Data, backend.gateways[gateway2.ID])
+}

--- a/internal/store/mocks/interfaces.go
+++ b/internal/store/mocks/interfaces.go
@@ -422,3 +422,152 @@ func (mr *MockStoreMockRecorder) UpsertRoute(ctx, route, updateConditionFn inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRoute", reflect.TypeOf((*MockStore)(nil).UpsertRoute), ctx, route, updateConditionFn)
 }
+
+// MockBackend is a mock of Backend interface.
+type MockBackend struct {
+	ctrl     *gomock.Controller
+	recorder *MockBackendMockRecorder
+}
+
+// MockBackendMockRecorder is the mock recorder for MockBackend.
+type MockBackendMockRecorder struct {
+	mock *MockBackend
+}
+
+// NewMockBackend creates a new mock instance.
+func NewMockBackend(ctrl *gomock.Controller) *MockBackend {
+	mock := &MockBackend{ctrl: ctrl}
+	mock.recorder = &MockBackendMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
+	return m.recorder
+}
+
+// DeleteGateway mocks base method.
+func (m *MockBackend) DeleteGateway(ctx context.Context, id core.GatewayID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteGateway", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteGateway indicates an expected call of DeleteGateway.
+func (mr *MockBackendMockRecorder) DeleteGateway(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGateway", reflect.TypeOf((*MockBackend)(nil).DeleteGateway), ctx, id)
+}
+
+// DeleteRoute mocks base method.
+func (m *MockBackend) DeleteRoute(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRoute", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRoute indicates an expected call of DeleteRoute.
+func (mr *MockBackendMockRecorder) DeleteRoute(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoute", reflect.TypeOf((*MockBackend)(nil).DeleteRoute), ctx, id)
+}
+
+// GetGateway mocks base method.
+func (m *MockBackend) GetGateway(ctx context.Context, id core.GatewayID) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGateway", ctx, id)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGateway indicates an expected call of GetGateway.
+func (mr *MockBackendMockRecorder) GetGateway(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGateway", reflect.TypeOf((*MockBackend)(nil).GetGateway), ctx, id)
+}
+
+// GetRoute mocks base method.
+func (m *MockBackend) GetRoute(ctx context.Context, id string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRoute", ctx, id)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRoute indicates an expected call of GetRoute.
+func (mr *MockBackendMockRecorder) GetRoute(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoute", reflect.TypeOf((*MockBackend)(nil).GetRoute), ctx, id)
+}
+
+// ListGateways mocks base method.
+func (m *MockBackend) ListGateways(ctx context.Context) ([][]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListGateways", ctx)
+	ret0, _ := ret[0].([][]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListGateways indicates an expected call of ListGateways.
+func (mr *MockBackendMockRecorder) ListGateways(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGateways", reflect.TypeOf((*MockBackend)(nil).ListGateways), ctx)
+}
+
+// ListRoutes mocks base method.
+func (m *MockBackend) ListRoutes(ctx context.Context) ([][]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRoutes", ctx)
+	ret0, _ := ret[0].([][]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRoutes indicates an expected call of ListRoutes.
+func (mr *MockBackendMockRecorder) ListRoutes(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoutes", reflect.TypeOf((*MockBackend)(nil).ListRoutes), ctx)
+}
+
+// UpsertGateways mocks base method.
+func (m *MockBackend) UpsertGateways(ctx context.Context, gateways ...store.GatewayRecord) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range gateways {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpsertGateways", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertGateways indicates an expected call of UpsertGateways.
+func (mr *MockBackendMockRecorder) UpsertGateways(ctx interface{}, gateways ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, gateways...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertGateways", reflect.TypeOf((*MockBackend)(nil).UpsertGateways), varargs...)
+}
+
+// UpsertRoutes mocks base method.
+func (m *MockBackend) UpsertRoutes(ctx context.Context, routes ...store.RouteRecord) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx}
+	for _, a := range routes {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpsertRoutes", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertRoutes indicates an expected call of UpsertRoutes.
+func (mr *MockBackendMockRecorder) UpsertRoutes(ctx interface{}, routes ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx}, routes...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRoutes", reflect.TypeOf((*MockBackend)(nil).UpsertRoutes), varargs...)
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,7 @@
+package store
+
+import (
+	"errors"
+)
+
+var ErrNotFound = errors.New("not found")


### PR DESCRIPTION
### Changes proposed in this PR:
This is the first part to be broken out of #165 . This defines the new `Backend` interface that handles CRUD ops for Gateways and Routes. It's not yet consumed anywhere, so this code is dark. I will consume it in a future PR as part of the ongoing refactor.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
