### PR TITLE
(dark) Refactor status syncing logic out of K8sGateway + K8sGateway into StatusUpdater

### DIFF
--- a/internal/k8s/reconciler/statuses.go
+++ b/internal/k8s/reconciler/statuses.go
@@ -1,0 +1,84 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/status"
+	"github.com/hashicorp/consul-api-gateway/internal/store"
+)
+
+var _ store.StatusUpdater = (*StatusUpdater)(nil)
+
+type StatusUpdater struct {
+	logger         hclog.Logger
+	client         gatewayclient.Client
+	deployer       *GatewayDeployer
+	controllerName string
+}
+
+func NewStatusUpdater(logger hclog.Logger, client gatewayclient.Client, deployer *GatewayDeployer, controllerName string) *StatusUpdater {
+	return &StatusUpdater{
+		logger:         logger,
+		client:         client,
+		deployer:       deployer,
+		controllerName: controllerName,
+	}
+}
+
+func (s *StatusUpdater) UpdateGatewayStatusOnSync(ctx context.Context, gateway store.Gateway, sync func() (bool, error)) error {
+	g := gateway.(*K8sGateway)
+
+	// we've done all but synced our state, so ensure our deployments are up-to-date
+	if err := s.deployer.Deploy(ctx, g); err != nil {
+		return err
+	}
+
+	didSync, err := sync()
+	if err != nil {
+		g.GatewayState.Status.InSync.SyncError = err
+	} else if didSync {
+		// clear out any old synchronization error statuses
+		g.GatewayState.Status.InSync = status.GatewayInSyncStatus{}
+	}
+
+	gatewayStatus := g.GatewayState.GetStatus(g.Gateway)
+	if !status.GatewayStatusEqual(gatewayStatus, g.Gateway.Status) {
+		g.Gateway.Status = gatewayStatus
+		if s.logger.IsTrace() {
+			data, err := json.MarshalIndent(gatewayStatus, "", "  ")
+			if err == nil {
+				s.logger.Trace("setting gateway status", "status", string(data))
+			}
+		}
+		if err := s.client.UpdateStatus(ctx, g.Gateway); err != nil {
+			// make sure we return an error immediately that's unwrapped
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *StatusUpdater) UpdateRouteStatus(ctx context.Context, route store.Route) error {
+	r := route.(*K8sRoute)
+
+	if status, ok := r.RouteState.ParentStatuses.NeedsUpdate(r.routeStatus(), s.controllerName, r.GetGeneration()); ok {
+		r.setStatus(status)
+
+		if s.logger.IsTrace() {
+			status, err := json.MarshalIndent(status, "", "  ")
+			if err == nil {
+				s.logger.Trace("syncing route status", "status", string(status))
+			}
+		}
+		if err := s.client.UpdateStatus(ctx, r.Route); err != nil {
+			return fmt.Errorf("error updating route status: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/k8s/reconciler/statuses_test.go
+++ b/internal/k8s/reconciler/statuses_test.go
@@ -1,0 +1,186 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/pointer"
+	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/gatewayclient/mocks"
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
+	apigwv1alpha1 "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
+)
+
+func TestStatuses_GatewayTrackSync(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mocks.NewMockClient(ctrl)
+
+	updater := NewStatusUpdater(hclog.NewNullLogger(), client, NewDeployer(DeployerConfig{
+		Client: client,
+		Logger: hclog.NewNullLogger(),
+	}), "")
+
+	factory := NewFactory(FactoryConfig{
+		Logger: hclog.NewNullLogger(),
+		Client: client,
+		Deployer: NewDeployer(DeployerConfig{
+			Logger: hclog.NewNullLogger(),
+			Client: client,
+		}),
+	})
+
+	gw := &gwv1beta1.Gateway{}
+
+	gateway := factory.NewGateway(NewGatewayConfig{
+		Gateway:         gw,
+		State:           state.InitialGatewayState(gw),
+		ConsulNamespace: "consul",
+	})
+	gateway.Gateway.Status = gateway.GatewayState.GetStatus(gw)
+	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+	assert.NoError(t, updater.UpdateGatewayStatusOnSync(context.Background(), gateway, func() (bool, error) {
+		return false, nil
+	}))
+
+	gw = &gwv1beta1.Gateway{}
+
+	gateway = factory.NewGateway(NewGatewayConfig{
+		Config: apigwv1alpha1.GatewayClassConfig{
+			Spec: apigwv1alpha1.GatewayClassConfigSpec{
+				DeploymentSpec: apigwv1alpha1.DeploymentSpec{
+					DefaultInstances: pointer.Int32(2),
+				},
+			},
+		},
+		Gateway:         gw,
+		State:           state.InitialGatewayState(gw),
+		ConsulNamespace: "consul",
+	})
+
+	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	client.EXPECT().UpdateStatus(gomock.Any(), gateway.Gateway).Return(nil)
+	assert.NoError(t, updater.UpdateGatewayStatusOnSync(context.Background(), gateway, func() (bool, error) {
+		return false, nil
+	}))
+
+	expected := errors.New("expected")
+
+	gw = &gwv1beta1.Gateway{}
+	gateway = factory.NewGateway(NewGatewayConfig{
+		Gateway:         gw,
+		State:           state.InitialGatewayState(gw),
+		ConsulNamespace: "consul",
+	})
+	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, expected)
+	assert.True(t, errors.Is(updater.UpdateGatewayStatusOnSync(context.Background(), gateway, func() (bool, error) {
+		return false, nil
+	}), expected))
+
+	gw = &gwv1beta1.Gateway{}
+	gateway = factory.NewGateway(NewGatewayConfig{
+		Gateway:         gw,
+		State:           state.InitialGatewayState(gw),
+		ConsulNamespace: "consul",
+	})
+	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	client.EXPECT().UpdateStatus(gomock.Any(), gateway.Gateway).Return(expected)
+	assert.Equal(t, expected, updater.UpdateGatewayStatusOnSync(context.Background(), gateway, func() (bool, error) {
+		return false, nil
+	}))
+
+	gw = &gwv1beta1.Gateway{}
+	gateway = factory.NewGateway(NewGatewayConfig{
+		Gateway:         gw,
+		State:           state.InitialGatewayState(gw),
+		ConsulNamespace: "consul",
+	})
+	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	client.EXPECT().UpdateStatus(gomock.Any(), gateway.Gateway).Return(nil)
+	assert.NoError(t, updater.UpdateGatewayStatusOnSync(context.Background(), gateway, func() (bool, error) {
+		return true, nil
+	}))
+
+	gw = &gwv1beta1.Gateway{}
+	gateway = factory.NewGateway(NewGatewayConfig{
+		Gateway:         gw,
+		State:           state.InitialGatewayState(gw),
+		ConsulNamespace: "consul",
+	})
+	client.EXPECT().GetDeployment(gomock.Any(), gomock.Any()).Return(nil, nil)
+	client.EXPECT().CreateOrUpdateDeployment(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+	client.EXPECT().UpdateStatus(gomock.Any(), gateway.Gateway).Return(nil)
+	assert.NoError(t, updater.UpdateGatewayStatusOnSync(context.Background(), gateway, func() (bool, error) {
+		return false, expected
+	}))
+}
+
+func TestStatuses_RouteSyncStatus(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mocks.NewMockClient(ctrl)
+
+	updater := NewStatusUpdater(hclog.NewNullLogger(), client, NewDeployer(DeployerConfig{
+		Client: client,
+		Logger: hclog.NewNullLogger(),
+	}), "")
+
+	inner := &gwv1alpha2.TCPRoute{
+		Spec: gwv1alpha2.TCPRouteSpec{
+			CommonRouteSpec: gwv1alpha2.CommonRouteSpec{
+				ParentRefs: []gwv1alpha2.ParentReference{{
+					Name: "expected",
+				}, {
+					Name: "other",
+				}},
+			},
+		},
+		Status: gwv1alpha2.TCPRouteStatus{
+			RouteStatus: gwv1alpha2.RouteStatus{
+				Parents: []gwv1alpha2.RouteParentStatus{{
+					ParentRef: gwv1alpha2.ParentReference{
+						Name: "expected",
+					},
+					ControllerName: "expected",
+				}, {
+					ParentRef: gwv1alpha2.ParentReference{
+						Name: "expected",
+					},
+					ControllerName: "other",
+				}, {
+					ParentRef: gwv1alpha2.ParentReference{
+						Name: "other",
+					},
+					ControllerName: "other",
+				}},
+			},
+		},
+	}
+
+	route := newK8sRoute(inner, K8sRouteConfig{Logger: hclog.NewNullLogger(), State: state.NewRouteState()})
+	route.RouteState.Bound(gwv1alpha2.ParentReference{
+		Name: "expected",
+	})
+
+	expected := errors.New("expected")
+	client.EXPECT().UpdateStatus(gomock.Any(), inner).Return(expected)
+	require.True(t, errors.Is(updater.UpdateRouteStatus(context.Background(), route), expected))
+
+	require.NoError(t, updater.UpdateRouteStatus(context.Background(), route))
+}


### PR DESCRIPTION
### Changes proposed in this PR:
This is the eighth part to be broken out of https://github.com/hashicorp/consul-api-gateway/pull/165 . This takes code from `K8sGateway` and `K8sRoute` related to syncing statuses and moves it into a separate `StatusUpdater`.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
