### PR TITLE
Move gateway + route validation up into reconcile manager

### DIFF
--- a/internal/k8s/reconciler/binder_test.go
+++ b/internal/k8s/reconciler/binder_test.go
@@ -388,7 +388,7 @@ func TestBinder(t *testing.T) {
 			}
 
 			binder := newBinder(client, test.gateway, gatewayState)
-			listeners := binder.Bind(context.Background(), factory.NewRoute(test.route))
+			listeners := binder.Bind(context.Background(), factory.NewRoute(NewRouteConfig{Route: test.route}))
 			if test.didBind {
 				require.NotEmpty(t, listeners)
 			} else {
@@ -416,9 +416,11 @@ func TestRouteAllowedForListenerNamespaces(t *testing.T) {
 		Namespaces: &gwv1beta1.RouteNamespaces{
 			From: &same,
 		},
-	}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace: "expected",
+	}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "expected",
+			},
 		},
 	}), client)
 	require.NoError(t, err)
@@ -428,9 +430,11 @@ func TestRouteAllowedForListenerNamespaces(t *testing.T) {
 		Namespaces: &gwv1beta1.RouteNamespaces{
 			From: &same,
 		},
-	}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace: "other",
+	}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "other",
+			},
 		},
 	}), client)
 	require.NoError(t, err)
@@ -442,9 +446,11 @@ func TestRouteAllowedForListenerNamespaces(t *testing.T) {
 		Namespaces: &gwv1beta1.RouteNamespaces{
 			From: &all,
 		},
-	}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace: "other",
+	}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "other",
+			},
 		},
 	}), client)
 	require.NoError(t, err)
@@ -471,9 +477,11 @@ func TestRouteAllowedForListenerNamespaces(t *testing.T) {
 				},
 			},
 		},
-	}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace: "expected",
+	}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "expected",
+			},
 		},
 	}), client)
 	require.NoError(t, err)
@@ -489,9 +497,11 @@ func TestRouteAllowedForListenerNamespaces(t *testing.T) {
 				},
 			},
 		},
-	}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace: "expected",
+	}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "expected",
+			},
 		},
 	}), client)
 	require.NoError(t, err)
@@ -507,9 +517,11 @@ func TestRouteAllowedForListenerNamespaces(t *testing.T) {
 				}},
 			},
 		},
-	}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace: "expected",
+	}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "expected",
+			},
 		},
 	}), client)
 	require.Error(t, err)
@@ -520,9 +532,11 @@ func TestRouteAllowedForListenerNamespaces(t *testing.T) {
 		Namespaces: &gwv1beta1.RouteNamespaces{
 			From: &unknown,
 		},
-	}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		ObjectMeta: meta.ObjectMeta{
-			Namespace: "expected",
+	}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: "expected",
+			},
 		},
 	}), client)
 	require.NoError(t, err)
@@ -545,14 +559,18 @@ func TestRouteKindIsAllowedForListener(t *testing.T) {
 	require.True(t, routeKindIsAllowedForListener([]gwv1beta1.RouteGroupKind{{
 		Group: (*gwv1beta1.Group)(&gwv1alpha2.GroupVersion.Group),
 		Kind:  "HTTPRoute",
-	}}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		TypeMeta: routeMeta,
+	}}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			TypeMeta: routeMeta,
+		},
 	})))
 	require.False(t, routeKindIsAllowedForListener([]gwv1beta1.RouteGroupKind{{
 		Group: (*gwv1beta1.Group)(&gwv1alpha2.GroupVersion.Group),
 		Kind:  "TCPRoute",
-	}}, factory.NewRoute(&gwv1alpha2.HTTPRoute{
-		TypeMeta: routeMeta,
+	}}, factory.NewRoute(NewRouteConfig{
+		Route: &gwv1alpha2.HTTPRoute{
+			TypeMeta: routeMeta,
+		},
 	})))
 }
 

--- a/internal/k8s/reconciler/factory.go
+++ b/internal/k8s/reconciler/factory.go
@@ -68,11 +68,22 @@ func (f *Factory) NewGateway(config NewGatewayConfig) *K8sGateway {
 	return gateway
 }
 
