### PR TITLE
(dark) Initial Consul backend storage implementation

### DIFF
--- a/internal/store/consul_backend.go
+++ b/internal/store/consul_backend.go
@@ -1,0 +1,152 @@
+package store
+
+import (
+	"context"
+	"strings"
+
+	consulapi "github.com/hashicorp/consul/api"
+
+	"github.com/hashicorp/consul-api-gateway/internal/core"
+)
+
+type ConsulBackend struct {
+	client *consulapi.Client
+
+	id         string
+	namespace  string
+	pathPrefix string
+}
+
+var _ Backend = &ConsulBackend{}
+
+func NewConsulBackend(id string, client *consulapi.Client, namespace, pathPrefix string) *ConsulBackend {
+	return &ConsulBackend{
+		id:         id,
+		client:     client,
+		namespace:  namespace,
+		pathPrefix: pathPrefix,
+	}
+}
+
+func (c *ConsulBackend) GetGateway(ctx context.Context, id core.GatewayID) ([]byte, error) {
+	pair, _, err := c.client.KV().Get(c.storagePath("gateways", id.ConsulNamespace, id.Service), c.queryOptions(ctx))
+	if err != nil {
+		return nil, err
+	}
+	if pair == nil {
+		return nil, ErrNotFound
+	}
+	return pair.Value, nil
+}
+
+func (c *ConsulBackend) ListGateways(ctx context.Context) ([][]byte, error) {
+	pairs, _, err := c.client.KV().List(c.listPath("gateways"), c.queryOptions(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	data := [][]byte{}
+	for _, pair := range pairs {
+		data = append(data, pair.Value)
+	}
+	return data, nil
+}
+
+func (c *ConsulBackend) DeleteGateway(ctx context.Context, id core.GatewayID) error {
+	_, err := c.client.KV().Delete(c.storagePath("gateways", id.ConsulNamespace, id.Service), c.writeOptions(ctx))
+	return err
+}
+
+func (c *ConsulBackend) UpsertGateways(ctx context.Context, gateways ...GatewayRecord) error {
+	operations := consulapi.TxnOps{}
+
+	for _, gateway := range gateways {
+		operations = append(operations, &consulapi.TxnOp{
+			KV: &consulapi.KVTxnOp{
+				Verb:  consulapi.KVSet,
+				Key:   c.storagePath("gateways", gateway.ID.ConsulNamespace, gateway.ID.Service),
+				Value: gateway.Data,
+			},
+		})
+	}
+
+	_, _, _, err := c.client.Txn().Txn(operations, c.queryOptions(ctx))
+	return err
+}
+
+func (c *ConsulBackend) GetRoute(ctx context.Context, id string) ([]byte, error) {
+	pair, _, err := c.client.KV().Get(c.storagePath("routes", "default", id), c.queryOptions(ctx))
+	if err != nil {
+		return nil, err
+	}
+	if pair == nil {
+		return nil, ErrNotFound
+	}
+	return pair.Value, nil
+}
+
+func (c *ConsulBackend) ListRoutes(ctx context.Context) ([][]byte, error) {
+	pairs, _, err := c.client.KV().List(c.listPath("routes"), c.queryOptions(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	data := [][]byte{}
+	for _, pair := range pairs {
+		data = append(data, pair.Value)
+	}
+	return data, nil
+}
+
+func (c *ConsulBackend) DeleteRoute(ctx context.Context, id string) error {
+	_, err := c.client.KV().Delete(c.storagePath("routes", "default", id), c.writeOptions(ctx))
+	return err
+}
+
+func (c *ConsulBackend) UpsertRoutes(ctx context.Context, routes ...RouteRecord) error {
+	operations := consulapi.TxnOps{}
+
+	for _, route := range routes {
+		operations = append(operations, &consulapi.TxnOp{
+			KV: &consulapi.KVTxnOp{
+				Verb:  consulapi.KVSet,
+				Key:   c.storagePath("routes", "default", route.ID), // this should decompose a complex route ID in the future
+				Value: route.Data,
+			},
+		})
+	}
+
+	_, _, _, err := c.client.Txn().Txn(operations, c.queryOptions(ctx))
+	return err
+}
+
+// this should eventually be used to construct paths like:
+//   v1/gateways/ns/default/foo-bar-baz
+//   v1/http-routes/ns/default/foo-bar-baz
+//   v1/tcp-routes/ns/default/foo-bar-baz
+//
+// TODO: for this to be fully functional we need to make sure that our route IDs encode this information
+// via some compound identifier rather than by just a "string" as they do now
+func (c *ConsulBackend) storagePath(entity, namespace, id string) string {
+	return strings.Join([]string{c.pathPrefix, "v1", entity, "ns", namespace, id}, "/")
+}
+
+func (c *ConsulBackend) listPath(entity string) string {
+	return strings.Join([]string{c.pathPrefix, "v1", entity}, "/")
+}
+
+func (c *ConsulBackend) queryOptions(ctx context.Context) *consulapi.QueryOptions {
+	opts := &consulapi.QueryOptions{}
+	if c.namespace != "" {
+		opts.Namespace = c.namespace
+	}
+	return opts.WithContext(ctx)
+}
+
+func (c *ConsulBackend) writeOptions(ctx context.Context) *consulapi.WriteOptions {
+	opts := &consulapi.WriteOptions{}
+	if c.namespace != "" {
+		opts.Namespace = c.namespace
+	}
+	return opts.WithContext(ctx)
+}

--- a/internal/store/consul_backend.go
+++ b/internal/store/consul_backend.go
@@ -12,9 +12,9 @@ import (
 type ConsulBackend struct {
 	client *consulapi.Client
 
-	id         string
-	namespace  string
-	pathPrefix string
+	id         string // this maps to a unique id for the controller deployment so we don't co-mingle multiple controller storage
+	namespace  string // this is the namespace that the storage actually uses for storing KV pairs
+	pathPrefix string // this is an arbitrary path prefix to append on all storage that is user-configurable
 }
 
 var _ Backend = &ConsulBackend{}

--- a/internal/store/consul_backend.go
+++ b/internal/store/consul_backend.go
@@ -121,18 +121,18 @@ func (c *ConsulBackend) UpsertRoutes(ctx context.Context, routes ...RouteRecord)
 }
 
 // this should eventually be used to construct paths like:
-//   v1/gateways/ns/default/foo-bar-baz
-//   v1/http-routes/ns/default/foo-bar-baz
-//   v1/tcp-routes/ns/default/foo-bar-baz
+//   v1/consul-api-gateway/gateways/ns/default/foo-bar-baz
+//   v1/consul-api-gateway/http-routes/ns/default/foo-bar-baz
+//   v1/consul-api-gateway/tcp-routes/ns/default/foo-bar-baz
 //
 // TODO: for this to be fully functional we need to make sure that our route IDs encode this information
 // via some compound identifier rather than by just a "string" as they do now
 func (c *ConsulBackend) storagePath(entity, namespace, id string) string {
-	return strings.Join([]string{c.pathPrefix, "v1", entity, "ns", namespace, id}, "/")
+	return strings.Join([]string{c.pathPrefix, "v1", c.id, entity, "ns", namespace, id}, "/")
 }
 
 func (c *ConsulBackend) listPath(entity string) string {
-	return strings.Join([]string{c.pathPrefix, "v1", entity}, "/")
+	return strings.Join([]string{c.pathPrefix, "v1", c.id, entity}, "/")
 }
 
 func (c *ConsulBackend) queryOptions(ctx context.Context) *consulapi.QueryOptions {

--- a/internal/store/consul_backend_test.go
+++ b/internal/store/consul_backend_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/consul-api-gateway/internal/core"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func testConsul(t *testing.T) *api.Client {
+	t.Helper()
+
+	consulSrv, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+		c.Peering = nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = consulSrv.Stop()
+	})
+	consulSrv.WaitForLeader(t)
+
+	cfg := api.DefaultConfig()
+	cfg.Address = consulSrv.HTTPAddr
+	consul, err := api.NewClient(cfg)
+	require.NoError(t, err)
+	return consul
+}
+
+func TestConsulStore_Gateways(t *testing.T) {
+	t.Parallel()
+
+	consul := testConsul(t)
+
+	id := uuid.New().String()
+
+	backend := NewConsulBackend(id, consul, "", "foo")
+	require.NoError(t, backend.UpsertGateways(context.Background(), []GatewayRecord{{
+		ID:   core.GatewayID{ConsulNamespace: "foo", Service: "foo"},
+		Data: []byte("foo"),
+	}}...))
+
+	gateways, err := backend.ListGateways(context.Background())
+	require.NoError(t, err)
+	require.Len(t, gateways, 1)
+	require.Contains(t, gateways, []byte("foo"))
+
+	require.NoError(t, backend.UpsertGateways(context.Background(), []GatewayRecord{{
+		ID:   core.GatewayID{ConsulNamespace: "bar", Service: "bar"},
+		Data: []byte("bar"),
+	}, {
+		ID:   core.GatewayID{ConsulNamespace: "baz", Service: "baz"},
+		Data: []byte("baz"),
+	}}...))
+
+	gateways, err = backend.ListGateways(context.Background())
+	require.NoError(t, err)
+	require.Len(t, gateways, 3)
+	require.Contains(t, gateways, []byte("foo"))
+	require.Contains(t, gateways, []byte("bar"))
+	require.Contains(t, gateways, []byte("baz"))
+
+	require.NoError(t, backend.DeleteGateway(context.Background(), core.GatewayID{ConsulNamespace: "bar", Service: "bar"}))
+
+	gateways, err = backend.ListGateways(context.Background())
+	require.NoError(t, err)
+	require.Len(t, gateways, 2)
+	require.Contains(t, gateways, []byte("foo"))
+	require.Contains(t, gateways, []byte("baz"))
+
+	gateway, err := backend.GetGateway(context.Background(), core.GatewayID{ConsulNamespace: "foo", Service: "foo"})
+	require.NoError(t, err)
+	require.Equal(t, gateway, []byte("foo"))
+}
+
+func TestConsulStore_Routes(t *testing.T) {
+	t.Parallel()
+
+	consul := testConsul(t)
+
+	id := uuid.New().String()
+
+	backend := NewConsulBackend(id, consul, "", "foo")
+	require.NoError(t, backend.UpsertRoutes(context.Background(), []RouteRecord{{
+		ID:   "foo",
+		Data: []byte("foo"),
+	}}...))
+
+	routes, err := backend.ListRoutes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, routes, 1)
+	require.Contains(t, routes, []byte("foo"))
+
+	require.NoError(t, backend.UpsertRoutes(context.Background(), []RouteRecord{{
+		ID:   "bar",
+		Data: []byte("bar"),
+	}, {
+		ID:   "baz",
+		Data: []byte("baz"),
+	}}...))
+
+	routes, err = backend.ListRoutes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, routes, 3)
+	require.Contains(t, routes, []byte("foo"))
+	require.Contains(t, routes, []byte("bar"))
+	require.Contains(t, routes, []byte("baz"))
+
+	require.NoError(t, backend.DeleteRoute(context.Background(), "bar"))
+
+	routes, err = backend.ListRoutes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, routes, 2)
+	require.Contains(t, routes, []byte("foo"))
+	require.Contains(t, routes, []byte("baz"))
+
+	route, err := backend.GetRoute(context.Background(), "foo")
+	require.NoError(t, err)
+	require.Equal(t, route, []byte("foo"))
+}


### PR DESCRIPTION
### Changes proposed in this PR:

Since @sarahalsmiller is out this week I just went ahead and threw this together to unblock some of our implementation work. This adds an implementation of a Consul-based `Backend` interface. A couple of things to note:

1. We'll want to touch up the `id` implementation for our core `Route` model to handle complex ids (rather than just be dumb strings) so that we can segment better in our storage layer -- right now since we don't have namespace data encoded in the ID we just stub out some of the values needed to construct the key path
2. We'll want to see whether or not we should separate out the TCP/HTTP implementations of our List/Upsert/etc. operations. This is a bigger issue that we can discuss now but can probably punt on similarly to how we talked about before in the PR that introduced the `ListRoutes/ListGateways` functions -- by adding a server-side filtering layer down the line.

Currently nothing actually uses this, but I'll add in the initialization code to our VM controller entrypoiint once this gets merged.

Also, note that I put this directly in the `store` subpackage, just to move to a flatter package structure -- it'd be nice to do the same with the `memory` backend implementation.

### How I've tested this PR:

Unit tests.

### Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
