### PR TITLE
Refactor binder interface to be reusable for multiple gateways

### DIFF
--- a/internal/k8s/reconciler/binder.go
+++ b/internal/k8s/reconciler/binder.go
@@ -25,29 +25,23 @@ const (
 // binder wraps a Gateway and the corresponding GatewayState and encapsulates
 // the logic for binding new routes to that Gateway.
 type binder struct {
-	Client       gatewayclient.Client
-	Gateway      *gwv1beta1.Gateway
-	GatewayState *state.GatewayState
+	Client gatewayclient.Client
 }
 
-func newBinder(client gatewayclient.Client, gateway *gwv1beta1.Gateway, state *state.GatewayState) *binder {
-	return &binder{
-		Client:       client,
-		Gateway:      gateway,
-		GatewayState: state,
-	}
+func newBinder(client gatewayclient.Client) *binder {
+	return &binder{Client: client}
 }
 
 // Bind will attempt to bind the provided route to all listeners on the Gateway and
 // remove the route from any listeners that the route should no longer be bound to.
 // The latter is important for scenarios such as the route's parent changing.
-func (b *binder) Bind(ctx context.Context, route *K8sRoute) []string {
+func (b *binder) Bind(ctx context.Context, gateway *K8sGateway, route *K8sRoute) []string {
 	var boundListeners []string
 
 	// If the route doesn't reference this Gateway, remove the route
 	// from any listeners that it may have previously bound to
-	if !b.routeReferencesThisGateway(route) {
-		for _, listenerState := range b.GatewayState.Listeners {
+	if !b.routeReferencesGateway(route, gateway) {
+		for _, listenerState := range gateway.GatewayState.Listeners {
 			delete(listenerState.Routes, route.ID())
 		}
 		return boundListeners
@@ -55,10 +49,10 @@ func (b *binder) Bind(ctx context.Context, route *K8sRoute) []string {
 
 	// The route does reference this Gateway, so attempt to bind to each listener
 	for _, ref := range route.commonRouteSpec().ParentRefs {
-		for i, listener := range b.Gateway.Spec.Listeners {
-			listenerState := b.GatewayState.Listeners[i]
-			if b.canBind(ctx, listener, listenerState, ref, route) {
-				listenerState.Routes[route.ID()] = route.resolve(b.GatewayState.ConsulNamespace, b.Gateway, listener)
+		for i, listener := range gateway.Spec.Listeners {
+			listenerState := gateway.GatewayState.Listeners[i]
+			if b.canBind(ctx, gateway.Namespace, listener, listenerState, ref, route) {
+				listenerState.Routes[route.ID()] = route.resolve(gateway.GatewayState.ConsulNamespace, gateway.Gateway, listener)
 				boundListeners = append(boundListeners, string(listener.Name))
 			} else {
 				// If the route cannot bind to this listener, remove the route
@@ -71,8 +65,8 @@ func (b *binder) Bind(ctx context.Context, route *K8sRoute) []string {
 	return boundListeners
 }
 
-func (b *binder) routeReferencesThisGateway(route *K8sRoute) bool {
-	thisGateway := utils.NamespacedName(b.Gateway)
+func (b *binder) routeReferencesGateway(route *K8sRoute, gateway *K8sGateway) bool {
+	thisGateway := utils.NamespacedName(gateway)
 	for _, ref := range route.commonRouteSpec().ParentRefs {
 		gatewayReferenced, isGatewayTypeRef := utils.ReferencesGateway(route.GetNamespace(), ref)
 		if isGatewayTypeRef && gatewayReferenced == thisGateway {
@@ -82,7 +76,7 @@ func (b *binder) routeReferencesThisGateway(route *K8sRoute) bool {
 	return false
 }
 
-func (b *binder) canBind(ctx context.Context, listener gwv1beta1.Listener, state *state.ListenerState, ref gwv1alpha2.ParentReference, route *K8sRoute) bool {
+func (b *binder) canBind(ctx context.Context, namespace string, listener gwv1beta1.Listener, state *state.ListenerState, ref gwv1alpha2.ParentReference, route *K8sRoute) bool {
 	if state.Status.Ready.HasError() {
 		return false
 	}
@@ -101,7 +95,7 @@ func (b *binder) canBind(ctx context.Context, listener gwv1beta1.Listener, state
 		return false
 	}
 
-	allowed, err := routeAllowedForListenerNamespaces(ctx, b.Gateway.Namespace, listener.AllowedRoutes, route, b.Client)
+	allowed, err := routeAllowedForListenerNamespaces(ctx, namespace, listener.AllowedRoutes, route, b.Client)
 	if err != nil {
 		route.RouteState.BindFailed(fmt.Errorf("error checking listener namespaces: %w", err), ref)
 		return false

--- a/internal/k8s/reconciler/binder_test.go
+++ b/internal/k8s/reconciler/binder_test.go
@@ -387,8 +387,10 @@ func TestBinder(t *testing.T) {
 				client.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(test.namespace, nil)
 			}
 
-			binder := newBinder(client, test.gateway, gatewayState)
-			listeners := binder.Bind(context.Background(), factory.NewRoute(test.route))
+			binder := newBinder(client)
+			listeners := binder.Bind(context.Background(),
+				factory.NewGateway(NewGatewayConfig{Gateway: test.gateway, State: gatewayState}),
+				factory.NewRoute(test.route))
 			if test.didBind {
 				require.NotEmpty(t, listeners)
 			} else {

--- a/internal/k8s/reconciler/gateway.go
+++ b/internal/k8s/reconciler/gateway.go
@@ -85,7 +85,7 @@ func (g *K8sGateway) Bind(ctx context.Context, route store.Route) []string {
 		return nil
 	}
 
-	return newBinder(g.client, g.Gateway, g.GatewayState).Bind(ctx, k8sRoute)
+	return newBinder(g.client).Bind(ctx, g, k8sRoute)
 }
 
 func (g *K8sGateway) Remove(ctx context.Context, routeID string) error {


### PR DESCRIPTION
### Changes proposed in this PR:
This is the fifth part to be broken out of https://github.com/hashicorp/consul-api-gateway/pull/165 . This restructures the `Binder` interface so that a single binder is reusable for multiple gateways instead of wrapping a single gateway.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