-func (f *Factory) NewRoute(route Route) *K8sRoute {
-	return newK8sRoute(route, K8sRouteConfig{
-		Logger:         f.logger.Named("route").With("name", route.GetName()),
+type NewRouteConfig struct {
+	Route Route
+	State *state.RouteState
+}
+
+func (f *Factory) NewRoute(config NewRouteConfig) *K8sRoute {
+	routeState := config.State
+	if routeState == nil {
+		routeState = state.NewRouteState()
+	}
+
+	return newK8sRoute(config.Route, K8sRouteConfig{
+		Logger:         f.logger.Named("route").With("name", config.Route.GetName()),
 		Client:         f.client,
 		ControllerName: f.controllerName,
 		Resolver:       f.resolver,
+		State:          routeState,
 	})
 }

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
 	rstatus "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/status"
-	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/validator"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/utils"
 	"github.com/hashicorp/consul-api-gateway/internal/store"
 	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
@@ -26,11 +25,10 @@ type K8sGateway struct {
 	*gwv1beta1.Gateway
 	GatewayState *state.GatewayState
 
-	logger    hclog.Logger
-	client    gatewayclient.Client
-	config    apigwv1alpha1.GatewayClassConfig
-	validator *validator.GatewayValidator
-	deployer  *GatewayDeployer
+	logger   hclog.Logger
+	client   gatewayclient.Client
+	config   apigwv1alpha1.GatewayClassConfig
+	deployer *GatewayDeployer
 }
 
 var _ store.StatusTrackingGateway = &K8sGateway{}
@@ -52,15 +50,10 @@ func newK8sGateway(gateway *gwv1beta1.Gateway, config K8sGatewayConfig) *K8sGate
 		Gateway:      gateway,
 		GatewayState: config.State,
 		config:       config.Config,
-		validator:    validator.NewGatewayValidator(config.Client),
 		deployer:     config.Deployer,
 		logger:       config.Logger.Named("gateway").With("name", gateway.Name, "namespace", gateway.Namespace),
 		client:       config.Client,
 	}
-}
-
-func (g *K8sGateway) Validate(ctx context.Context) error {
-	return g.validator.Validate(ctx, g.GatewayState, g.Gateway, g.deployer.Service(g.config, g.Gateway))
 }
 
 func (g *K8sGateway) ID() core.GatewayID {

--- a/internal/k8s/reconciler/mocks/manager.go
+++ b/internal/k8s/reconciler/mocks/manager.go
@@ -9,8 +9,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	reconciler "github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler"
 	types "k8s.io/apimachinery/pkg/types"
+	v1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	v1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
@@ -122,7 +122,7 @@ func (mr *MockReconcileManagerMockRecorder) UpsertGatewayClass(ctx, gc interface
 }
 
 // UpsertHTTPRoute mocks base method.
-func (m *MockReconcileManager) UpsertHTTPRoute(ctx context.Context, r reconciler.Route) error {
+func (m *MockReconcileManager) UpsertHTTPRoute(ctx context.Context, r *v1alpha2.HTTPRoute) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertHTTPRoute", ctx, r)
 	ret0, _ := ret[0].(error)
@@ -136,7 +136,7 @@ func (mr *MockReconcileManagerMockRecorder) UpsertHTTPRoute(ctx, r interface{}) 
 }
 
 // UpsertTCPRoute mocks base method.
-func (m *MockReconcileManager) UpsertTCPRoute(ctx context.Context, r reconciler.Route) error {
+func (m *MockReconcileManager) UpsertTCPRoute(ctx context.Context, r *v1alpha2.TCPRoute) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertTCPRoute", ctx, r)
 	ret0, _ := ret[0].(error)

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/converter"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
-	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/validator"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/service"
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/utils"
 	"github.com/hashicorp/consul-api-gateway/internal/store"
@@ -38,7 +37,6 @@ type K8sRoute struct {
 	controllerName string
 	logger         hclog.Logger
 	client         gatewayclient.Client
-	validator      *validator.RouteValidator
 }
 
 type serializedRoute struct {
@@ -63,7 +61,6 @@ func newK8sRoute(route Route, config K8sRouteConfig) *K8sRoute {
 		controllerName: config.ControllerName,
 		logger:         config.Logger.Named("route").With("name", route.GetName()),
 		client:         config.Client,
-		validator:      validator.NewRouteValidator(config.Resolver, config.Client),
 	}
 }
 
@@ -184,10 +181,6 @@ func (r *K8sRoute) parents() []gwv1alpha2.ParentReference {
 		return route.Spec.ParentRefs
 	}
 	return nil
-}
-
-func (r *K8sRoute) validate(ctx context.Context) error {
-	return r.validator.Validate(ctx, r.RouteState, r.Route)
 }
 
 func (r *K8sRoute) OnGatewayRemoved(gateway store.Gateway) {

--- a/internal/k8s/reconciler/route.go
+++ b/internal/k8s/reconciler/route.go
@@ -52,12 +52,13 @@ type K8sRouteConfig struct {
 	Logger         hclog.Logger
 	Client         gatewayclient.Client
 	Resolver       service.BackendResolver
+	State          *state.RouteState
 }
 
 func newK8sRoute(route Route, config K8sRouteConfig) *K8sRoute {
 	return &K8sRoute{
 		Route:          route,
-		RouteState:     state.NewRouteState(),
+		RouteState:     config.State,
 		controllerName: config.ControllerName,
 		logger:         config.Logger.Named("route").With("name", route.GetName()),
 		client:         config.Client,

--- a/internal/k8s/reconciler/route_test.go
+++ b/internal/k8s/reconciler/route_test.go
@@ -16,6 +16,7 @@ import (
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	clientMocks "github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
 )
 
 func TestRouteID(t *testing.T) {
@@ -175,9 +176,9 @@ func TestRouteResolve(t *testing.T) {
 	}
 	listener := gwv1beta1.Listener{}
 
-	require.Nil(t, factory.NewRoute(&core.Pod{}).resolve("", gateway, listener))
+	require.Nil(t, factory.NewRoute(NewRouteConfig{Route: &core.Pod{}}).resolve("", gateway, listener))
 
-	require.NotNil(t, factory.NewRoute(&gwv1alpha2.HTTPRoute{}).resolve("", gateway, listener))
+	require.NotNil(t, factory.NewRoute(NewRouteConfig{Route: &gwv1alpha2.HTTPRoute{}}).resolve("", gateway, listener))
 }
 
 func TestRouteSyncStatus(t *testing.T) {
@@ -226,6 +227,7 @@ func TestRouteSyncStatus(t *testing.T) {
 		ControllerName: "expected",
 		Logger:         logger,
 		Client:         client,
+		State:          state.NewRouteState(),
 	})
 	route.RouteState.Bound(gwv1alpha2.ParentReference{Name: "expected"})
 

--- a/internal/k8s/reconciler/validator/gateway.go
+++ b/internal/k8s/reconciler/validator/gateway.go
@@ -34,15 +34,17 @@ func NewGatewayValidator(client gatewayclient.Client) *GatewayValidator {
 	}
 }
 
-func (g *GatewayValidator) Validate(ctx context.Context, state *state.GatewayState, gateway *gwv1beta1.Gateway, service *core.Service) error {
+func (g *GatewayValidator) Validate(ctx context.Context, gateway *gwv1beta1.Gateway, service *core.Service) (*state.GatewayState, error) {
+	state := state.InitialGatewayState(gateway)
+
 	g.validateListenerConflicts(state, gateway)
 
 	if err := g.validatePods(ctx, state, gateway); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := g.validateGatewayIP(ctx, state, gateway, service); err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(gateway.Spec.Addresses) != 0 {
@@ -50,10 +52,10 @@ func (g *GatewayValidator) Validate(ctx context.Context, state *state.GatewaySta
 	}
 
 	if err := g.validateListeners(ctx, state, gateway); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return state, nil
 }
 
 func (g *GatewayValidator) validateListeners(ctx context.Context, state *state.GatewayState, gateway *gwv1beta1.Gateway) error {

--- a/internal/k8s/reconciler/validator/route_test.go
+++ b/internal/k8s/reconciler/validator/route_test.go
@@ -26,9 +26,8 @@ func TestRouteValidate(t *testing.T) {
 	resolver := mocks.NewMockBackendResolver(ctrl)
 	client := clientMocks.NewMockClient(ctrl)
 
-	routeState := state.NewRouteState()
 	validator := NewRouteValidator(resolver, client)
-	err := validator.Validate(context.Background(), routeState, &gwv1alpha2.HTTPRoute{})
+	routeState, err := validator.Validate(context.Background(), &gwv1alpha2.HTTPRoute{})
 	require.NoError(t, err)
 	require.True(t, routeState.ResolutionErrors.Empty())
 
@@ -41,8 +40,7 @@ func TestRouteValidate(t *testing.T) {
 	}
 	resolver.EXPECT().Resolve(gomock.Any(), gomock.Any(), reference).Return(resolved, nil)
 
-	routeState = state.NewRouteState()
-	err = validator.Validate(context.Background(), routeState, &gwv1alpha2.HTTPRoute{
+	routeState, err = validator.Validate(context.Background(), &gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			Rules: []gwv1alpha2.HTTPRouteRule{{
 				BackendRefs: []gwv1alpha2.HTTPBackendRef{{
@@ -56,10 +54,9 @@ func TestRouteValidate(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, routeState.ResolutionErrors.Empty())
 
-	routeState = state.NewRouteState()
 	expected := errors.New("expected")
 	resolver.EXPECT().Resolve(gomock.Any(), gomock.Any(), reference).Return(nil, expected)
-	err = validator.Validate(context.Background(), routeState, &gwv1alpha2.HTTPRoute{
+	routeState, err = validator.Validate(context.Background(), &gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			Rules: []gwv1alpha2.HTTPRouteRule{{
 				BackendRefs: []gwv1alpha2.HTTPBackendRef{{
@@ -75,7 +72,7 @@ func TestRouteValidate(t *testing.T) {
 	resolver.EXPECT().Resolve(gomock.Any(), gomock.Any(), reference).Return(nil, service.NewK8sResolutionError("error"))
 
 	routeState = state.NewRouteState()
-	err = validator.Validate(context.Background(), routeState, &gwv1alpha2.HTTPRoute{
+	routeState, err = validator.Validate(context.Background(), &gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			Rules: []gwv1alpha2.HTTPRouteRule{{
 				BackendRefs: []gwv1alpha2.HTTPBackendRef{{
@@ -119,9 +116,7 @@ func TestRouteValidateDontAllowCrossNamespace(t *testing.T) {
 		},
 	}
 
-	routeState := state.NewRouteState()
-
-	err := validator.Validate(context.Background(), routeState, &gwv1alpha2.HTTPRoute{
+	routeState, err := validator.Validate(context.Background(), &gwv1alpha2.HTTPRoute{
 		Spec: gwv1alpha2.HTTPRouteSpec{
 			Rules: []gwv1alpha2.HTTPRouteRule{{
 				BackendRefs: []gwv1alpha2.HTTPBackendRef{{
@@ -176,9 +171,7 @@ func TestRouteValidateAllowCrossNamespaceWithReferenceGrant(t *testing.T) {
 		Resolve(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&service.ResolvedReference{Type: service.ConsulServiceReference, Reference: &service.BackendReference{}}, nil)
 
-	routeState := state.NewRouteState()
-
-	err := validator.Validate(context.Background(), routeState, &gwv1alpha2.HTTPRoute{
+	routeState, err := validator.Validate(context.Background(), &gwv1alpha2.HTTPRoute{
 		ObjectMeta: meta.ObjectMeta{Namespace: "namespace1"},
 		TypeMeta:   meta.TypeMeta{APIVersion: "gateway.networking.k8s.io/v1alpha2", Kind: "HTTPRoute"},
 		Spec: gwv1alpha2.HTTPRouteSpec{


### PR DESCRIPTION
### Changes proposed in this PR:
This is the fourth part to be broken out of https://github.com/hashicorp/consul-api-gateway/pull/165 . This removes the validation entrypoint from the route + gateway themselves to further simplify them and instead calls the validator directly from the `ReconcileManager` before doing the upsert into the store.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
