### PR TITLE
Add basic controller CLI entrypoint

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -22,6 +22,7 @@ type ServerConfig struct {
 }
 
 type Server struct {
+	logger          hclog.Logger
 	server          *http.Server
 	certFile        string
 	keyFile         string
@@ -34,6 +35,7 @@ func NewServer(config ServerConfig) *Server {
 	router.Mount("/api/internal", internal.NewServer("/api/internal", config.Consul, config.Logger))
 
 	return &Server{
+		logger: config.Logger,
 		server: &http.Server{
 			Handler: router,
 			Addr:    config.Address,
@@ -49,8 +51,10 @@ func (s *Server) Run(ctx context.Context) error {
 	errs := make(chan error, 1)
 	go func() {
 		if s.certFile != "" && s.keyFile != "" {
+			s.logger.Info("Certificate file and private key file provided, serving API over HTTPS", "address", s.server.Addr)
 			errs <- s.server.ListenAndServeTLS(s.certFile, s.keyFile)
 		} else {
+			s.logger.Info("TLS certificate configuration not provided, serving API over HTTP", "address", s.server.Addr)
 			errs <- s.server.ListenAndServe()
 		}
 	}()

--- a/internal/commands/controller/command.go
+++ b/internal/commands/controller/command.go
@@ -1,0 +1,192 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/hashicorp/consul-api-gateway/internal/api"
+	"github.com/hashicorp/consul-api-gateway/internal/common"
+	"github.com/hashicorp/consul-api-gateway/internal/consul"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/mitchellh/cli"
+	"golang.org/x/sync/errgroup"
+)
+
+func RegisterCommands(ctx context.Context, commands map[string]cli.CommandFactory, ui cli.Ui, logOutput io.Writer) {
+	commands["controller"] = func() (cli.Command, error) {
+		return NewCommand(ctx, ui, logOutput), nil
+	}
+
+	commands["controller health"] = func() (cli.Command, error) {
+		return NewHealthCommand(ctx, ui, logOutput), nil
+	}
+}
+
+type Command struct {
+	*common.CommonCLI
+	help string
+
+	flagControllerAddress  string // Server address for requests
+	flagControllerPort     uint   // Server port for requests
+	flagControllerCertFile string // Server TLS certificate file
+	flagControllerKeyFile  string // Server TLS key file
+
+	flagConsulAddress           string // Consul server address
+	flagConsulToken             string // Consul token
+	flagConsulScheme            string // Consul server scheme
+	flagConsulTLSCAFile         string // Consul TLS CA file for TLS verification
+	flagConsulTLSClientCertFile string // Consul client mTLS certificate
+	flagConsulTLSClientKeyFile  string // Consul client mTLS key
+	flagConsulTLSSkipVerify     bool   // Skip Consul TLS verification
+
+	flagConsulRegistrationName      string           // Name of service to register in Consul
+	flagConsulRegistrationNamespace string           // Namespace of service to register in Consul
+	flagConsulRegistrationTags      common.ArrayFlag // Tags for service to register in Consul
+
+	flagConsulStoragePath      string // Storage path for persistent data
+	flagConsulStorageNamespace string // Storage namespace for persistent data
+}
+
+func NewCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *Command {
+	cmd := &Command{
+		CommonCLI: common.NewCommonCLI(ctx, help, synopsis, ui, logOutput, "controller"),
+	}
+	cmd.init()
+	cmd.help = common.FlagUsage(help, cmd.Flags)
+
+	return cmd
+}
+
+func (c *Command) init() {
+	c.Flags.StringVar(&c.flagControllerAddress, "gateway-controller-address", "localhost", "Server address to use for client.")
+	c.Flags.UintVar(&c.flagControllerPort, "gateway-controller-port", 5605, "Server port to use for client.")
+	c.Flags.StringVar(&c.flagControllerCertFile, "gateway-controller-cert-file", "", "Path to TLS certificate file for HTTPS connections.")
+	c.Flags.StringVar(&c.flagControllerKeyFile, "gateway-controller-key-file", "", "Path to TLS key file for HTTPS connections.")
+
+	c.Flags.StringVar(&c.flagConsulAddress, "consul-address", "", "Consul Address.")
+	c.Flags.StringVar(&c.flagConsulToken, "consul-token", "", "Token to use for Consul client.")
+	c.Flags.StringVar(&c.flagConsulScheme, "consul-scheme", "", "Scheme to use for Consul client.")
+	c.Flags.StringVar(&c.flagConsulTLSCAFile, "consul-tls-ca-file", "", "Path to CA for Consul server.")
+	c.Flags.StringVar(&c.flagConsulTLSClientCertFile, "consul-tls-client-cert-file", "", "Path to client certificate file for Consul.")
+	c.Flags.StringVar(&c.flagConsulTLSClientKeyFile, "consul-tls-client-key-file", "", "Path to client key file for Consul.")
+	c.Flags.BoolVar(&c.flagConsulTLSSkipVerify, "consul-tls-skip-verify", false, "Skip verification for Consul connection.")
+
+	c.Flags.StringVar(&c.flagConsulRegistrationNamespace, "consul-registration-namespace", "", "Namespace to use for Consul service registration.")
+	c.Flags.StringVar(&c.flagConsulRegistrationName, "consul-registration-name", "api-gateway-controller", "Name to use for Consul service registration.")
+	c.Flags.Var(&c.flagConsulRegistrationTags, "consul-registration-tags", "Tags to add for Consul service registration.")
+
+	c.Flags.StringVar(&c.flagConsulStoragePath, "consul-storage-path", "", "Storage path for Gateway data persisted in Consul.")
+	c.Flags.StringVar(&c.flagConsulStorageNamespace, "consul-storage-namespace", "", "Storage namespace for Gateway data persisted in Consul.")
+}
+
+func (c *Command) Run(args []string) (ret int) {
+	if err := c.Parse(args); err != nil {
+		return c.Error("parsing command line flags", err)
+	}
+
+	logger := c.Logger("controller")
+	address := fmt.Sprintf("%s:%d", c.flagControllerAddress, c.flagControllerPort)
+
+	client, err := consulapi.NewClient(c.ConsulConfig())
+	if err != nil {
+		return c.Error("initializing Consul client", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(c.Context(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	// add store stuff here
+
+	server := api.NewServer(api.ServerConfig{
+		Logger:          logger,
+		Consul:          client,
+		Address:         address,
+		CertFile:        c.flagControllerCertFile,
+		KeyFile:         c.flagControllerKeyFile,
+		ShutdownTimeout: 10 * time.Second,
+	})
+	group.Go(func() error {
+		return server.Run(groupCtx)
+	})
+
+	registry := consul.NewServiceRegistry(
+		logger.Named("service-registry"),
+		client,
+		c.flagConsulRegistrationName,
+		c.flagConsulRegistrationNamespace,
+		c.flagControllerAddress,
+	).WithTags(c.flagConsulRegistrationTags)
+
+	if err := registry.Register(groupCtx); err != nil {
+		return c.Error("error registering controller", err)
+	}
+	defer func() {
+		logger.Trace("deregistering controller")
+		// using context.Background here since the global context has
+		// already been canceled at this point and we're just in a cleanup
+		// function
+		if err := registry.Deregister(context.Background()); err != nil {
+			logger.Error("error deregistering service", "error", err)
+			ret = 1
+		}
+	}()
+
+	if err := group.Wait(); err != nil {
+		return c.Error("unexpected error", err)
+	}
+
+	return c.Success("Stopping Gateway API controller")
+}
+
+func (c *Command) ConsulConfig() *consulapi.Config {
+	consulCfg := consulapi.DefaultConfig()
+	if c.flagConsulAddress != "" {
+		consulCfg.Address = c.flagConsulAddress
+	}
+	if c.flagConsulToken != "" {
+		consulCfg.Token = c.flagConsulToken
+	}
+	if c.flagConsulScheme != "" {
+		consulCfg.Scheme = c.flagConsulScheme
+	}
+	if c.flagConsulTLSCAFile != "" {
+		consulCfg.TLSConfig.CAFile = c.flagConsulTLSCAFile
+	}
+	if c.flagConsulTLSClientCertFile != "" {
+		consulCfg.TLSConfig.CertFile = c.flagConsulTLSClientCertFile
+	}
+	if c.flagConsulTLSClientKeyFile != "" {
+		consulCfg.TLSConfig.KeyFile = c.flagConsulTLSClientKeyFile
+	}
+	if c.flagConsulTLSSkipVerify {
+		consulCfg.TLSConfig.InsecureSkipVerify = true
+	}
+
+	return consulCfg
+}
+
+func (c *Command) Help() string {
+	return help
+}
+
+const synopsis = "Manage Consul API Gateway Controller"
+const help = `
+Usage: consul-api-gateway controller <subcommand> [options] [args]
+  This command has subcommands for interacting with Consul API Gateway
+  Controller. Here are some simple examples, and more detailed examples
+	are available in the subcommands or the documentation.
+
+  Checking Gateway controller health:
+
+    $ consul-api-gateway controller health
+
+  For more examples, ask for subcommand help or view the documentation at
+  https://www.consul.io/docs/api-gateway.
+`

--- a/internal/commands/controller/health.go
+++ b/internal/commands/controller/health.go
@@ -1,0 +1,50 @@
+package controller
+
+import (
+	"context"
+	"io"
+
+	"github.com/hashicorp/consul-api-gateway/internal/common"
+	"github.com/mitchellh/cli"
+)
+
+type HealthCommand struct {
+	*common.ClientCLI
+}
+
+func NewHealthCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *HealthCommand {
+	return &HealthCommand{
+		ClientCLI: common.NewClientCLI(ctx, healthHelp, healthSynopsis, ui, logOutput, "health"),
+	}
+}
+
+func (c *HealthCommand) Run(args []string) int {
+	if err := c.Parse(args); err != nil {
+		return c.Error("parsing command line flags", err)
+	}
+
+	// client, err := c.CreateClient()
+	// if err != nil {
+	// 	return c.Error("creating the client", err)
+	// }
+	//
+	// health, err := client.Internal().GetControllerHealth(c.Context(), c.Namespace(), name)
+	// if err != nil {
+	// 	return c.Error("sending the request", err)
+	// }
+	//
+	// return c.Success(fmt.Sprintf("Successfully retrieved controller health: %v", health))
+
+	return c.Success("health")
+}
+
+const (
+	healthSynopsis = "Gets the health of all registered Consul Gateway API controllers"
+	healthHelp     = `
+Usage: consul-api-gateway controller health [options]
+
+  Gets Consul Gateway API controller health.
+
+  Additional flags and more advanced use cases are detailed below.
+`
+)

--- a/internal/commands/controller/health.go
+++ b/internal/commands/controller/health.go
@@ -39,7 +39,7 @@ func (c *HealthCommand) Run(args []string) int {
 }
 
 const (
-	healthSynopsis = "Gets the health of all registered Consul Gateway API controllers"
+	healthSynopsis = "Gets the health of all registered Consul API Gateway controllers"
 	healthHelp     = `
 Usage: consul-api-gateway controller health [options]
 

--- a/internal/commands/controller/health.go
+++ b/internal/commands/controller/health.go
@@ -43,7 +43,7 @@ const (
 	healthHelp     = `
 Usage: consul-api-gateway controller health [options]
 
-  Gets Consul Gateway API controller health.
+  Gets Consul API Gateway controller health.
 
   Additional flags and more advanced use cases are detailed below.
 `

--- a/internal/commands/exec/exec.go
+++ b/internal/commands/exec/exec.go
@@ -108,7 +108,7 @@ func RunExec(config ExecConfig) (ret int) {
 	}
 
 	config.Logger.Trace("registering service")
-	if err := registry.Register(ctx); err != nil {
+	if err := registry.RegisterGateway(ctx); err != nil {
 		config.Logger.Error("error registering service", "error", err)
 		return 1
 	}

--- a/internal/common/flags.go
+++ b/internal/common/flags.go
@@ -1,0 +1,14 @@
+package common
+
+import "strings"
+
+type ArrayFlag []string
+
+func (i *ArrayFlag) String() string {
+	return strings.Join(*i, ", ")
+}
+
+func (i *ArrayFlag) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}

--- a/internal/consul/registration.go
+++ b/internal/consul/registration.go
@@ -93,7 +93,7 @@ func (s *ServiceRegistry) RegisterGateway(ctx context.Context) error {
 // Register registers a service with Consul.
 func (s *ServiceRegistry) Register(ctx context.Context) error {
 	return s.register(ctx, &api.AgentServiceRegistration{
-		Kind:      api.ServiceKind(api.ServiceKindTypical),
+		Kind:      api.ServiceKindTypical,
 		ID:        s.id,
 		Name:      s.name,
 		Namespace: s.namespace,
@@ -109,7 +109,8 @@ func (s *ServiceRegistry) Register(ctx context.Context) error {
 }
 
 func (s *ServiceRegistry) updateTTL(ctx context.Context) error {
-	return s.consul.Agent().UpdateTTL(s.id, "service healthy", "pass")
+	opts := &api.QueryOptions{}
+	return s.consul.Agent().UpdateTTLOpts(s.id, "service healthy", "pass", opts.WithContext(ctx))
 }
 
 func (s *ServiceRegistry) register(ctx context.Context, registration *api.AgentServiceRegistration, ttl bool) error {

--- a/internal/consul/registration.go
+++ b/internal/consul/registration.go
@@ -17,6 +17,7 @@ import (
 const (
 	serviceCheckName          = "consul-api-gateway Gateway Listener"
 	serviceCheckInterval      = "10s"
+	serviceCheckTTL           = "20s"
 	serviceDeregistrationTime = "1m"
 )
 
@@ -31,11 +32,13 @@ type ServiceRegistry struct {
 	name      string
 	namespace string
 	host      string
+	tags      []string
 
 	cancel                 context.CancelFunc
 	tries                  uint64
 	backoffInterval        time.Duration
 	reregistrationInterval time.Duration
+	updateTTLInterval      time.Duration
 }
 
 // NewServiceRegistry creates a new service registry instance
@@ -50,7 +53,14 @@ func NewServiceRegistry(logger hclog.Logger, consul *api.Client, service, namesp
 		tries:                  defaultMaxAttempts,
 		backoffInterval:        defaultBackoffInterval,
 		reregistrationInterval: 30 * time.Second,
+		updateTTLInterval:      10 * time.Second,
 	}
+}
+
+// WithTags adds tags to associate with the service being registered.
+func (s *ServiceRegistry) WithTags(tags []string) *ServiceRegistry {
+	s.tags = tags
+	return s
 }
 
 // WithTries tells the service registry to retry on any remote operations.
@@ -59,13 +69,55 @@ func (s *ServiceRegistry) WithTries(tries uint64) *ServiceRegistry {
 	return s
 }
 
+// Register registers a Gateway service with Consul.
+func (s *ServiceRegistry) RegisterGateway(ctx context.Context) error {
+	return s.register(ctx, &api.AgentServiceRegistration{
+		Kind:      api.ServiceKind(api.IngressGateway),
+		ID:        s.id,
+		Name:      s.name,
+		Namespace: s.namespace,
+		Address:   s.host,
+		Tags:      s.tags,
+		Meta: map[string]string{
+			"external-source": "consul-api-gateway",
+		},
+		Checks: api.AgentServiceChecks{{
+			Name:                           fmt.Sprintf("%s - Ready", serviceCheckName),
+			TCP:                            fmt.Sprintf("%s:%d", s.host, 20000),
+			Interval:                       serviceCheckInterval,
+			DeregisterCriticalServiceAfter: serviceDeregistrationTime,
+		}},
+	}, false)
+}
+
 // Register registers a service with Consul.
 func (s *ServiceRegistry) Register(ctx context.Context) error {
+	return s.register(ctx, &api.AgentServiceRegistration{
+		Kind:      api.ServiceKind(api.ServiceKindTypical),
+		ID:        s.id,
+		Name:      s.name,
+		Namespace: s.namespace,
+		Address:   s.host,
+		Tags:      s.tags,
+		Checks: api.AgentServiceChecks{{
+			CheckID:                        s.id,
+			Name:                           fmt.Sprintf("%s - Health", s.name),
+			TTL:                            serviceCheckTTL,
+			DeregisterCriticalServiceAfter: serviceDeregistrationTime,
+		}},
+	}, true)
+}
+
+func (s *ServiceRegistry) updateTTL(ctx context.Context) error {
+	return s.consul.Agent().UpdateTTL(s.id, "service healthy", "pass")
+}
+
+func (s *ServiceRegistry) register(ctx context.Context, registration *api.AgentServiceRegistration, ttl bool) error {
 	if s.cancel != nil {
 		return nil
 	}
 
-	if err := s.retryRegistration(ctx); err != nil {
+	if err := s.retryRegistration(ctx, registration); err != nil {
 		return err
 	}
 	childCtx, cancel := context.WithCancel(ctx)
@@ -75,17 +127,30 @@ func (s *ServiceRegistry) Register(ctx context.Context) error {
 		for {
 			select {
 			case <-time.After(s.reregistrationInterval):
-				s.ensureRegistration(childCtx)
+				s.ensureRegistration(childCtx, registration)
 			case <-childCtx.Done():
 				return
 			}
 		}
 	}()
 
+	if ttl {
+		go func() {
+			for {
+				select {
+				case <-time.After(s.updateTTLInterval):
+					s.updateTTL(childCtx)
+				case <-childCtx.Done():
+					return
+				}
+			}
+		}()
+	}
+
 	return nil
 }
 
-func (s *ServiceRegistry) ensureRegistration(ctx context.Context) {
+func (s *ServiceRegistry) ensureRegistration(ctx context.Context, registration *api.AgentServiceRegistration) {
 	_, _, err := s.consul.Agent().Service(s.id, &api.QueryOptions{
 		Namespace: s.namespace,
 	})
@@ -96,7 +161,7 @@ func (s *ServiceRegistry) ensureRegistration(ctx context.Context) {
 	var statusError api.StatusError
 	if errors.As(err, &statusError) {
 		if statusError.Code == http.StatusNotFound {
-			if err := s.retryRegistration(ctx); err != nil {
+			if err := s.retryRegistration(ctx, registration); err != nil {
 				s.logger.Error("error registering service", "error", err)
 				return
 			}
@@ -109,9 +174,9 @@ func (s *ServiceRegistry) ensureRegistration(ctx context.Context) {
 	s.logger.Error("error fetching service", "error", err)
 }
 
-func (s *ServiceRegistry) retryRegistration(ctx context.Context) error {
+func (s *ServiceRegistry) retryRegistration(ctx context.Context, registration *api.AgentServiceRegistration) error {
 	return backoff.Retry(func() error {
-		err := s.register(ctx)
+		err := s.registerService(ctx, registration)
 		if err != nil {
 			s.logger.Error("error registering service", "error", err)
 		}
@@ -119,24 +184,7 @@ func (s *ServiceRegistry) retryRegistration(ctx context.Context) error {
 	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewConstantBackOff(s.backoffInterval), s.tries), ctx))
 }
 
-func (s *ServiceRegistry) register(ctx context.Context) error {
-	registration := &api.AgentServiceRegistration{
-		Kind:      api.ServiceKind(api.IngressGateway),
-		ID:        s.id,
-		Name:      s.name,
-		Namespace: s.namespace,
-		Address:   s.host,
-		Meta: map[string]string{
-			"external-source": "consul-api-gateway",
-		},
-		Checks: api.AgentServiceChecks{{
-			Name:                           fmt.Sprintf("%s - Ready", serviceCheckName),
-			TCP:                            fmt.Sprintf("%s:%d", s.host, 20000),
-			Interval:                       serviceCheckInterval,
-			DeregisterCriticalServiceAfter: serviceDeregistrationTime,
-		}},
-	}
-
+func (s *ServiceRegistry) registerService(ctx context.Context, registration *api.AgentServiceRegistration) error {
 	return s.consul.Agent().ServiceRegisterOpts(registration, (&api.ServiceRegisterOpts{}).WithContext(ctx))
 }
 

--- a/internal/consul/registration_test.go
+++ b/internal/consul/registration_test.go
@@ -57,7 +57,7 @@ func TestRegister(t *testing.T) {
 			registry.backoffInterval = 0
 			registry.id = id
 
-			err := registry.Register(context.Background())
+			err := registry.RegisterGateway(context.Background())
 			if test.fail {
 				require.Error(t, err)
 				return

--- a/internal/envoy/sds.go
+++ b/internal/envoy/sds.go
@@ -70,6 +70,11 @@ func NewSDSServer(logger hclog.Logger, fetcher CertificateFetcher, client Secret
 	}
 }
 
+func (s *SDSServer) WithAddress(address string, port uint) *SDSServer {
+	s.bindAddress = fmt.Sprintf("%s:%d", address, port)
+	return s
+}
+
 // Run starts the SDS server
 func (s *SDSServer) Run(ctx context.Context) error {
 	childCtx, cancel := context.WithCancel(ctx)

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mitchellh/cli"
 
+	"github.com/hashicorp/consul-api-gateway/internal/commands/controller"
 	cmdExec "github.com/hashicorp/consul-api-gateway/internal/commands/exec"
 	"github.com/hashicorp/consul-api-gateway/internal/commands/gateways"
 	"github.com/hashicorp/consul-api-gateway/internal/commands/httproutes"
@@ -53,6 +54,7 @@ func initializeCommands(ui cli.Ui, logOutput io.Writer) map[string]cli.CommandFa
 	gateways.RegisterCommands(context.Background(), commands, ui, logOutput)
 	httproutes.RegisterCommands(context.Background(), commands, ui, logOutput)
 	tcproutes.RegisterCommands(context.Background(), commands, ui, logOutput)
+	controller.RegisterCommands(context.Background(), commands, ui, logOutput)
 
 	return commands
 }


### PR DESCRIPTION
### Changes proposed in this PR:

This adds an entrypoint for the API server. As we flesh out the API implementation it'll need some tweaking, but for now it spins up a server based off of the configuration flags passed to it and a goroutine that registers the controller as a Consul service along with periodically updating the TTL health check it registers.

It also scaffolds out an entrypoint for returning controller "health" that we'll want to build an internal endpoint for that grabs all of the instance health from the controllers that have been registered in Consul.

### How I've tested this PR:

Manually, here are some outputs/screenshots:

In one terminal:

```
➜  consul-api-gateway git:(vm-controller-cli-entrypoint) ./consul-api-gateway controller
```

In another:

```
➜  consul-api-gateway git:(vm-controller-cli-entrypoint) ./consul-api-gateway gateways list
There was an error sending the request:
	server error - code: 501, message: Not implemented
➜  consul-api-gateway git:(vm-controller-cli-entrypoint) ./consul-api-gateway gateways delete foo
Successfully deleted Gateway: foo
```

In the first terminal again after a Ctrl+C:

```
➜  consul-api-gateway git:(vm-controller-cli-entrypoint) ./consul-api-gateway controller
2022-09-08T21:11:49.824-0400 [INFO]  v1/gateways.go:49: controller: deleting gateway: namespace=default name=foo
^CStopping Gateway API controller
```

Screenshot of the  registered Consul service:

<img width="882" alt="Screen Shot 2022-09-08 at 9 12 55 PM" src="https://user-images.githubusercontent.com/3577250/189251712-d2e8d92f-09d8-4adc-93a1-a7d4deeca6e3.png">

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
