### PR TITLE
(dark) Include marshaling funcs when generating statuses

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/*zz_generated_*.go linguist-generated=true

--- a/internal/k8s/reconciler/status/zz_generated_status.go
+++ b/internal/k8s/reconciler/status/zz_generated_status.go
@@ -3,6 +3,9 @@ package status
 // GENERATED from statuses.yaml, DO NOT EDIT DIRECTLY
 
 import (
+	"encoding/json"
+	"errors"
+
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -100,6 +103,39 @@ func (s GatewayClassAcceptedStatus) Condition(generation int64) meta.Condition {
 		ObservedGeneration: generation,
 		LastTransitionTime: meta.Now(),
 	}
+}
+
+// MarshalJSON marshals a GatewayClassAcceptedStatus value to JSON
+func (s GatewayClassAcceptedStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.InvalidParameters != nil {
+		data["InvalidParameters"] = s.InvalidParameters.Error()
+	}
+
+	if s.Waiting != nil {
+		data["Waiting"] = s.Waiting.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a GatewayClassAcceptedStatus from JSON
+func (s *GatewayClassAcceptedStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["InvalidParameters"]; ok {
+		s.InvalidParameters = errors.New(err)
+	}
+
+	if err, ok := data["Waiting"]; ok {
+		s.Waiting = errors.New(err)
+	}
+
+	return nil
 }
 
 // HasError returns whether any of the GatewayClassAcceptedStatus errors are
@@ -249,6 +285,47 @@ func (s GatewayReadyStatus) Condition(generation int64) meta.Condition {
 	}
 }
 
+// MarshalJSON marshals a GatewayReadyStatus value to JSON
+func (s GatewayReadyStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.ListenersNotValid != nil {
+		data["ListenersNotValid"] = s.ListenersNotValid.Error()
+	}
+
+	if s.ListenersNotReady != nil {
+		data["ListenersNotReady"] = s.ListenersNotReady.Error()
+	}
+
+	if s.AddressNotAssigned != nil {
+		data["AddressNotAssigned"] = s.AddressNotAssigned.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a GatewayReadyStatus from JSON
+func (s *GatewayReadyStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["ListenersNotValid"]; ok {
+		s.ListenersNotValid = errors.New(err)
+	}
+
+	if err, ok := data["ListenersNotReady"]; ok {
+		s.ListenersNotReady = errors.New(err)
+	}
+
+	if err, ok := data["AddressNotAssigned"]; ok {
+		s.AddressNotAssigned = errors.New(err)
+	}
+
+	return nil
+}
+
 // HasError returns whether any of the GatewayReadyStatus errors are set.
 func (s GatewayReadyStatus) HasError() bool {
 	return s.ListenersNotValid != nil || s.ListenersNotReady != nil || s.AddressNotAssigned != nil
@@ -372,6 +449,55 @@ func (s GatewayScheduledStatus) Condition(generation int64) meta.Condition {
 	}
 }
 
+// MarshalJSON marshals a GatewayScheduledStatus value to JSON
+func (s GatewayScheduledStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.NotReconciled != nil {
+		data["NotReconciled"] = s.NotReconciled.Error()
+	}
+
+	if s.PodFailed != nil {
+		data["PodFailed"] = s.PodFailed.Error()
+	}
+
+	if s.Unknown != nil {
+		data["Unknown"] = s.Unknown.Error()
+	}
+
+	if s.NoResources != nil {
+		data["NoResources"] = s.NoResources.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a GatewayScheduledStatus from JSON
+func (s *GatewayScheduledStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["NotReconciled"]; ok {
+		s.NotReconciled = errors.New(err)
+	}
+
+	if err, ok := data["PodFailed"]; ok {
+		s.PodFailed = errors.New(err)
+	}
+
+	if err, ok := data["Unknown"]; ok {
+		s.Unknown = errors.New(err)
+	}
+
+	if err, ok := data["NoResources"]; ok {
+		s.NoResources = errors.New(err)
+	}
+
+	return nil
+}
+
 // HasError returns whether any of the GatewayScheduledStatus errors are set.
 func (s GatewayScheduledStatus) HasError() bool {
 	return s.NotReconciled != nil || s.PodFailed != nil || s.Unknown != nil || s.NoResources != nil
@@ -429,6 +555,31 @@ func (s GatewayInSyncStatus) Condition(generation int64) meta.Condition {
 		ObservedGeneration: generation,
 		LastTransitionTime: meta.Now(),
 	}
+}
+
+// MarshalJSON marshals a GatewayInSyncStatus value to JSON
+func (s GatewayInSyncStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.SyncError != nil {
+		data["SyncError"] = s.SyncError.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a GatewayInSyncStatus from JSON
+func (s *GatewayInSyncStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["SyncError"]; ok {
+		s.SyncError = errors.New(err)
+	}
+
+	return nil
 }
 
 // HasError returns whether any of the GatewayInSyncStatus errors are set.
@@ -580,6 +731,55 @@ func (s RouteAcceptedStatus) Condition(generation int64) meta.Condition {
 		ObservedGeneration: generation,
 		LastTransitionTime: meta.Now(),
 	}
+}
+
+// MarshalJSON marshals a RouteAcceptedStatus value to JSON
+func (s RouteAcceptedStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.InvalidRouteKind != nil {
+		data["InvalidRouteKind"] = s.InvalidRouteKind.Error()
+	}
+
+	if s.ListenerNamespacePolicy != nil {
+		data["ListenerNamespacePolicy"] = s.ListenerNamespacePolicy.Error()
+	}
+
+	if s.ListenerHostnameMismatch != nil {
+		data["ListenerHostnameMismatch"] = s.ListenerHostnameMismatch.Error()
+	}
+
+	if s.BindError != nil {
+		data["BindError"] = s.BindError.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a RouteAcceptedStatus from JSON
+func (s *RouteAcceptedStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["InvalidRouteKind"]; ok {
+		s.InvalidRouteKind = errors.New(err)
+	}
+
+	if err, ok := data["ListenerNamespacePolicy"]; ok {
+		s.ListenerNamespacePolicy = errors.New(err)
+	}
+
+	if err, ok := data["ListenerHostnameMismatch"]; ok {
+		s.ListenerHostnameMismatch = errors.New(err)
+	}
+
+	if err, ok := data["BindError"]; ok {
+		s.BindError = errors.New(err)
+	}
+
+	return nil
 }
 
 // RouteResolvedRefsStatus - This condition indicates whether the controller was
@@ -746,6 +946,71 @@ func (s RouteResolvedRefsStatus) Condition(generation int64) meta.Condition {
 	}
 }
 
+// MarshalJSON marshals a RouteResolvedRefsStatus value to JSON
+func (s RouteResolvedRefsStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.Errors != nil {
+		data["Errors"] = s.Errors.Error()
+	}
+
+	if s.ServiceNotFound != nil {
+		data["ServiceNotFound"] = s.ServiceNotFound.Error()
+	}
+
+	if s.ConsulServiceNotFound != nil {
+		data["ConsulServiceNotFound"] = s.ConsulServiceNotFound.Error()
+	}
+
+	if s.RefNotPermitted != nil {
+		data["RefNotPermitted"] = s.RefNotPermitted.Error()
+	}
+
+	if s.InvalidKind != nil {
+		data["InvalidKind"] = s.InvalidKind.Error()
+	}
+
+	if s.BackendNotFound != nil {
+		data["BackendNotFound"] = s.BackendNotFound.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a RouteResolvedRefsStatus from JSON
+func (s *RouteResolvedRefsStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["Errors"]; ok {
+		s.Errors = errors.New(err)
+	}
+
+	if err, ok := data["ServiceNotFound"]; ok {
+		s.ServiceNotFound = errors.New(err)
+	}
+
+	if err, ok := data["ConsulServiceNotFound"]; ok {
+		s.ConsulServiceNotFound = errors.New(err)
+	}
+
+	if err, ok := data["RefNotPermitted"]; ok {
+		s.RefNotPermitted = errors.New(err)
+	}
+
+	if err, ok := data["InvalidKind"]; ok {
+		s.InvalidKind = errors.New(err)
+	}
+
+	if err, ok := data["BackendNotFound"]; ok {
+		s.BackendNotFound = errors.New(err)
+	}
+
+	return nil
+}
+
 // HasError returns whether any of the RouteResolvedRefsStatus errors are set.
 func (s RouteResolvedRefsStatus) HasError() bool {
 	return s.Errors != nil || s.ServiceNotFound != nil || s.ConsulServiceNotFound != nil || s.RefNotPermitted != nil || s.InvalidKind != nil || s.BackendNotFound != nil
@@ -880,6 +1145,47 @@ func (s ListenerConflictedStatus) Condition(generation int64) meta.Condition {
 		ObservedGeneration: generation,
 		LastTransitionTime: meta.Now(),
 	}
+}
+
+// MarshalJSON marshals a ListenerConflictedStatus value to JSON
+func (s ListenerConflictedStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.HostnameConflict != nil {
+		data["HostnameConflict"] = s.HostnameConflict.Error()
+	}
+
+	if s.ProtocolConflict != nil {
+		data["ProtocolConflict"] = s.ProtocolConflict.Error()
+	}
+
+	if s.RouteConflict != nil {
+		data["RouteConflict"] = s.RouteConflict.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a ListenerConflictedStatus from JSON
+func (s *ListenerConflictedStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["HostnameConflict"]; ok {
+		s.HostnameConflict = errors.New(err)
+	}
+
+	if err, ok := data["ProtocolConflict"]; ok {
+		s.ProtocolConflict = errors.New(err)
+	}
+
+	if err, ok := data["RouteConflict"]; ok {
+		s.RouteConflict = errors.New(err)
+	}
+
+	return nil
 }
 
 // HasError returns whether any of the ListenerConflictedStatus errors are set.
@@ -1042,6 +1348,55 @@ func (s ListenerDetachedStatus) Condition(generation int64) meta.Condition {
 	}
 }
 
+// MarshalJSON marshals a ListenerDetachedStatus value to JSON
+func (s ListenerDetachedStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.PortUnavailable != nil {
+		data["PortUnavailable"] = s.PortUnavailable.Error()
+	}
+
+	if s.UnsupportedExtension != nil {
+		data["UnsupportedExtension"] = s.UnsupportedExtension.Error()
+	}
+
+	if s.UnsupportedProtocol != nil {
+		data["UnsupportedProtocol"] = s.UnsupportedProtocol.Error()
+	}
+
+	if s.UnsupportedAddress != nil {
+		data["UnsupportedAddress"] = s.UnsupportedAddress.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a ListenerDetachedStatus from JSON
+func (s *ListenerDetachedStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["PortUnavailable"]; ok {
+		s.PortUnavailable = errors.New(err)
+	}
+
+	if err, ok := data["UnsupportedExtension"]; ok {
+		s.UnsupportedExtension = errors.New(err)
+	}
+
+	if err, ok := data["UnsupportedProtocol"]; ok {
+		s.UnsupportedProtocol = errors.New(err)
+	}
+
+	if err, ok := data["UnsupportedAddress"]; ok {
+		s.UnsupportedAddress = errors.New(err)
+	}
+
+	return nil
+}
+
 // HasError returns whether any of the ListenerDetachedStatus errors are set.
 func (s ListenerDetachedStatus) HasError() bool {
 	return s.PortUnavailable != nil || s.UnsupportedExtension != nil || s.UnsupportedProtocol != nil || s.UnsupportedAddress != nil
@@ -1121,6 +1476,39 @@ func (s ListenerReadyStatus) Condition(generation int64) meta.Condition {
 		ObservedGeneration: generation,
 		LastTransitionTime: meta.Now(),
 	}
+}
+
+// MarshalJSON marshals a ListenerReadyStatus value to JSON
+func (s ListenerReadyStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.Invalid != nil {
+		data["Invalid"] = s.Invalid.Error()
+	}
+
+	if s.Pending != nil {
+		data["Pending"] = s.Pending.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a ListenerReadyStatus from JSON
+func (s *ListenerReadyStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["Invalid"]; ok {
+		s.Invalid = errors.New(err)
+	}
+
+	if err, ok := data["Pending"]; ok {
+		s.Pending = errors.New(err)
+	}
+
+	return nil
 }
 
 // HasError returns whether any of the ListenerReadyStatus errors are set.
@@ -1229,6 +1617,47 @@ func (s ListenerResolvedRefsStatus) Condition(generation int64) meta.Condition {
 		ObservedGeneration: generation,
 		LastTransitionTime: meta.Now(),
 	}
+}
+
+// MarshalJSON marshals a ListenerResolvedRefsStatus value to JSON
+func (s ListenerResolvedRefsStatus) MarshalJSON() ([]byte, error) {
+	data := map[string]string{}
+
+	if s.InvalidCertificateRef != nil {
+		data["InvalidCertificateRef"] = s.InvalidCertificateRef.Error()
+	}
+
+	if s.InvalidRouteKinds != nil {
+		data["InvalidRouteKinds"] = s.InvalidRouteKinds.Error()
+	}
+
+	if s.RefNotPermitted != nil {
+		data["RefNotPermitted"] = s.RefNotPermitted.Error()
+	}
+
+	return json.Marshal(data)
+}
+
+// UnmarshalJSON unmarshals a ListenerResolvedRefsStatus from JSON
+func (s *ListenerResolvedRefsStatus) UnmarshalJSON(b []byte) error {
+	data := map[string]string{}
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+
+	if err, ok := data["InvalidCertificateRef"]; ok {
+		s.InvalidCertificateRef = errors.New(err)
+	}
+
+	if err, ok := data["InvalidRouteKinds"]; ok {
+		s.InvalidRouteKinds = errors.New(err)
+	}
+
+	if err, ok := data["RefNotPermitted"]; ok {
+		s.RefNotPermitted = errors.New(err)
+	}
+
+	return nil
 }
 
 // HasError returns whether any of the ListenerResolvedRefsStatus errors are

--- a/internal/k8s/reconciler/status/zz_generated_status_test.go
+++ b/internal/k8s/reconciler/status/zz_generated_status_test.go
@@ -3,6 +3,7 @@ package status
 // GENERATED from statuses.yaml, DO NOT EDIT DIRECTLY
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -45,6 +46,25 @@ func TestGatewayClassStatus(t *testing.T) {
 	reason = GatewayClassConditionReasonAccepted
 	require.Equal(t, conditionType, conditions[0].Type)
 	require.Equal(t, reason, conditions[0].Reason)
+}
+
+func TestGatewayClassAcceptedStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := GatewayClassAcceptedStatus{
+		InvalidParameters: errors.New("InvalidParameters"),
+		Waiting:           errors.New("Waiting"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := GatewayClassAcceptedStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.InvalidParameters.Error(), unmarshaled.InvalidParameters.Error())
+
+	require.Equal(t, status.Waiting.Error(), unmarshaled.Waiting.Error())
 }
 
 func TestGatewayReadyStatus(t *testing.T) {
@@ -151,6 +171,69 @@ func TestGatewayStatus(t *testing.T) {
 	require.Equal(t, reason, conditions[2].Reason)
 }
 
+func TestGatewayReadyStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := GatewayReadyStatus{
+		ListenersNotValid:  errors.New("ListenersNotValid"),
+		ListenersNotReady:  errors.New("ListenersNotReady"),
+		AddressNotAssigned: errors.New("AddressNotAssigned"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := GatewayReadyStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.ListenersNotValid.Error(), unmarshaled.ListenersNotValid.Error())
+
+	require.Equal(t, status.ListenersNotReady.Error(), unmarshaled.ListenersNotReady.Error())
+
+	require.Equal(t, status.AddressNotAssigned.Error(), unmarshaled.AddressNotAssigned.Error())
+}
+
+func TestGatewayScheduledStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := GatewayScheduledStatus{
+		NotReconciled: errors.New("NotReconciled"),
+		PodFailed:     errors.New("PodFailed"),
+		Unknown:       errors.New("Unknown"),
+		NoResources:   errors.New("NoResources"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := GatewayScheduledStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.NotReconciled.Error(), unmarshaled.NotReconciled.Error())
+
+	require.Equal(t, status.PodFailed.Error(), unmarshaled.PodFailed.Error())
+
+	require.Equal(t, status.Unknown.Error(), unmarshaled.Unknown.Error())
+
+	require.Equal(t, status.NoResources.Error(), unmarshaled.NoResources.Error())
+}
+
+func TestGatewayInSyncStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := GatewayInSyncStatus{
+		SyncError: errors.New("SyncError"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := GatewayInSyncStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.SyncError.Error(), unmarshaled.SyncError.Error())
+}
+
 func TestRouteAcceptedStatus(t *testing.T) {
 	t.Parallel()
 
@@ -241,6 +324,62 @@ func TestRouteStatus(t *testing.T) {
 	reason = RouteConditionReasonResolvedRefs
 	require.Equal(t, conditionType, conditions[1].Type)
 	require.Equal(t, reason, conditions[1].Reason)
+}
+
+func TestRouteAcceptedStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := RouteAcceptedStatus{
+		InvalidRouteKind:         errors.New("InvalidRouteKind"),
+		ListenerNamespacePolicy:  errors.New("ListenerNamespacePolicy"),
+		ListenerHostnameMismatch: errors.New("ListenerHostnameMismatch"),
+		BindError:                errors.New("BindError"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := RouteAcceptedStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.InvalidRouteKind.Error(), unmarshaled.InvalidRouteKind.Error())
+
+	require.Equal(t, status.ListenerNamespacePolicy.Error(), unmarshaled.ListenerNamespacePolicy.Error())
+
+	require.Equal(t, status.ListenerHostnameMismatch.Error(), unmarshaled.ListenerHostnameMismatch.Error())
+
+	require.Equal(t, status.BindError.Error(), unmarshaled.BindError.Error())
+}
+
+func TestRouteResolvedRefsStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := RouteResolvedRefsStatus{
+		Errors:                errors.New("Errors"),
+		ServiceNotFound:       errors.New("ServiceNotFound"),
+		ConsulServiceNotFound: errors.New("ConsulServiceNotFound"),
+		RefNotPermitted:       errors.New("RefNotPermitted"),
+		InvalidKind:           errors.New("InvalidKind"),
+		BackendNotFound:       errors.New("BackendNotFound"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := RouteResolvedRefsStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.Errors.Error(), unmarshaled.Errors.Error())
+
+	require.Equal(t, status.ServiceNotFound.Error(), unmarshaled.ServiceNotFound.Error())
+
+	require.Equal(t, status.ConsulServiceNotFound.Error(), unmarshaled.ConsulServiceNotFound.Error())
+
+	require.Equal(t, status.RefNotPermitted.Error(), unmarshaled.RefNotPermitted.Error())
+
+	require.Equal(t, status.InvalidKind.Error(), unmarshaled.InvalidKind.Error())
+
+	require.Equal(t, status.BackendNotFound.Error(), unmarshaled.BackendNotFound.Error())
 }
 
 func TestListenerConflictedStatus(t *testing.T) {
@@ -427,4 +566,92 @@ func TestListenerStatus(t *testing.T) {
 	status = ListenerStatus{}
 	status.ResolvedRefs.RefNotPermitted = validationError
 	require.False(t, status.Valid())
+}
+
+func TestListenerConflictedStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := ListenerConflictedStatus{
+		HostnameConflict: errors.New("HostnameConflict"),
+		ProtocolConflict: errors.New("ProtocolConflict"),
+		RouteConflict:    errors.New("RouteConflict"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := ListenerConflictedStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.HostnameConflict.Error(), unmarshaled.HostnameConflict.Error())
+
+	require.Equal(t, status.ProtocolConflict.Error(), unmarshaled.ProtocolConflict.Error())
+
+	require.Equal(t, status.RouteConflict.Error(), unmarshaled.RouteConflict.Error())
+}
+
+func TestListenerDetachedStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := ListenerDetachedStatus{
+		PortUnavailable:      errors.New("PortUnavailable"),
+		UnsupportedExtension: errors.New("UnsupportedExtension"),
+		UnsupportedProtocol:  errors.New("UnsupportedProtocol"),
+		UnsupportedAddress:   errors.New("UnsupportedAddress"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := ListenerDetachedStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.PortUnavailable.Error(), unmarshaled.PortUnavailable.Error())
+
+	require.Equal(t, status.UnsupportedExtension.Error(), unmarshaled.UnsupportedExtension.Error())
+
+	require.Equal(t, status.UnsupportedProtocol.Error(), unmarshaled.UnsupportedProtocol.Error())
+
+	require.Equal(t, status.UnsupportedAddress.Error(), unmarshaled.UnsupportedAddress.Error())
+}
+
+func TestListenerReadyStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := ListenerReadyStatus{
+		Invalid: errors.New("Invalid"),
+		Pending: errors.New("Pending"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := ListenerReadyStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.Invalid.Error(), unmarshaled.Invalid.Error())
+
+	require.Equal(t, status.Pending.Error(), unmarshaled.Pending.Error())
+}
+
+func TestListenerResolvedRefsStatusMarshaling(t *testing.T) {
+	t.Parallel()
+
+	status := ListenerResolvedRefsStatus{
+		InvalidCertificateRef: errors.New("InvalidCertificateRef"),
+		InvalidRouteKinds:     errors.New("InvalidRouteKinds"),
+		RefNotPermitted:       errors.New("RefNotPermitted"),
+	}
+
+	data, err := json.Marshal(&status)
+	require.NoError(t, err)
+	unmarshaled := ListenerResolvedRefsStatus{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	require.Equal(t, status.InvalidCertificateRef.Error(), unmarshaled.InvalidCertificateRef.Error())
+
+	require.Equal(t, status.InvalidRouteKinds.Error(), unmarshaled.InvalidRouteKinds.Error())
+
+	require.Equal(t, status.RefNotPermitted.Error(), unmarshaled.RefNotPermitted.Error())
 }

--- a/internal/k8s/reconciler/status/zz_generated_status_test.go
+++ b/internal/k8s/reconciler/status/zz_generated_status_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,19 +19,20 @@ func TestGatewayClassAcceptedStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = GatewayClassAcceptedStatus{}
-	require.Equal(t, "Accepted", status.Condition(0).Message)
-	require.Equal(t, GatewayClassConditionReasonAccepted, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "Accepted", status.Condition(0).Message)
+	assert.Equal(t, GatewayClassConditionReasonAccepted, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = GatewayClassAcceptedStatus{InvalidParameters: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayClassConditionReasonInvalidParameters, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayClassConditionReasonInvalidParameters, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = GatewayClassAcceptedStatus{Waiting: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayClassConditionReasonWaiting, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayClassConditionReasonWaiting, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestGatewayClassStatus(t *testing.T) {
@@ -44,8 +46,8 @@ func TestGatewayClassStatus(t *testing.T) {
 
 	conditionType = GatewayClassConditionAccepted
 	reason = GatewayClassConditionReasonAccepted
-	require.Equal(t, conditionType, conditions[0].Type)
-	require.Equal(t, reason, conditions[0].Reason)
+	assert.Equal(t, conditionType, conditions[0].Type)
+	assert.Equal(t, reason, conditions[0].Reason)
 }
 
 func TestGatewayClassAcceptedStatusMarshaling(t *testing.T) {
@@ -58,13 +60,11 @@ func TestGatewayClassAcceptedStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := GatewayClassAcceptedStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.InvalidParameters.Error(), unmarshaled.InvalidParameters.Error())
-
-	require.Equal(t, status.Waiting.Error(), unmarshaled.Waiting.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.InvalidParameters.Error(), unmarshaled.InvalidParameters.Error())
+	assert.Equal(t, status.Waiting.Error(), unmarshaled.Waiting.Error())
 }
 
 func TestGatewayReadyStatus(t *testing.T) {
@@ -75,24 +75,25 @@ func TestGatewayReadyStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = GatewayReadyStatus{}
-	require.Equal(t, "Ready", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonReady, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "Ready", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonReady, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = GatewayReadyStatus{ListenersNotValid: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonListenersNotValid, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonListenersNotValid, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = GatewayReadyStatus{ListenersNotReady: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonListenersNotReady, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonListenersNotReady, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = GatewayReadyStatus{AddressNotAssigned: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonAddressNotAssigned, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonAddressNotAssigned, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestGatewayScheduledStatus(t *testing.T) {
@@ -103,29 +104,30 @@ func TestGatewayScheduledStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = GatewayScheduledStatus{}
-	require.Equal(t, "Scheduled", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonScheduled, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "Scheduled", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonScheduled, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = GatewayScheduledStatus{NotReconciled: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonNotReconciled, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonNotReconciled, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = GatewayScheduledStatus{PodFailed: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonPodFailed, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonPodFailed, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = GatewayScheduledStatus{Unknown: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonUnknown, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonUnknown, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = GatewayScheduledStatus{NoResources: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonNoResources, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonNoResources, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestGatewayInSyncStatus(t *testing.T) {
@@ -136,14 +138,15 @@ func TestGatewayInSyncStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = GatewayInSyncStatus{}
-	require.Equal(t, "InSync", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonInSync, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "InSync", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonInSync, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = GatewayInSyncStatus{SyncError: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, GatewayConditionReasonSyncError, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, GatewayConditionReasonSyncError, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestGatewayStatus(t *testing.T) {
@@ -157,18 +160,18 @@ func TestGatewayStatus(t *testing.T) {
 
 	conditionType = GatewayConditionReady
 	reason = GatewayConditionReasonReady
-	require.Equal(t, conditionType, conditions[0].Type)
-	require.Equal(t, reason, conditions[0].Reason)
+	assert.Equal(t, conditionType, conditions[0].Type)
+	assert.Equal(t, reason, conditions[0].Reason)
 
 	conditionType = GatewayConditionScheduled
 	reason = GatewayConditionReasonScheduled
-	require.Equal(t, conditionType, conditions[1].Type)
-	require.Equal(t, reason, conditions[1].Reason)
+	assert.Equal(t, conditionType, conditions[1].Type)
+	assert.Equal(t, reason, conditions[1].Reason)
 
 	conditionType = GatewayConditionInSync
 	reason = GatewayConditionReasonInSync
-	require.Equal(t, conditionType, conditions[2].Type)
-	require.Equal(t, reason, conditions[2].Reason)
+	assert.Equal(t, conditionType, conditions[2].Type)
+	assert.Equal(t, reason, conditions[2].Reason)
 }
 
 func TestGatewayReadyStatusMarshaling(t *testing.T) {
@@ -182,15 +185,12 @@ func TestGatewayReadyStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := GatewayReadyStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.ListenersNotValid.Error(), unmarshaled.ListenersNotValid.Error())
-
-	require.Equal(t, status.ListenersNotReady.Error(), unmarshaled.ListenersNotReady.Error())
-
-	require.Equal(t, status.AddressNotAssigned.Error(), unmarshaled.AddressNotAssigned.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.ListenersNotValid.Error(), unmarshaled.ListenersNotValid.Error())
+	assert.Equal(t, status.ListenersNotReady.Error(), unmarshaled.ListenersNotReady.Error())
+	assert.Equal(t, status.AddressNotAssigned.Error(), unmarshaled.AddressNotAssigned.Error())
 }
 
 func TestGatewayScheduledStatusMarshaling(t *testing.T) {
@@ -205,17 +205,13 @@ func TestGatewayScheduledStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := GatewayScheduledStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.NotReconciled.Error(), unmarshaled.NotReconciled.Error())
-
-	require.Equal(t, status.PodFailed.Error(), unmarshaled.PodFailed.Error())
-
-	require.Equal(t, status.Unknown.Error(), unmarshaled.Unknown.Error())
-
-	require.Equal(t, status.NoResources.Error(), unmarshaled.NoResources.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.NotReconciled.Error(), unmarshaled.NotReconciled.Error())
+	assert.Equal(t, status.PodFailed.Error(), unmarshaled.PodFailed.Error())
+	assert.Equal(t, status.Unknown.Error(), unmarshaled.Unknown.Error())
+	assert.Equal(t, status.NoResources.Error(), unmarshaled.NoResources.Error())
 }
 
 func TestGatewayInSyncStatusMarshaling(t *testing.T) {
@@ -227,11 +223,10 @@ func TestGatewayInSyncStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
-	unmarshaled := GatewayInSyncStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
 
-	require.Equal(t, status.SyncError.Error(), unmarshaled.SyncError.Error())
+	unmarshaled := GatewayInSyncStatus{}
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.SyncError.Error(), unmarshaled.SyncError.Error())
 }
 
 func TestRouteAcceptedStatus(t *testing.T) {
@@ -242,24 +237,24 @@ func TestRouteAcceptedStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = RouteAcceptedStatus{}
-	require.Equal(t, "Route accepted.", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonAccepted, status.Condition(0).Reason)
+	assert.Equal(t, "Route accepted.", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonAccepted, status.Condition(0).Reason)
 
 	status = RouteAcceptedStatus{InvalidRouteKind: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonInvalidRouteKind, status.Condition(0).Reason)
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonInvalidRouteKind, status.Condition(0).Reason)
 
 	status = RouteAcceptedStatus{ListenerNamespacePolicy: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonListenerNamespacePolicy, status.Condition(0).Reason)
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonListenerNamespacePolicy, status.Condition(0).Reason)
 
 	status = RouteAcceptedStatus{ListenerHostnameMismatch: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonListenerHostnameMismatch, status.Condition(0).Reason)
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonListenerHostnameMismatch, status.Condition(0).Reason)
 
 	status = RouteAcceptedStatus{BindError: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonBindError, status.Condition(0).Reason)
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonBindError, status.Condition(0).Reason)
 
 }
 
@@ -271,39 +266,40 @@ func TestRouteResolvedRefsStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = RouteResolvedRefsStatus{}
-	require.Equal(t, "ResolvedRefs", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonResolvedRefs, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "ResolvedRefs", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonResolvedRefs, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = RouteResolvedRefsStatus{Errors: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonErrors, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonErrors, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = RouteResolvedRefsStatus{ServiceNotFound: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonServiceNotFound, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonServiceNotFound, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = RouteResolvedRefsStatus{ConsulServiceNotFound: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonConsulServiceNotFound, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonConsulServiceNotFound, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = RouteResolvedRefsStatus{RefNotPermitted: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonRefNotPermitted, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonRefNotPermitted, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = RouteResolvedRefsStatus{InvalidKind: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonInvalidKind, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonInvalidKind, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = RouteResolvedRefsStatus{BackendNotFound: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, RouteConditionReasonBackendNotFound, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, RouteConditionReasonBackendNotFound, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestRouteStatus(t *testing.T) {
@@ -317,13 +313,13 @@ func TestRouteStatus(t *testing.T) {
 
 	conditionType = RouteConditionAccepted
 	reason = RouteConditionReasonAccepted
-	require.Equal(t, conditionType, conditions[0].Type)
-	require.Equal(t, reason, conditions[0].Reason)
+	assert.Equal(t, conditionType, conditions[0].Type)
+	assert.Equal(t, reason, conditions[0].Reason)
 
 	conditionType = RouteConditionResolvedRefs
 	reason = RouteConditionReasonResolvedRefs
-	require.Equal(t, conditionType, conditions[1].Type)
-	require.Equal(t, reason, conditions[1].Reason)
+	assert.Equal(t, conditionType, conditions[1].Type)
+	assert.Equal(t, reason, conditions[1].Reason)
 }
 
 func TestRouteAcceptedStatusMarshaling(t *testing.T) {
@@ -338,17 +334,13 @@ func TestRouteAcceptedStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := RouteAcceptedStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.InvalidRouteKind.Error(), unmarshaled.InvalidRouteKind.Error())
-
-	require.Equal(t, status.ListenerNamespacePolicy.Error(), unmarshaled.ListenerNamespacePolicy.Error())
-
-	require.Equal(t, status.ListenerHostnameMismatch.Error(), unmarshaled.ListenerHostnameMismatch.Error())
-
-	require.Equal(t, status.BindError.Error(), unmarshaled.BindError.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.InvalidRouteKind.Error(), unmarshaled.InvalidRouteKind.Error())
+	assert.Equal(t, status.ListenerNamespacePolicy.Error(), unmarshaled.ListenerNamespacePolicy.Error())
+	assert.Equal(t, status.ListenerHostnameMismatch.Error(), unmarshaled.ListenerHostnameMismatch.Error())
+	assert.Equal(t, status.BindError.Error(), unmarshaled.BindError.Error())
 }
 
 func TestRouteResolvedRefsStatusMarshaling(t *testing.T) {
@@ -365,21 +357,15 @@ func TestRouteResolvedRefsStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := RouteResolvedRefsStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.Errors.Error(), unmarshaled.Errors.Error())
-
-	require.Equal(t, status.ServiceNotFound.Error(), unmarshaled.ServiceNotFound.Error())
-
-	require.Equal(t, status.ConsulServiceNotFound.Error(), unmarshaled.ConsulServiceNotFound.Error())
-
-	require.Equal(t, status.RefNotPermitted.Error(), unmarshaled.RefNotPermitted.Error())
-
-	require.Equal(t, status.InvalidKind.Error(), unmarshaled.InvalidKind.Error())
-
-	require.Equal(t, status.BackendNotFound.Error(), unmarshaled.BackendNotFound.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.Errors.Error(), unmarshaled.Errors.Error())
+	assert.Equal(t, status.ServiceNotFound.Error(), unmarshaled.ServiceNotFound.Error())
+	assert.Equal(t, status.ConsulServiceNotFound.Error(), unmarshaled.ConsulServiceNotFound.Error())
+	assert.Equal(t, status.RefNotPermitted.Error(), unmarshaled.RefNotPermitted.Error())
+	assert.Equal(t, status.InvalidKind.Error(), unmarshaled.InvalidKind.Error())
+	assert.Equal(t, status.BackendNotFound.Error(), unmarshaled.BackendNotFound.Error())
 }
 
 func TestListenerConflictedStatus(t *testing.T) {
@@ -390,24 +376,25 @@ func TestListenerConflictedStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = ListenerConflictedStatus{}
-	require.Equal(t, "NoConflicts", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonNoConflicts, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "NoConflicts", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonNoConflicts, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = ListenerConflictedStatus{HostnameConflict: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonHostnameConflict, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonHostnameConflict, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = ListenerConflictedStatus{ProtocolConflict: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonProtocolConflict, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonProtocolConflict, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = ListenerConflictedStatus{RouteConflict: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonRouteConflict, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonRouteConflict, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestListenerDetachedStatus(t *testing.T) {
@@ -418,29 +405,30 @@ func TestListenerDetachedStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = ListenerDetachedStatus{}
-	require.Equal(t, "Attached", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonAttached, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "Attached", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonAttached, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = ListenerDetachedStatus{PortUnavailable: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonPortUnavailable, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonPortUnavailable, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = ListenerDetachedStatus{UnsupportedExtension: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonUnsupportedExtension, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonUnsupportedExtension, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = ListenerDetachedStatus{UnsupportedProtocol: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonUnsupportedProtocol, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonUnsupportedProtocol, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = ListenerDetachedStatus{UnsupportedAddress: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonUnsupportedAddress, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonUnsupportedAddress, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestListenerReadyStatus(t *testing.T) {
@@ -451,19 +439,20 @@ func TestListenerReadyStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = ListenerReadyStatus{}
-	require.Equal(t, "Ready", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonReady, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "Ready", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonReady, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = ListenerReadyStatus{Invalid: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonInvalid, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonInvalid, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = ListenerReadyStatus{Pending: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonPending, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonPending, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestListenerResolvedRefsStatus(t *testing.T) {
@@ -474,24 +463,25 @@ func TestListenerResolvedRefsStatus(t *testing.T) {
 	expected := errors.New("expected")
 
 	status = ListenerResolvedRefsStatus{}
-	require.Equal(t, "ResolvedRefs", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonResolvedRefs, status.Condition(0).Reason)
-	require.False(t, status.HasError())
+	assert.Equal(t, "ResolvedRefs", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonResolvedRefs, status.Condition(0).Reason)
+	assert.False(t, status.HasError())
 
 	status = ListenerResolvedRefsStatus{InvalidCertificateRef: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonInvalidCertificateRef, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonInvalidCertificateRef, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = ListenerResolvedRefsStatus{InvalidRouteKinds: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonInvalidRouteKinds, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonInvalidRouteKinds, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
 
 	status = ListenerResolvedRefsStatus{RefNotPermitted: expected}
-	require.Equal(t, "expected", status.Condition(0).Message)
-	require.Equal(t, ListenerConditionReasonRefNotPermitted, status.Condition(0).Reason)
-	require.True(t, status.HasError())
+	assert.Equal(t, "expected", status.Condition(0).Message)
+	assert.Equal(t, ListenerConditionReasonRefNotPermitted, status.Condition(0).Reason)
+	assert.True(t, status.HasError())
+
 }
 
 func TestListenerStatus(t *testing.T) {
@@ -505,23 +495,23 @@ func TestListenerStatus(t *testing.T) {
 
 	conditionType = ListenerConditionConflicted
 	reason = ListenerConditionReasonNoConflicts
-	require.Equal(t, conditionType, conditions[0].Type)
-	require.Equal(t, reason, conditions[0].Reason)
+	assert.Equal(t, conditionType, conditions[0].Type)
+	assert.Equal(t, reason, conditions[0].Reason)
 
 	conditionType = ListenerConditionDetached
 	reason = ListenerConditionReasonAttached
-	require.Equal(t, conditionType, conditions[1].Type)
-	require.Equal(t, reason, conditions[1].Reason)
+	assert.Equal(t, conditionType, conditions[1].Type)
+	assert.Equal(t, reason, conditions[1].Reason)
 
 	conditionType = ListenerConditionReady
 	reason = ListenerConditionReasonReady
-	require.Equal(t, conditionType, conditions[2].Type)
-	require.Equal(t, reason, conditions[2].Reason)
+	assert.Equal(t, conditionType, conditions[2].Type)
+	assert.Equal(t, reason, conditions[2].Reason)
 
 	conditionType = ListenerConditionResolvedRefs
 	reason = ListenerConditionReasonResolvedRefs
-	require.Equal(t, conditionType, conditions[3].Type)
-	require.Equal(t, reason, conditions[3].Reason)
+	assert.Equal(t, conditionType, conditions[3].Type)
+	assert.Equal(t, reason, conditions[3].Reason)
 
 	require.True(t, status.Valid())
 
@@ -529,43 +519,44 @@ func TestListenerStatus(t *testing.T) {
 
 	status = ListenerStatus{}
 	status.Conflicted.HostnameConflict = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.Conflicted.ProtocolConflict = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.Conflicted.RouteConflict = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.Detached.PortUnavailable = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.Detached.UnsupportedExtension = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.Detached.UnsupportedProtocol = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.Detached.UnsupportedAddress = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.ResolvedRefs.InvalidCertificateRef = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.ResolvedRefs.InvalidRouteKinds = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
 
 	status = ListenerStatus{}
 	status.ResolvedRefs.RefNotPermitted = validationError
-	require.False(t, status.Valid())
+	assert.False(t, status.Valid())
+
 }
 
 func TestListenerConflictedStatusMarshaling(t *testing.T) {
@@ -579,15 +570,12 @@ func TestListenerConflictedStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := ListenerConflictedStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.HostnameConflict.Error(), unmarshaled.HostnameConflict.Error())
-
-	require.Equal(t, status.ProtocolConflict.Error(), unmarshaled.ProtocolConflict.Error())
-
-	require.Equal(t, status.RouteConflict.Error(), unmarshaled.RouteConflict.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.HostnameConflict.Error(), unmarshaled.HostnameConflict.Error())
+	assert.Equal(t, status.ProtocolConflict.Error(), unmarshaled.ProtocolConflict.Error())
+	assert.Equal(t, status.RouteConflict.Error(), unmarshaled.RouteConflict.Error())
 }
 
 func TestListenerDetachedStatusMarshaling(t *testing.T) {
@@ -602,17 +590,13 @@ func TestListenerDetachedStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := ListenerDetachedStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.PortUnavailable.Error(), unmarshaled.PortUnavailable.Error())
-
-	require.Equal(t, status.UnsupportedExtension.Error(), unmarshaled.UnsupportedExtension.Error())
-
-	require.Equal(t, status.UnsupportedProtocol.Error(), unmarshaled.UnsupportedProtocol.Error())
-
-	require.Equal(t, status.UnsupportedAddress.Error(), unmarshaled.UnsupportedAddress.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.PortUnavailable.Error(), unmarshaled.PortUnavailable.Error())
+	assert.Equal(t, status.UnsupportedExtension.Error(), unmarshaled.UnsupportedExtension.Error())
+	assert.Equal(t, status.UnsupportedProtocol.Error(), unmarshaled.UnsupportedProtocol.Error())
+	assert.Equal(t, status.UnsupportedAddress.Error(), unmarshaled.UnsupportedAddress.Error())
 }
 
 func TestListenerReadyStatusMarshaling(t *testing.T) {
@@ -625,13 +609,11 @@ func TestListenerReadyStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := ListenerReadyStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.Invalid.Error(), unmarshaled.Invalid.Error())
-
-	require.Equal(t, status.Pending.Error(), unmarshaled.Pending.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.Invalid.Error(), unmarshaled.Invalid.Error())
+	assert.Equal(t, status.Pending.Error(), unmarshaled.Pending.Error())
 }
 
 func TestListenerResolvedRefsStatusMarshaling(t *testing.T) {
@@ -645,13 +627,10 @@ func TestListenerResolvedRefsStatusMarshaling(t *testing.T) {
 
 	data, err := json.Marshal(&status)
 	require.NoError(t, err)
+
 	unmarshaled := ListenerResolvedRefsStatus{}
-	err = json.Unmarshal(data, &unmarshaled)
-	require.NoError(t, err)
-
-	require.Equal(t, status.InvalidCertificateRef.Error(), unmarshaled.InvalidCertificateRef.Error())
-
-	require.Equal(t, status.InvalidRouteKinds.Error(), unmarshaled.InvalidRouteKinds.Error())
-
-	require.Equal(t, status.RefNotPermitted.Error(), unmarshaled.RefNotPermitted.Error())
+	require.NoError(t, json.Unmarshal(data, &unmarshaled))
+	assert.Equal(t, status.InvalidCertificateRef.Error(), unmarshaled.InvalidCertificateRef.Error())
+	assert.Equal(t, status.InvalidRouteKinds.Error(), unmarshaled.InvalidRouteKinds.Error())
+	assert.Equal(t, status.RefNotPermitted.Error(), unmarshaled.RefNotPermitted.Error())
 }


### PR DESCRIPTION
### Changes proposed in this PR:
This is the second part to be broken out of https://github.com/hashicorp/consul-api-gateway/pull/165 . This adds marshal/unmarshal funcs for the generated statuses by extending the generator.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
