### PR TITLE
Add e2e tests

### DIFF
--- a/internal/api/schemas/v1.yaml
+++ b/internal/api/schemas/v1.yaml
@@ -647,6 +647,8 @@ components:
         name:
           type: string
           minLength: 1
+        listener:
+          type: string
         namespace:
           type: string
     HTTPRoute:
@@ -654,6 +656,7 @@ components:
       required:
       - name
       - gateways
+      - rules
       properties:
         name:
           type: string
@@ -673,8 +676,11 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/HTTPRouteRule"
+          minItems: 1
     HTTPRouteRule:
       type: object
+      required:
+      - services
       properties:
         matches:
           type: array
@@ -686,6 +692,7 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/HTTPService"
+          minItems: 1
     HTTPService:
       type: object
       required:
@@ -693,6 +700,7 @@ components:
       properties:
         name:
           type: string
+          minLength: 1
         namespace:
           type: string
         weight:
@@ -812,6 +820,7 @@ components:
       required:
       - name
       - gateways
+      - services
       properties:
         name:
           type: string

--- a/internal/api/v1/zz_generated.go
+++ b/internal/api/v1/zz_generated.go
@@ -104,6 +104,7 @@ type GatewayPage struct {
 
 // GatewayReference defines model for GatewayReference.
 type GatewayReference struct {
+	Listener  *string `json:"listener,omitempty"`
 	Name      string  `json:"name"`
 	Namespace *string `json:"namespace,omitempty"`
 }
@@ -166,7 +167,7 @@ type HTTPRoute struct {
 	Hostnames []string           `json:"hostnames,omitempty"`
 	Name      string             `json:"name"`
 	Namespace *string            `json:"namespace,omitempty"`
-	Rules     []HTTPRouteRule    `json:"rules,omitempty"`
+	Rules     []HTTPRouteRule    `json:"rules"`
 }
 
 // HTTPRoutePage defines model for HTTPRoutePage.
@@ -179,7 +180,7 @@ type HTTPRoutePage struct {
 type HTTPRouteRule struct {
 	Filters  *HTTPFilters  `json:"filters,omitempty"`
 	Matches  []HTTPMatch   `json:"matches,omitempty"`
-	Services []HTTPService `json:"services,omitempty"`
+	Services []HTTPService `json:"services"`
 }
 
 // HTTPService defines model for HTTPService.
@@ -213,7 +214,7 @@ type TCPRoute struct {
 	Gateways  []GatewayReference `json:"gateways"`
 	Name      string             `json:"name"`
 	Namespace *string            `json:"namespace,omitempty"`
-	Services  []TCPService       `json:"services,omitempty"`
+	Services  []TCPService       `json:"services"`
 }
 
 // TCPRoutePage defines model for TCPRoutePage.
@@ -3932,39 +3933,39 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xaS3PjuBH+KywkpxQteTyZHHSKo9HarvVDsbRbqdqdqoXJlogJCXAA0Lbi0n9PNcGn",
-	"SEmkHraU6GLTJNDoRn/dXzfgN+KIIBQcuFak90aU40FA48c+SM0mzKEa8M9QihDfQPzxmUa+xoc/S5iQ",
-	"HvlTN5fTTYR0f8VBRTHzuU30LATSI+LpOziazG3SF1xL4fsgr4H62qsuxlz8mUxUWjI+xYmcBlD7QWmq",
-	"I1XzaW4TCT8iJsElvd+MABvFZ3O+1Sg4kFLIqlaOcOPlJ0IGVJMeYVx/viCZAMY1TEGihACUotN4dMD4",
-	"LfApmvnJXqNfOs02a9XpdkU1vNBZVTufKQ0cpNlADYFa563bZEasMOM3Zk6uJJWSzow1mhY2N1cmdchK",
-	"G80wFVIHGnsoN2bFHhwoehLthon/y7pNzcfmTkr9PW/slgWtsxVX6PoIE5DAnRqF9+TiOmWux+PhT8zX",
-	"CYbLenhA3TbgRmHX8RwjsrqB8yUqlGZV9KCum/ximglO/WHpc2VjKktICMQzlOxYNinztAK9zaKrLb2j",
-	"2qmJogBfP3B8BB4F6Dl4pY4mNgklTNgrRkE0MQ+hBAUcv0mYRj6Vg1d8pZjgBVc3iMVn6kcNMJQqZ6dB",
-	"aeYtQ9USEzfHlBFYH5OecIub1n+4vx/0x8QmXwe3g/GA2ORqgH9eDy6/Eps8DMc3D/cjYpPh5bh/jb8f",
-	"Rvh9+Av+HD9e9ge1exhSk/zWaTyk2sv0/RGBnLUy+J84Y4m9y4CVL7kRrJphqDVUVmOkYGdLpQ8Z+Y8i",
-	"0jukoZwo1tUMnlA6JoV2mW4HdGMTGfnQLqrjbXqMfKjFeE0RsJJVM4n1NcDSckrinA0UX6t0InilrrH1",
-	"FV0nOR+vUyWlbkQGgrSlJUtTqgL5zJyW0kZmUvOUlU7Y0Q4sDfPVyH0BNvV04ROPgicsXhrXUHFNPMoq",
-	"2sUOJu28mu9mpVurcdGm6WSZxAVri2qvCb2sp6mSfZKQ8NmFiWlnyV9ImxwdCqkNH7yyAHngb1++fP4S",
-	"Z0Lz96e6ZjCUQgtH+EX68LQOcWknrGUJ7a/dwvHtqC/4hE0jSbEorOxaZnCid0GRup0b9z+OLHaS9Vvn",
-	"iXG/mCYC+poruELbDfgg3dr90kHmwC3YoLAl++gEd5DgKrCvJrn8/KlFliseWlUB6rDQAzmKmG5b0AT0",
-	"9VeQKtG0MjxgfPnnOq6qHLFV7fco4z8x8N0G3kqbiHXDJHumGn6GWTPBC96MV7GLmlVFfqtrWxU4kWR6",
-	"NkI3GfMuQ/YzzC4jozfjpJf0cWlJ3CP/OusLriL/bCz+DTzP8DSeSuYomfGJSCkRK3nMzQFlPunhK5xM",
-	"Q3aWhPXfPao85ggZdhwR5AuZZazL4Y2V5DxrDBQHRBIlYZbvdbvl2XObuKAcyUKD3zopd5TTKQTANb6O",
-	"D8Qc4AryOCR34j/M96k1jJ585li3ZoB10TkvLa963e7Ly0snMMM7Qk67wM9+GXXvhrfdi855N0Yt0369",
-	"QdhhpAAlnzrnnXMcL0LgNGSkRz7HrwyQYv90i3QxNQcXZXsfQUeSK4v6vuUksQyulc7rkFi+Ce8bl/Ri",
-	"Ur9KpeJSkgZgirLfFoWPPbCyFKQsMcnkWlpYPlNIhDFqTCuc+TKfROzkVLwuJL8hslUouDJwvDg/T2GE",
-	"bWDvjdAw9DE0meDd78oEdi6vAW/GNBGDtGxaYoiVrm+QNEkP5neigjn6rlk84vAagqPBtSAfEwpV4+C+",
-	"BEy+FrU4vKT7X3WrGZbjDDMGKP0P4c52vaV1FqWxpoXlxJqQYtLSMoJ5xdef3kOxg/Pz3M6juvuGgTI3",
-	"TvdBQ9X95j26XzE+9SFFgMW4pT2w/vg9Ned38kcerNYTVeBawgzC15aK0EBwK9D5Gi+RQ2dlSrhHUXki",
-	"QIcnqieZIKGnQiKoQKFdSvhrdVPSxc3K7gHE7urc3NJpkwnuMNPKijj7ERn/VUP+CvTmTpuAdry9+ez8",
-	"/za0vewebSUkzDDL3Hyha5C/JUyx40b+Thnaoty1Ci17FQVJ279HF5SOQWq2IrHlsNygdXiW93xrSycc",
-	"b5nxa4K0vqLKTv42qKmSZQ++oiqfxNY4Izbk2Cqq3PPLiqr8aHg/ZVXh6LlqWPYR8UFd913rqpWaHZi3",
-	"F6J+k9Iqh8LOq6sihhpRdUGXDymxzNJHUmChF1o7r3mV1dp5md+Opco6tkDP2dDEefw83/q0JEXOlD0D",
-	"X0f5aYl2w++zU9oG+DAYXDhKWYOTVPhBleRHc7LSADDbNOIlLrhv3mlviZu9wMY+tfu7YaMFcLTu6I8V",
-	"HKdjhXfNX1u2ubQZ0+XNbQtYlvrc5W3ucmCemtzdgWM33dACWLbogjZNb+Wu6P0y3Kkb27wb27zd2hQl",
-	"HwCQU8f3MTlOO634TzuLp7yNCDD9byC1FSKPr9Mr/a/V/whONqHCDDaNmLBJD5ju7KaAyjV61zRXWvZE",
-	"g2tpsClwmpPjtsA5cWPztHckKW9rDmx105lxYWPYqRUMeHi3nEfGec0uOTOfL7vjzCC/nyvOVRGVfvuI",
-	"C86jjfSdVDGNbjfbVDNN78dOZcSWZcTOrjbbeu7E5XuM8Pn8vwEAAP//LgT/lFFEAAA=",
+	"H4sIAAAAAAAC/+xa21PbOhr/VzzafdoxCdDtPuRp2TQFplyyJO2cmbYzFfbnWD225EoykMPkfz8jy9f4",
+	"EjsJkJyTFzC29F1/303iGVnMDxgFKgUaPCNhueDj6HEIXBKHWFiC+jPgLFBvIPr4gENPqod/cnDQAP2j",
+	"n9Hpx0T6X9SiPJnFwkRyHgAaIHb/EyyJFiYaMio58zzgF4A96ZaZEVv9jDcKyQmdqY0U+1D5QUgsQ1Hx",
+	"aWEiDr9CwsFGg6+agKnIp3u+Vwg44pzxslQWsyP2DuM+lmiACJXvTlFKgFAJM+CKgg9C4Fm02if0CuhM",
+	"qXlirpAv2WZqXlWynWMJj3hels4jQgIFrg0owRervHUV74gEJvRS78mExJzjudZG4pxxM2EShzTqqJeJ",
+	"AFvQ2kOZMg022FH0xNKNY/8XZZvpj+2dlPh70dotS1KnHBtkvQMHOFAL6mHVaNIt+79K0ovpdPyReDIG",
+	"eFFIF7DdBfmK2EW0R5MsW3dRI0JhV0kObNvxLyIJo9gbFz6XDFNiwcFnD1DQo25TCgMBchOmzZpeY2lV",
+	"hJivXt9S9Qg09JXn4AlbEpko4OCQJxUioaMfAg4CqPrGYRZ6mI+e1CtBGM25ukWgPmAvbIGhRDgziVi9",
+	"rw5VNSqujylNsDpgXWbnjTa8vbkZDafIRB9GV6PpCJnofKT+vBidfUAmuh1PL29vJshE47Pp8EL9vp2o",
+	"7+PP6uf07mw4qrRhgHVmXCXxGEs3lfdXCHzeSeH/qx01+tYBK2O5FqzaYagzVJoxktOzo9C7jPw7Fsot",
+	"1qisiqxqKFwmZFQUumW6LZQbE/HQg25RHZnpLvRW6VXdLqTWTFg3eqO6a6htwLjas4Y2ldGaFz4m3Chr",
+	"ZJKSrE5WpFeJktRzZVaF3I6a1OZZAfyBWB2pTfSmbj5OOdUZKqG6JTNtJQIegcxcmftEQ/9eNUGte7Go",
+	"8Z6kbfPymJSMd+0dUBoJK7y6blqqo7ikbV5ss7lrvsr1xEtNQ5zY1LMNjp6Z0b9Ql1wfMC51XXkivqon",
+	"/3n//t37CJX675OqiTPgTDKLefky5EoZKNZWUFltpLfShNOryZBRh8xCjlVzWbJaqnAsd06QKstNh29X",
+	"dLYSO51Ty3RYyCz4KRNwk1LSmHgSK79sMUl9uUEtyVmnJOdu5LpSBJTzXXbe1SHh5Q/Jyli1SOACn4RE",
+	"du2RfPz0BbiIJS0t9wmt/1zVsZeO9Mr6u5jQjwQ8u4W3krlk1TJOHrCETzBvR3jJmxEXMy9ZmeT3qklY",
+	"gBVyIucT5Sat3llAPsH8LNRyE4oG8WiYdNkD9NvRkFERekdT9jvQLNnjaCtaKMqEOiypjmo4UGnax8RD",
+	"A/VKbcYBOYoj/L8uFi6xGA96FvMzRpqNcTa+NOL0Z0wBqwUhV5RUwh/0+8XdCxPZICxOAo3fKirXmOIZ",
+	"+ECleh0dwFlABWRxiK7ZH8TzsDEO7z1iGVd6gXHaOy6wF4N+//Hxsefr5T3GZ32gR58n/evxVf+0d9yP",
+	"UEukV62QGloSgKKT3nHvWK1nAVAcEDRA76JXGkiRf/r5yjHTZyFFfe9AhpwKA3ueYcWxDLaR7OuhiL4O",
+	"70sbDaL6fp7l2gBz7IPu1r4uE5+6YKQpSBjMSekakhkeEaomRqjR03Xqy2yTSudRWqgKye8K2SJgVGg4",
+	"nh4fJzBSk+XgGeEg8FRoEkb7P4UO7IxeixIalYkIpEXVYkWMhL9GkpNcBGxFBH3UXsE8pPAUgCXBNiBb",
+	"EzBR4eAhB5V8DWxQeEzsX3arXpbhTGUMEPJ/zJ5v26RVGiWxJplhRZKgfNKSPIRFydcnryHYzvl5YWZR",
+	"3X9WgbLQTvdAQtn9+r1yvyB05kGCAINQQ7pg/PiWqPMN/ciC1bjHAmyD6UXqtSFCpSDYJeh8iFhk0GlM",
+	"CTeKVJYIlMNj0eNMEJenXCIoQaFbSvh32SgJc83Z3oHYbc7NHZ3mOMrCRAojpORXqP1XDvlzkOs7zQFp",
+	"uS/ms+O/bWi76b1dIyT0MkPftCnXqPrNYaaGb1W/kwptYGobuem9jIL4BOAFXVA4EakwRazLbrlByuAo",
+	"m/lWtk5qvaHXrwjS6o4qPTdco6eK2e58R1U8x61wRqTIvnVUmefrmqrsYPll2qrcwXVZsfSjwge27Vft",
+	"qxol2zFvL0X9Oq1VBoWtd1d5DLUq1TlZ3qTF0qz3pMFSXujsvPZdVmfnpX7bly5r3wI9q4Y6zqPnxcan",
+	"JQlyZuQB6KqSn7Rol/QmPaVtgQ+NwaWjlBU4SYjvVEu+NycrLQCzySBeqAU37SftDXHzIrAxD+P+dqrR",
+	"Ejg6T/T7Co7DscKr5q8Nx1zcrtJlw20HWBbm3Poxtx6YhyF3e+DYzjS0BJYNpqB101txKnq9DHeYxtaf",
+	"xtYft9ZFyRsA5DDxvU2Ok1an+iet5VPeVgUw+W8gsREi92/SK/yv1V8EJ+uUwhQ2rSphmxkwsey6gMok",
+	"etU0V2B7KIMry2Bb4LQvjpsC51Ab26e9PUl5G9fATjedaS1sDTvRUAF375Zzz2peu0vO1Od1d5wp5F/m",
+	"irMpopJvb3HBubeRvpUuptXtZpdupu392KGN2LCN2NrVZlfPHWr5C0b4YvFnAAAA//8UsO0CwUQAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/commands/deployment/command.go
+++ b/internal/commands/deployment/command.go
@@ -44,7 +44,7 @@ type Command struct {
 	flagEnvoyBinary string // Path to envoy binary
 }
 
-func NewCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *Command {
+func NewCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	cmd := &Command{
 		CommonCLI: common.NewCommonCLI(ctx, help, synopsis, ui, logOutput, "deployment"),
 	}

--- a/internal/commands/gateways/command.go
+++ b/internal/commands/gateways/command.go
@@ -29,7 +29,7 @@ func RegisterCommands(ctx context.Context, commands map[string]cli.CommandFactor
 	}
 }
 
-func NewCommand() *Command {
+func NewCommand() cli.Command {
 	return &Command{}
 }
 

--- a/internal/commands/gateways/delete.go
+++ b/internal/commands/gateways/delete.go
@@ -14,7 +14,7 @@ type DeleteCommand struct {
 	*common.ClientCLIWithNamespace
 }
 
-func NewDeleteCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *DeleteCommand {
+func NewDeleteCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &DeleteCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, deleteHelp, deleteSynopsis, ui, logOutput, "delete"),
 	}

--- a/internal/commands/gateways/fixtures/basic-success-output
+++ b/internal/commands/gateways/fixtures/basic-success-output
@@ -1,0 +1,1 @@
+Successfully created Gateway

--- a/internal/commands/gateways/fixtures/basic-success.json
+++ b/internal/commands/gateways/fixtures/basic-success.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-basic-success",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080
+  }]
+}

--- a/internal/commands/gateways/fixtures/conflicting-listeners-output
+++ b/internal/commands/gateways/fixtures/conflicting-listeners-output
@@ -1,0 +1,6 @@
+There was an error sending the request:
+	server error - code: 400, message: 2 errors occurred:
+	* listener.1: name "" conflicts with listener.0
+	* listener.1: port 8080 conflicts with listener.0
+
+

--- a/internal/commands/gateways/fixtures/conflicting-listeners.json
+++ b/internal/commands/gateways/fixtures/conflicting-listeners.json
@@ -1,0 +1,10 @@
+{
+  "name": "test-conflicting-listeners",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080
+  },{
+    "protocol": "http",
+    "port": 8080
+  }]
+}

--- a/internal/commands/gateways/fixtures/invalid-name-output
+++ b/internal/commands/gateways/fixtures/invalid-name-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: name: minimum string length is 1; current value: ""

--- a/internal/commands/gateways/fixtures/invalid-name.json
+++ b/internal/commands/gateways/fixtures/invalid-name.json
@@ -1,0 +1,6 @@
+{
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080
+  }]
+}

--- a/internal/commands/gateways/fixtures/invalid-tls-output
+++ b/internal/commands/gateways/fixtures/invalid-tls-output
@@ -1,0 +1,5 @@
+There was an error sending the request:
+	server error - code: 400, message: 1 error occurred:
+	* listener.0.tls.certificates: certificates must be specified if TLS is enabled
+
+

--- a/internal/commands/gateways/fixtures/invalid-tls-versions-output
+++ b/internal/commands/gateways/fixtures/invalid-tls-versions-output
@@ -1,0 +1,7 @@
+There was an error sending the request:
+	server error - code: 400, message: 3 errors occurred:
+	* listener.0.tls.cipherSuites: configuring TLS cipher suites is only supported for TLS 1.2 and earlier
+	* listener.0.tls.maxVersion: invalid TLS version "TLS_FOO"
+	* listener.0.tls.cipherSuites.0: unsupported TLS cipher suite "BAR"
+
+

--- a/internal/commands/gateways/fixtures/invalid-tls-versions.json
+++ b/internal/commands/gateways/fixtures/invalid-tls-versions.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-invalid-tls-versions",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {
+      "minVersion": "TLSv1_3",
+      "maxVersion": "TLS_FOO",
+      "cipherSuites": ["BAR"],
+      "certificates": [{
+        "vault": {
+          "path": "certificate",
+          "chainField": "server.cert",
+          "privateKeyField": "server.key"
+        }
+      }]
+    }
+  }]
+}

--- a/internal/commands/gateways/fixtures/invalid-tls.json
+++ b/internal/commands/gateways/fixtures/invalid-tls.json
@@ -1,0 +1,8 @@
+{
+  "name": "invalid-tls",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {}
+  }]
+}

--- a/internal/commands/gateways/fixtures/invalid-vault-chain-field-output
+++ b/internal/commands/gateways/fixtures/invalid-vault-chain-field-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: listeners.0.tls.certificates.0.vault.chainField: minimum string length is 1; current value: ""

--- a/internal/commands/gateways/fixtures/invalid-vault-chain-field.json
+++ b/internal/commands/gateways/fixtures/invalid-vault-chain-field.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-invalid-vault-chain-field",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {
+      "certificates": [{
+        "vault": {
+          "path": "certificate",
+          "privateKeyField": "server.key"
+        }
+      }]
+    }
+  }]
+}

--- a/internal/commands/gateways/fixtures/invalid-vault-path-output
+++ b/internal/commands/gateways/fixtures/invalid-vault-path-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: listeners.0.tls.certificates.0.vault.path: minimum string length is 1; current value: ""

--- a/internal/commands/gateways/fixtures/invalid-vault-path.json
+++ b/internal/commands/gateways/fixtures/invalid-vault-path.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-invalid-vault-path",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {
+      "certificates": [{
+        "vault": {
+          "chainField": "server.cert",
+          "privateKeyField": "server.key"
+        }
+      }]
+    }
+  }]
+}

--- a/internal/commands/gateways/fixtures/invalid-vault-private-key-field-output
+++ b/internal/commands/gateways/fixtures/invalid-vault-private-key-field-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: listeners.0.tls.certificates.0.vault.privateKeyField: minimum string length is 1; current value: ""

--- a/internal/commands/gateways/fixtures/invalid-vault-private-key-field.json
+++ b/internal/commands/gateways/fixtures/invalid-vault-private-key-field.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-invalid-vault-private-key-field",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {
+      "certificates": [{
+        "vault": {
+          "path": "certificate",
+          "chainField": "server.cert"
+        }
+      }]
+    }
+  }]
+}

--- a/internal/commands/gateways/fixtures/no-listener-port-output
+++ b/internal/commands/gateways/fixtures/no-listener-port-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: listeners.0.port: number must be at least 1; current value: "0"

--- a/internal/commands/gateways/fixtures/no-listener-port.json
+++ b/internal/commands/gateways/fixtures/no-listener-port.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-no-listener-port",
+  "listeners": [{
+    "protocol": "http"
+  }]
+}

--- a/internal/commands/gateways/fixtures/no-listener-protocol-output
+++ b/internal/commands/gateways/fixtures/no-listener-protocol-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: listeners.0.protocol: value is not one of the allowed values; allowed values: [http, tcp]; current value: ""

--- a/internal/commands/gateways/fixtures/no-listener-protocol.json
+++ b/internal/commands/gateways/fixtures/no-listener-protocol.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-no-listener-protocol",
+  "listeners": [{
+    "port": 8080
+  }]
+}

--- a/internal/commands/gateways/fixtures/no-listeners-output
+++ b/internal/commands/gateways/fixtures/no-listeners-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: listeners: value is not nullable

--- a/internal/commands/gateways/fixtures/no-listeners.json
+++ b/internal/commands/gateways/fixtures/no-listeners.json
@@ -1,0 +1,3 @@
+{
+  "name": "test-no-listeners"
+}

--- a/internal/commands/gateways/fixtures/non-existent-vault-certificate-output
+++ b/internal/commands/gateways/fixtures/non-existent-vault-certificate-output
@@ -1,0 +1,5 @@
+There was an error sending the request:
+	server error - code: 400, message: 1 error occurred:
+	* listener.0.tls.certificates.0: unable to retrieve Vault certificate
+
+

--- a/internal/commands/gateways/fixtures/non-existent-vault-certificate.json
+++ b/internal/commands/gateways/fixtures/non-existent-vault-certificate.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-non-existent-certificate",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {
+      "certificates": [{
+        "vault": {
+          "path": "non-existent",
+          "chainField": "server.cert",
+          "privateKeyField": "server.key"
+        }
+      }]
+    }
+  }]
+}

--- a/internal/commands/gateways/fixtures/non-existent-vault-chain-field-output
+++ b/internal/commands/gateways/fixtures/non-existent-vault-chain-field-output
@@ -1,0 +1,5 @@
+There was an error sending the request:
+	server error - code: 400, message: 1 error occurred:
+	* listener.0.tls.certificates.0: invalid Vault field "non-existent" for certificate chain
+
+

--- a/internal/commands/gateways/fixtures/non-existent-vault-chain-field.json
+++ b/internal/commands/gateways/fixtures/non-existent-vault-chain-field.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-non-existent-vault-chain-field",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {
+      "certificates": [{
+        "vault": {
+          "path": "certificate",
+          "chainField": "non-existent",
+          "privateKeyField": "server.key"
+        }
+      }]
+    }
+  }]
+}

--- a/internal/commands/gateways/fixtures/non-existent-vault-private-key-field-output
+++ b/internal/commands/gateways/fixtures/non-existent-vault-private-key-field-output
@@ -1,0 +1,5 @@
+There was an error sending the request:
+	server error - code: 400, message: 1 error occurred:
+	* listener.0.tls.certificates.0: invalid Vault field "non-existent" for certificate private key
+
+

--- a/internal/commands/gateways/fixtures/non-existent-vault-private-key-field.json
+++ b/internal/commands/gateways/fixtures/non-existent-vault-private-key-field.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-non-existent-vault-private-key-field",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {
+      "certificates": [{
+        "vault": {
+          "path": "certificate",
+          "chainField": "server.cert",
+          "privateKeyField": "non-existent"
+        }
+      }]
+    }
+  }]
+}

--- a/internal/commands/gateways/fixtures/vault-certificate-success-output
+++ b/internal/commands/gateways/fixtures/vault-certificate-success-output
@@ -1,0 +1,1 @@
+Successfully created Gateway

--- a/internal/commands/gateways/fixtures/vault-certificate-success.json
+++ b/internal/commands/gateways/fixtures/vault-certificate-success.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-vault-certificate-success",
+  "listeners": [{
+    "protocol": "http",
+    "port": 8080,
+    "tls": {
+      "certificates": [{
+        "vault": {
+          "path": "certificate",
+          "chainField": "server.cert",
+          "privateKeyField": "server.key"
+        }
+      }]
+    }
+  }]
+}

--- a/internal/commands/gateways/get.go
+++ b/internal/commands/gateways/get.go
@@ -14,7 +14,7 @@ type GetCommand struct {
 	*common.ClientCLIWithNamespace
 }
 
-func NewGetCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *GetCommand {
+func NewGetCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &GetCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, getHelp, getSynopsis, ui, logOutput, "get"),
 	}

--- a/internal/commands/gateways/list.go
+++ b/internal/commands/gateways/list.go
@@ -18,7 +18,7 @@ type ListCommand struct {
 	flagAllNamespaces bool // list from all namespaces
 }
 
-func NewListCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *ListCommand {
+func NewListCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	cmd := &ListCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, listHelp, listSynopsis, ui, logOutput, "get"),
 	}

--- a/internal/commands/gateways/put.go
+++ b/internal/commands/gateways/put.go
@@ -16,7 +16,7 @@ type PutCommand struct {
 	*common.ClientCLI
 }
 
-func NewPutCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *PutCommand {
+func NewPutCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &PutCommand{
 		ClientCLI: common.NewClientCLI(ctx, putHelp, putSynopsis, ui, logOutput, "delete"),
 	}

--- a/internal/commands/gateways/put_test.go
+++ b/internal/commands/gateways/put_test.go
@@ -1,0 +1,26 @@
+package gateways
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/consul-api-gateway/internal/testing/vm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPut_Fixtures(t *testing.T) {
+	vm.TestFixtures(t, vm.FixturesConfig{
+		Command: NewPutCommand,
+		Args: func(fixture vm.Fixture) []string {
+			return []string{fixture.InputPath}
+		},
+		Setup: func(controller *vm.Controller) {
+			// create a valid Vault cert to use
+			_, err := controller.Vault.Client.KVv2("secret").Put(context.Background(), "certificate", map[string]interface{}{
+				"server.cert": "1234",
+				"server.key":  "5678",
+			})
+			require.NoError(t, err)
+		},
+	})
+}

--- a/internal/commands/health/command.go
+++ b/internal/commands/health/command.go
@@ -19,7 +19,7 @@ type Command struct {
 	*common.ClientCLI
 }
 
-func NewCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *Command {
+func NewCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &Command{
 		ClientCLI: common.NewClientCLI(ctx, help, synopsis, ui, logOutput, "health"),
 	}

--- a/internal/commands/health/command_test.go
+++ b/internal/commands/health/command_test.go
@@ -1,0 +1,39 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul-api-gateway/internal/testing/vm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealth(t *testing.T) {
+	t.Parallel()
+
+	controller := vm.TestController(t)
+
+	expectedOutput := "Successfully retrieved controller health"
+
+	controller.RunCLI(t, vm.CLITest{
+		Command: NewCommand,
+		OutputCheck: func(t *testing.T, output string) {
+			assert.Contains(t, output, expectedOutput)
+		},
+	})
+}
+
+func TestHealth_MultiControllers(t *testing.T) {
+	t.Parallel()
+
+	controller := vm.TestController(t)
+	_ = controller.PeerController(t)
+
+	expectedOutput := "Successfully retrieved controller health"
+
+	controller.RunCLI(t, vm.CLITest{
+		Command: NewCommand,
+		OutputCheck: func(t *testing.T, output string) {
+			assert.Contains(t, output, expectedOutput)
+		},
+	})
+}

--- a/internal/commands/httproutes/command.go
+++ b/internal/commands/httproutes/command.go
@@ -29,7 +29,7 @@ func RegisterCommands(ctx context.Context, commands map[string]cli.CommandFactor
 	}
 }
 
-func NewCommand() *Command {
+func NewCommand() cli.Command {
 	return &Command{}
 }
 

--- a/internal/commands/httproutes/delete.go
+++ b/internal/commands/httproutes/delete.go
@@ -14,7 +14,7 @@ type DeleteCommand struct {
 	*common.ClientCLIWithNamespace
 }
 
-func NewDeleteCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *DeleteCommand {
+func NewDeleteCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &DeleteCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, deleteHelp, deleteSynopsis, ui, logOutput, "delete"),
 	}

--- a/internal/commands/httproutes/fixtures/http-basic-success-output
+++ b/internal/commands/httproutes/fixtures/http-basic-success-output
@@ -1,0 +1,1 @@
+Successfully created route

--- a/internal/commands/httproutes/fixtures/http-basic-success.json
+++ b/internal/commands/httproutes/fixtures/http-basic-success.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-http-basic-success",
+  "gateways": [{
+    "name": "http-1",
+    "listener": "listener-2"
+  },{
+    "name": "http-2"
+  }],
+  "rules" : [{
+    "services": [{
+      "name": "http-service-1"
+    }]
+  }]
+}

--- a/internal/commands/httproutes/fixtures/no-gateway-output
+++ b/internal/commands/httproutes/fixtures/no-gateway-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: gateways: value is not nullable

--- a/internal/commands/httproutes/fixtures/no-gateway.json
+++ b/internal/commands/httproutes/fixtures/no-gateway.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-no-gateway",
+  "rules" : [{
+    "services": [{
+      "name": "http-service-1"
+    }]
+  }]
+}

--- a/internal/commands/httproutes/fixtures/no-rules-output
+++ b/internal/commands/httproutes/fixtures/no-rules-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: rules: value is not nullable

--- a/internal/commands/httproutes/fixtures/no-rules.json
+++ b/internal/commands/httproutes/fixtures/no-rules.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-no-rules",
+  "gateways": [{
+    "name": "http-1",
+    "listener": "listener-2"
+  },{
+    "name": "http-2"
+  }]
+}

--- a/internal/commands/httproutes/fixtures/no-service-output
+++ b/internal/commands/httproutes/fixtures/no-service-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: rules.0.services: minimum number of items is 1; current value: "[]"

--- a/internal/commands/httproutes/fixtures/no-service.json
+++ b/internal/commands/httproutes/fixtures/no-service.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-no-service",
+  "gateways": [{
+    "name": "http-1",
+    "listener": "listener-2"
+  },{
+    "name": "http-2"
+  }],
+  "rules" : [{
+    "services": []
+  }]
+}

--- a/internal/commands/httproutes/fixtures/service-not-found-output
+++ b/internal/commands/httproutes/fixtures/service-not-found-output
@@ -1,0 +1,5 @@
+There was an error sending the request:
+	server error - code: 400, message: 1 error occurred:
+	* no service "http-service-3" found
+
+

--- a/internal/commands/httproutes/fixtures/service-not-found.json
+++ b/internal/commands/httproutes/fixtures/service-not-found.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-service-not-found",
+  "gateways": [{
+    "name": "http-1",
+    "listener": "listener-2"
+  },{
+    "name": "http-2"
+  }],
+  "rules" : [{
+    "services": [{
+      "name": "http-service-3"
+    }]
+  }]
+}

--- a/internal/commands/httproutes/get.go
+++ b/internal/commands/httproutes/get.go
@@ -14,7 +14,7 @@ type GetCommand struct {
 	*common.ClientCLIWithNamespace
 }
 
-func NewGetCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *GetCommand {
+func NewGetCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &GetCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, getHelp, getSynopsis, ui, logOutput, "get"),
 	}

--- a/internal/commands/httproutes/list.go
+++ b/internal/commands/httproutes/list.go
@@ -18,7 +18,7 @@ type ListCommand struct {
 	flagAllNamespaces bool // list from all namespaces
 }
 
-func NewListCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *ListCommand {
+func NewListCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	cmd := &ListCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, listHelp, listSynopsis, ui, logOutput, "get"),
 	}

--- a/internal/commands/httproutes/put.go
+++ b/internal/commands/httproutes/put.go
@@ -16,7 +16,7 @@ type PutCommand struct {
 	*common.ClientCLI
 }
 
-func NewPutCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *PutCommand {
+func NewPutCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &PutCommand{
 		ClientCLI: common.NewClientCLI(ctx, putHelp, putSynopsis, ui, logOutput, "delete"),
 	}

--- a/internal/commands/httproutes/put_test.go
+++ b/internal/commands/httproutes/put_test.go
@@ -1,0 +1,67 @@
+package httproutes
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/hashicorp/consul-api-gateway/internal/api/v1"
+	"github.com/hashicorp/consul-api-gateway/internal/common"
+	"github.com/hashicorp/consul-api-gateway/internal/testing/vm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPut_Fixtures(t *testing.T) {
+	vm.TestFixtures(t, vm.FixturesConfig{
+		Command: NewPutCommand,
+		Args: func(fixture vm.Fixture) []string {
+			return []string{fixture.InputPath}
+		},
+		Setup: func(controller *vm.Controller) {
+			// create some Consul service targets
+			_ = controller.RegisterHTTPServiceTargetWithName(t, "http-service-1")
+			_ = controller.RegisterHTTPServiceTargetWithName(t, "http-service-2")
+
+			// create a couple of TCP-based gateways and HTTP-based gateways
+			_, err := controller.Client.V1().CreateGateway(context.Background(), v1.Gateway{
+				Listeners: []v1.Listener{{
+					Name:     common.StringPtr("listener-1"),
+					Port:     9091,
+					Protocol: v1.ListenerProtocolHttp,
+				}, {
+					Name:     common.StringPtr("listener-2"),
+					Port:     9092,
+					Protocol: v1.ListenerProtocolHttp,
+				}},
+				Name: "http-1",
+			})
+			require.NoError(t, err)
+
+			_, err = controller.Client.V1().CreateGateway(context.Background(), v1.Gateway{
+				Listeners: []v1.Listener{{
+					Port:     9093,
+					Protocol: v1.ListenerProtocolHttp,
+				}, {
+					Name:     common.StringPtr("listener-2"),
+					Port:     9094,
+					Protocol: v1.ListenerProtocolHttp,
+				}},
+				Name: "http-2",
+			})
+			require.NoError(t, err)
+
+			_, err = controller.Client.V1().CreateGateway(context.Background(), v1.Gateway{
+				Listeners: []v1.Listener{{
+					Name:     common.StringPtr("listener-1"),
+					Port:     9095,
+					Protocol: v1.ListenerProtocolTcp,
+				}, {
+					Name:     common.StringPtr("listener-2"),
+					Port:     9096,
+					Protocol: v1.ListenerProtocolTcp,
+				}},
+				Name: "tcp-1",
+			})
+			require.NoError(t, err)
+		},
+	})
+}

--- a/internal/commands/tcproutes/command.go
+++ b/internal/commands/tcproutes/command.go
@@ -29,7 +29,7 @@ func RegisterCommands(ctx context.Context, commands map[string]cli.CommandFactor
 	}
 }
 
-func NewCommand() *Command {
+func NewCommand() cli.Command {
 	return &Command{}
 }
 

--- a/internal/commands/tcproutes/delete.go
+++ b/internal/commands/tcproutes/delete.go
@@ -14,7 +14,7 @@ type DeleteCommand struct {
 	*common.ClientCLIWithNamespace
 }
 
-func NewDeleteCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *DeleteCommand {
+func NewDeleteCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &DeleteCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, deleteHelp, deleteSynopsis, ui, logOutput, "delete"),
 	}

--- a/internal/commands/tcproutes/fixtures/no-gateway-output
+++ b/internal/commands/tcproutes/fixtures/no-gateway-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: gateways: value is not nullable

--- a/internal/commands/tcproutes/fixtures/no-gateway.json
+++ b/internal/commands/tcproutes/fixtures/no-gateway.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-no-gateway",
+  "services": [{
+    "name": "tcp-service-1"
+  }]
+}

--- a/internal/commands/tcproutes/fixtures/no-service-output
+++ b/internal/commands/tcproutes/fixtures/no-service-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: services: value is not nullable

--- a/internal/commands/tcproutes/fixtures/no-service.json
+++ b/internal/commands/tcproutes/fixtures/no-service.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-no-service",
+  "gateways": [{
+    "name": "tcp-1",
+    "listener": "listener-2"
+  },{
+    "name": "tcp-2"
+  }]
+}

--- a/internal/commands/tcproutes/fixtures/service-not-found-output
+++ b/internal/commands/tcproutes/fixtures/service-not-found-output
@@ -1,0 +1,5 @@
+There was an error sending the request:
+	server error - code: 400, message: 1 error occurred:
+	* no service "tcp-service-3" found
+
+

--- a/internal/commands/tcproutes/fixtures/service-not-found.json
+++ b/internal/commands/tcproutes/fixtures/service-not-found.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-service-not-found",
+  "gateways": [{
+    "name": "tcp-1",
+    "listener": "listener-2"
+  },{
+    "name": "tcp-2"
+  }],
+  "services": [{
+    "name": "tcp-service-3"
+  }]
+}

--- a/internal/commands/tcproutes/fixtures/tcp-basic-success-output
+++ b/internal/commands/tcproutes/fixtures/tcp-basic-success-output
@@ -1,0 +1,1 @@
+Successfully created route

--- a/internal/commands/tcproutes/fixtures/tcp-basic-success.json
+++ b/internal/commands/tcproutes/fixtures/tcp-basic-success.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-tcp-basic-success",
+  "gateways": [{
+    "name": "tcp-1",
+    "listener": "listener-2"
+  },{
+    "name": "tcp-2"
+  }],
+  "services": [{
+    "name": "tcp-service-1"
+  }]
+}

--- a/internal/commands/tcproutes/fixtures/tcp-multiple-services-output
+++ b/internal/commands/tcproutes/fixtures/tcp-multiple-services-output
@@ -1,0 +1,2 @@
+There was an error sending the request:
+	server error - code: 400, message: services: maximum number of items is 1; current value: "[map[name:tcp-service-1] map[name:tcp-service-2]]"

--- a/internal/commands/tcproutes/fixtures/tcp-multiple-services.json
+++ b/internal/commands/tcproutes/fixtures/tcp-multiple-services.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-tcp-multiple-services",
+  "gateways": [{
+    "name": "tcp-1",
+    "listener": "listener-2"
+  },{
+    "name": "tcp-2"
+  }],
+  "services": [{
+    "name": "tcp-service-1"
+  },{
+    "name": "tcp-service-2"
+  }]
+}

--- a/internal/commands/tcproutes/get.go
+++ b/internal/commands/tcproutes/get.go
@@ -14,7 +14,7 @@ type GetCommand struct {
 	*common.ClientCLIWithNamespace
 }
 
-func NewGetCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *GetCommand {
+func NewGetCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &GetCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, getHelp, getSynopsis, ui, logOutput, "get"),
 	}

--- a/internal/commands/tcproutes/list.go
+++ b/internal/commands/tcproutes/list.go
@@ -18,7 +18,7 @@ type ListCommand struct {
 	flagAllNamespaces bool // list from all namespaces
 }
 
-func NewListCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *ListCommand {
+func NewListCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	cmd := &ListCommand{
 		ClientCLIWithNamespace: common.NewClientCLIWithNamespace(ctx, listHelp, listSynopsis, ui, logOutput, "get"),
 	}

--- a/internal/commands/tcproutes/put.go
+++ b/internal/commands/tcproutes/put.go
@@ -16,7 +16,7 @@ type PutCommand struct {
 	*common.ClientCLI
 }
 
-func NewPutCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) *PutCommand {
+func NewPutCommand(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command {
 	return &PutCommand{
 		ClientCLI: common.NewClientCLI(ctx, putHelp, putSynopsis, ui, logOutput, "delete"),
 	}

--- a/internal/commands/tcproutes/put_test.go
+++ b/internal/commands/tcproutes/put_test.go
@@ -1,0 +1,67 @@
+package tcproutes
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/hashicorp/consul-api-gateway/internal/api/v1"
+	"github.com/hashicorp/consul-api-gateway/internal/common"
+	"github.com/hashicorp/consul-api-gateway/internal/testing/vm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPut_Fixtures(t *testing.T) {
+	vm.TestFixtures(t, vm.FixturesConfig{
+		Command: NewPutCommand,
+		Args: func(fixture vm.Fixture) []string {
+			return []string{fixture.InputPath}
+		},
+		Setup: func(controller *vm.Controller) {
+			// create some Consul service targets
+			_ = controller.RegisterTCPServiceTargetWithName(t, "tcp-service-1")
+			_ = controller.RegisterTCPServiceTargetWithName(t, "tcp-service-2")
+
+			// create a couple of TCP-based gateways and HTTP-based gateways
+			_, err := controller.Client.V1().CreateGateway(context.Background(), v1.Gateway{
+				Listeners: []v1.Listener{{
+					Name:     common.StringPtr("listener-1"),
+					Port:     9091,
+					Protocol: v1.ListenerProtocolHttp,
+				}, {
+					Name:     common.StringPtr("listener-2"),
+					Port:     9092,
+					Protocol: v1.ListenerProtocolHttp,
+				}},
+				Name: "http-1",
+			})
+			require.NoError(t, err)
+
+			_, err = controller.Client.V1().CreateGateway(context.Background(), v1.Gateway{
+				Listeners: []v1.Listener{{
+					Name:     common.StringPtr("listener-1"),
+					Port:     9095,
+					Protocol: v1.ListenerProtocolTcp,
+				}, {
+					Name:     common.StringPtr("listener-2"),
+					Port:     9096,
+					Protocol: v1.ListenerProtocolTcp,
+				}},
+				Name: "tcp-1",
+			})
+			require.NoError(t, err)
+
+			_, err = controller.Client.V1().CreateGateway(context.Background(), v1.Gateway{
+				Listeners: []v1.Listener{{
+					Port:     9097,
+					Protocol: v1.ListenerProtocolTcp,
+				}, {
+					Name:     common.StringPtr("listener-2"),
+					Port:     9098,
+					Protocol: v1.ListenerProtocolTcp,
+				}},
+				Name: "tcp-2",
+			})
+			require.NoError(t, err)
+		},
+	})
+}

--- a/internal/testing/vm/consul.go
+++ b/internal/testing/vm/consul.go
@@ -1,0 +1,67 @@
+package vm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type Consul struct {
+	Client      *api.Client
+	Config      *api.Config
+	ConnectCert string
+	Node        string
+	Token       string
+	XDSPort     int
+}
+
+func TestConsul(t *testing.T, acls bool) *Consul {
+	t.Helper()
+
+	token := uuid.New().String()
+
+	file, err := os.CreateTemp("", "bootstrap")
+	require.NoError(t, err)
+	certPath := file.Name()
+	require.NoError(t, file.Close())
+
+	consulSrv, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+		c.ACL.Enabled = acls
+		c.ACL.Tokens.InitialManagement = token
+		c.Peering = nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = consulSrv.Stop()
+		_ = os.Remove(certPath)
+	})
+	consulSrv.WaitForLeader(t)
+	consulSrv.WaitForActiveCARoot(t)
+
+	cfg := api.DefaultConfig()
+	cfg.Address = consulSrv.HTTPAddr
+	cfg.Token = token
+	consul, err := api.NewClient(cfg)
+	require.NoError(t, err)
+
+	roots, _, err := consul.Connect().CARoots(nil)
+	require.NoError(t, err)
+	for _, root := range roots.Roots {
+		if root.Active {
+			require.NoError(t, os.WriteFile(certPath, []byte(root.RootCertPEM), 0644))
+		}
+	}
+
+	return &Consul{
+		Client:      consul,
+		Token:       token,
+		Node:        consulSrv.Config.NodeID,
+		Config:      cfg,
+		XDSPort:     consulSrv.Config.Ports.GRPC,
+		ConnectCert: certPath,
+	}
+}

--- a/internal/testing/vm/consul_test.go
+++ b/internal/testing/vm/consul_test.go
@@ -1,0 +1,23 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TestConsul(t *testing.T) {
+	consul := TestConsul(t, true)
+
+	_, err := consul.Client.KV().Put(&api.KVPair{
+		Key:   "foo",
+		Value: []byte("bar"),
+	}, nil)
+	require.NoError(t, err)
+
+	kv, _, err := consul.Client.KV().Get("foo", nil)
+	require.NoError(t, err)
+
+	require.Equal(t, "bar", string(kv.Value))
+}

--- a/internal/testing/vm/fixtures.go
+++ b/internal/testing/vm/fixtures.go
@@ -1,0 +1,106 @@
+package vm
+
+import (
+	"context"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	generate bool
+)
+
+func init() {
+	if os.Getenv("GENERATE") == "true" {
+		generate = true
+	}
+}
+
+type Fixture struct {
+	Name       string
+	ExitCode   int
+	InputPath  string
+	OutputPath string
+}
+
+type FixturesConfig struct {
+	Command func(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command
+	Args    func(fixture Fixture) []string
+	Setup   func(controller *Controller)
+}
+
+func TestFixtures(t *testing.T, config FixturesConfig) {
+	t.Helper()
+
+	controller := TestController(t)
+
+	if config.Setup != nil {
+		config.Setup(controller)
+	}
+
+	for _, fixture := range getFixtures(t) {
+		fixture := fixture
+
+		t.Run(fixture.Name, func(t *testing.T) {
+			t.Parallel()
+
+			args := []string{}
+			if config.Args != nil {
+				args = config.Args(fixture)
+			}
+
+			controller.RunCLI(t, CLITest{
+				Command:    config.Command,
+				ExitStatus: fixture.ExitCode,
+				Args:       args,
+				OutputCheck: func(t *testing.T, output string) {
+					if generate {
+						require.NoError(t, os.WriteFile(fixture.OutputPath, []byte(output), 0644))
+					}
+					data, err := os.ReadFile(fixture.OutputPath)
+					require.NoError(t, err)
+
+					expected := string(data)
+					assert.Equal(t, expected, output)
+				},
+			})
+		})
+	}
+}
+
+func getFixtures(t *testing.T) []Fixture {
+	t.Helper()
+
+	files, err := os.ReadDir(path.Join("fixtures"))
+	require.NoError(t, err)
+
+	fixtures := []Fixture{}
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(file.Name(), ".json") {
+			name := strings.TrimSuffix(file.Name(), ".json")
+
+			exitCode := 1
+			if strings.Contains(name, "success") {
+				exitCode = 0
+			}
+
+			fixtures = append(fixtures, Fixture{
+				Name:       name,
+				ExitCode:   exitCode,
+				InputPath:  path.Join("fixtures", file.Name()),
+				OutputPath: path.Join("fixtures", name+"-output"),
+			})
+		}
+	}
+	return fixtures
+}

--- a/internal/testing/vm/server.go
+++ b/internal/testing/vm/server.go
@@ -1,0 +1,235 @@
+package vm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/google/uuid"
+	"github.com/hashicorp/consul-api-gateway/internal/api"
+	"github.com/hashicorp/consul-api-gateway/internal/commands/controller"
+	"github.com/hashicorp/consul-api-gateway/internal/commands/deployment"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Controller struct {
+	Consul *Consul
+	Vault  *Vault
+
+	Client *api.Client
+	Port   int
+
+	ctx context.Context
+}
+
+func TestController(t *testing.T) *Controller {
+	t.Helper()
+
+	consul := TestConsul(t, true)
+	vault := TestVault(t)
+	return runController(t, context.Background(), vault, consul)
+}
+
+func (c *Controller) PeerController(t *testing.T) *Controller {
+	t.Helper()
+
+	return runController(t, c.ctx, c.Vault, c.Consul)
+}
+
+func runController(t *testing.T, ctx context.Context, vault *Vault, consul *Consul) *Controller {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(ctx)
+	command := controller.NewCommand(ctx, cli.NewMockUi(), io.Discard)
+
+	ports := freeport.MustTake(4)
+	apiPort := ports[0]
+	sdsPort := ports[1]
+	metricsPort := ports[2]
+	profPort := ports[3]
+
+	go func() {
+		_ = command.Run([]string{
+			"-gateway-controller-port", strconv.Itoa(apiPort),
+			"-sds-port", strconv.Itoa(sdsPort),
+			"-debug-metrics-port", strconv.Itoa(metricsPort),
+			"-debug-pprof-port", strconv.Itoa(profPort),
+			"-consul-address", consul.Config.Address,
+			"-consul-xds-port", strconv.Itoa(consul.XDSPort),
+			"-consul-token", consul.Token,
+			"-vault-address", vault.Config.Address,
+			"-vault-token", vault.Token,
+			"-vault-mount", "secret",
+		})
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+	})
+
+	client, err := api.CreateClient(api.ClientConfig{
+		Address: "127.0.0.1",
+		Port:    uint(apiPort),
+		Token:   consul.Token,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, backoff.Retry(func() error {
+		_, err := client.V1().Health(context.Background())
+		return err
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 10)))
+
+	return &Controller{
+		Consul: consul,
+		Vault:  vault,
+		Client: client,
+		Port:   apiPort,
+		ctx:    ctx,
+	}
+}
+
+func (c *Controller) Deployment(t *testing.T, name, token string) {
+	t.Helper()
+
+	var wg sync.WaitGroup
+
+	ctx, cancel := context.WithCancel(context.Background())
+	command := deployment.NewCommand(ctx, cli.NewMockUi(), io.Discard)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		_ = command.Run([]string{
+			"-gateway-ip", "127.0.0.1",
+			"-gateway-controller-token", token,
+			"-gateway-controller-port", strconv.Itoa(c.Port),
+		})
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	require.NoError(t, backoff.Retry(func() error {
+		services, _, err := c.Consul.Client.Catalog().Service(name, "", nil)
+		if err != nil {
+			return err
+		}
+		if len(services) == 0 {
+			return errors.New("service not found")
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 10)))
+}
+
+type CLITest struct {
+	Command     func(ctx context.Context, ui cli.Ui, logOutput io.Writer) cli.Command
+	ExitStatus  int
+	Args        []string
+	OutputCheck func(t *testing.T, output string)
+	Timeout     time.Duration
+}
+
+func (c *Controller) RunCLI(t *testing.T, tt CLITest) {
+	t.Helper()
+
+	timeout := tt.Timeout
+	if timeout == 0 {
+		timeout = 10 * time.Second
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var buffer bytes.Buffer
+	command := tt.Command(ctx, &cli.BasicUi{Writer: &buffer, ErrorWriter: &buffer}, &buffer)
+	assert.Equal(t, tt.ExitStatus, command.Run(append([]string{
+		"-log-level", "error",
+		"-consul-token", c.Consul.Token,
+		"-gateway-controller-port", strconv.Itoa(c.Port),
+	}, tt.Args...)))
+
+	if tt.OutputCheck != nil {
+		tt.OutputCheck(t, buffer.String())
+	}
+}
+
+func (c *Controller) RegisterHTTPServiceTarget(t *testing.T) *ProxyTarget {
+	t.Helper()
+
+	return c.registerServiceTargetWithName(t, "http", uuid.New().String())
+}
+
+func (c *Controller) RegisterHTTPServiceTargetWithName(t *testing.T, name string) *ProxyTarget {
+	t.Helper()
+
+	return c.registerServiceTargetWithName(t, "http", name)
+}
+
+func (c *Controller) RegisterTCPServiceTarget(t *testing.T) *ProxyTarget {
+	t.Helper()
+
+	return c.registerServiceTargetWithName(t, "tcp", uuid.New().String())
+}
+
+func (c *Controller) RegisterTCPServiceTargetWithName(t *testing.T, name string) *ProxyTarget {
+	t.Helper()
+
+	return c.registerServiceTargetWithName(t, "tcp", name)
+}
+
+func (c *Controller) registerServiceTargetWithName(t *testing.T, protocol, name string) *ProxyTarget {
+	t.Helper()
+
+	template := httpBootstrapTemplate
+	if protocol == "tcp" {
+		template = tcpBootstrapTemplate
+	}
+
+	target := c.runProxyTarget(t, name, template)
+
+	client := c.Consul.Client
+
+	registration := &consulapi.AgentServiceRegistration{
+		ID:      target.Name,
+		Name:    target.Name,
+		Port:    target.Port,
+		Address: "127.0.0.1",
+	}
+	require.NoError(t, client.Agent().ServiceRegisterOpts(registration, consulapi.ServiceRegisterOpts{}))
+
+	_, _, err := client.ConfigEntries().Set(&consulapi.ServiceConfigEntry{
+		Kind:     consulapi.ServiceDefaults,
+		Name:     target.Name,
+		Protocol: protocol,
+	}, nil)
+	require.NoError(t, err)
+
+	proxyRegistration := &consulapi.AgentServiceRegistration{
+		Kind: consulapi.ServiceKindConnectProxy,
+		ID:   target.Name,
+		Name: target.Name,
+		Port: target.ProxyPort,
+		Proxy: &consulapi.AgentServiceConnectProxyConfig{
+			DestinationServiceName: target.Name,
+			LocalServiceAddress:    "127.0.0.1",
+			LocalServicePort:       target.Port,
+		},
+		Address: "127.0.0.1",
+	}
+	require.NoError(t, client.Agent().ServiceRegisterOpts(proxyRegistration, consulapi.ServiceRegisterOpts{}))
+
+	return target
+}

--- a/internal/testing/vm/server_test.go
+++ b/internal/testing/vm/server_test.go
@@ -1,0 +1,52 @@
+package vm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TestController(t *testing.T) {
+	controller := TestController(t)
+
+	_, err := controller.Client.V1().Health(context.Background())
+	require.NoError(t, err)
+
+	name := "stub-deployment" // this should come from a created gateway.Name attribute
+	token := "token"          // this should come from token minting
+	controller.Deployment(t, name, token)
+
+	// check gateway registration
+	services, _, err := controller.Consul.Client.Catalog().Service(name, "", nil)
+	require.NoError(t, err)
+	require.Len(t, services, 1)
+
+	// check the target registration routines
+	target := controller.RegisterHTTPServiceTarget(t)
+	require.NoError(t, backoff.Retry(func() error {
+		services, _, err := controller.Consul.Client.Catalog().Service(target.Name, "", nil)
+		if err != nil {
+			return err
+		}
+		if len(services) != 1 {
+			return errors.New("proxy target not found")
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 10)))
+
+	target = controller.RegisterTCPServiceTarget(t)
+	require.NoError(t, backoff.Retry(func() error {
+		services, _, err := controller.Consul.Client.Catalog().Service(target.Name, "", nil)
+		if err != nil {
+			return err
+		}
+		if len(services) != 1 {
+			return errors.New("proxy target not found")
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 10)))
+}

--- a/internal/testing/vm/template.go
+++ b/internal/testing/vm/template.go
@@ -1,0 +1,290 @@
+package vm
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"text/template"
+
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	tcpBootstrapTemplate  *template.Template
+	httpBootstrapTemplate *template.Template
+)
+
+func init() {
+	tcpBootstrapTemplate = template.Must(template.New("tcp-bootstrap").Parse(tcpBootstrapJSONTemplate))
+	httpBootstrapTemplate = template.Must(template.New("http-bootstrap").Parse(httpBootstrapJSONTemplate))
+}
+
+type bootstrapArgs struct {
+	ID            string
+	Token         string
+	ConsulXDSPort int
+	Port          int
+	CertFile      string
+}
+
+type ProxyTarget struct {
+	Name      string
+	Port      int
+	ProxyPort int
+}
+
+func (c *Controller) runProxyTarget(t *testing.T, name string, template *template.Template) *ProxyTarget {
+	t.Helper()
+
+	envoyBinary, err := exec.LookPath("envoy")
+	require.NoError(t, err)
+
+	name, path, port, proxyPort := c.renderBootstrap(t, name, template)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, envoyBinary, "-c", path, "--log-level", "error")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Start())
+
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cancel()
+	})
+
+	return &ProxyTarget{
+		Name:      name,
+		Port:      port,
+		ProxyPort: proxyPort,
+	}
+}
+
+func (c *Controller) renderBootstrap(t *testing.T, name string, template *template.Template) (string, string, int, int) {
+	t.Helper()
+
+	ports := freeport.MustTake(2)
+	port := ports[0]
+	proxyPort := ports[1]
+
+	file, err := os.CreateTemp("", "bootstrap")
+	require.NoError(t, err)
+
+	path := file.Name()
+	require.NoError(t, file.Close())
+
+	t.Cleanup(func() {
+		_ = os.Remove(path)
+	})
+
+	var data bytes.Buffer
+	require.NoError(t, template.Execute(&data, &bootstrapArgs{
+		ID:            name,
+		Token:         c.Consul.Token,
+		ConsulXDSPort: c.Consul.XDSPort,
+		Port:          port,
+		// interestingly the gRPC port using testutil is not TLS
+		CertFile: c.Consul.ConnectCert,
+	}))
+	require.NoError(t, os.WriteFile(path, data.Bytes(), 0644))
+
+	return name, path, port, proxyPort
+}
+
+const (
+	httpBootstrapJSONTemplate = `{
+	"admin": {},
+	"node": {
+		"cluster": "{{ .ID }}",
+		"id": "{{ .ID }}",
+		"metadata": {
+			"namespace": "default"
+		}
+	},
+	"static_resources": {
+		"listeners": [{
+			"name": "static",
+			"address": {
+				"socket_address": {
+					"address": "127.0.0.1",
+					"port_value": {{ .Port }}
+				}
+			},
+			"filter_chains": [{
+				"filters": [{
+					"name": "envoy.filters.network.http_connection_manager",
+					"typed_config": {
+						"@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+						"stat_prefix": "edge",
+						"http_filters": [{
+							"name": "envoy.filters.http.router",
+							"typed_config": {
+								"@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+							}
+						}],
+						"route_config": {
+							"virtual_hosts": [{
+								"name": "direct_response",
+								"domains": ["*"],
+								"routes": [{
+									"match": {
+										"prefix": "/"
+									},
+									"direct_response": {
+										"status": 200,
+										"body": {
+											"inline_string": "{{ .ID }}"
+										}
+									}
+								}]
+							}]	
+						}
+					}
+				}]
+			}]
+		}],
+		"clusters": [
+			{
+				"name": "consul-server",
+				"ignore_health_on_host_removal": false,
+				"connect_timeout": "1s",
+				"type": "STATIC",
+				"http2_protocol_options": {},
+				"loadAssignment": {
+					"clusterName": "consul-server",
+					"endpoints": [
+						{
+							"lbEndpoints": [
+								{
+									"endpoint": {
+										"address": {
+											"socket_address": {
+												"address": "127.0.0.1",
+												"port_value": {{ .ConsulXDSPort }}
+											}
+										}
+									}
+								}
+							]
+						}
+					]
+				}
+			}
+		]
+	},
+	"dynamic_resources": {
+		"lds_config": {
+			"ads": {},
+			"resource_api_version": "V3"
+		},
+		"cds_config": {
+			"ads": {},
+			"resource_api_version": "V3"
+		},
+		"ads_config": {
+			"api_type": "DELTA_GRPC",
+			"transport_api_version": "V3",
+			"grpc_services": {
+				"initial_metadata": [
+					{
+						"key": "x-consul-token",
+						"value": "{{ .Token }}"
+					}
+				],
+				"envoy_grpc": {
+					"cluster_name": "consul-server"
+				}
+			}
+		}
+	}
+}
+`
+	tcpBootstrapJSONTemplate = `{
+	"admin": {},
+	"node": {
+		"cluster": "{{ .ID }}",
+		"id": "{{ .ID }}",
+		"metadata": {
+			"namespace": "default"
+		}
+	},
+	"static_resources": {
+		"listeners": [{
+			"name": "static",
+			"address": {
+				"socket_address": {
+					"address": "127.0.0.1",
+					"port_value": {{ .Port }}
+				}
+			},
+			"filter_chains": [{
+				"filters": [{
+					"name": "envoy.filters.network.direct_response",
+					"typed_config": {
+						"@type": "type.googleapis.com/envoy.extensions.filters.network.direct_response.v3.Config",
+						"response": {
+							"inline_string": "{{ .ID }}"
+						}
+					}
+				}]
+			}]
+		}],
+		"clusters": [
+			{
+				"name": "consul-server",
+				"ignore_health_on_host_removal": false,
+				"connect_timeout": "1s",
+				"type": "STATIC",
+				"http2_protocol_options": {},
+				"loadAssignment": {
+					"clusterName": "consul-server",
+					"endpoints": [
+						{
+							"lbEndpoints": [
+								{
+									"endpoint": {
+										"address": {
+											"socket_address": {
+												"address": "127.0.0.1",
+												"port_value": {{ .ConsulXDSPort }}
+											}
+										}
+									}
+								}
+							]
+						}
+					]
+				}
+			}
+		]
+	},
+	"dynamic_resources": {
+		"lds_config": {
+			"ads": {},
+			"resource_api_version": "V3"
+		},
+		"cds_config": {
+			"ads": {},
+			"resource_api_version": "V3"
+		},
+		"ads_config": {
+			"api_type": "DELTA_GRPC",
+			"transport_api_version": "V3",
+			"grpc_services": {
+				"initial_metadata": [
+					{
+						"key": "x-consul-token",
+						"value": "{{ .Token }}"
+					}
+				],
+				"envoy_grpc": {
+					"cluster_name": "consul-server"
+				}
+			}
+		}
+	}
+}
+`
+)

--- a/internal/testing/vm/vault.go
+++ b/internal/testing/vm/vault.go
@@ -1,0 +1,60 @@
+package vm
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/google/uuid"
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/require"
+)
+
+type Vault struct {
+	Client *api.Client
+	Config *api.Config
+	Token  string
+}
+
+func TestVault(t *testing.T) *Vault {
+	t.Helper()
+
+	vault, err := exec.LookPath("vault")
+	require.NoError(t, err)
+
+	token := uuid.New().String()
+
+	port := freeport.MustTake(1)[0]
+	address := fmt.Sprintf("127.0.0.1:%d", port)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, vault, "server", "-dev", "-dev-listen-address", address, "-dev-no-store-token", "-dev-no-store-token", "-dev-root-token-id", token)
+	require.NoError(t, cmd.Start())
+
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cancel()
+	})
+
+	config := &api.Config{
+		Address: "http://" + address,
+	}
+	client, err := api.NewClient(config)
+	require.NoError(t, err)
+	client.SetToken(token)
+
+	require.NoError(t, backoff.Retry(func() error {
+		_, err := client.Sys().Health()
+		return err
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 10)))
+
+	return &Vault{
+		Client: client,
+		Token:  token,
+		Config: config,
+	}
+}

--- a/internal/testing/vm/vault_test.go
+++ b/internal/testing/vm/vault_test.go
@@ -1,0 +1,25 @@
+package vm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TestVault(t *testing.T) {
+	vault := TestVault(t)
+
+	require.NoError(t, vault.Client.Sys().Mount("mount", &api.MountInput{Type: "kv-v2"}))
+
+	_, err := vault.Client.KVv2("mount").Put(context.Background(), "foo", map[string]interface{}{
+		"bar": "baz",
+	})
+	require.NoError(t, err)
+
+	secret, err := vault.Client.KVv2("mount").Get(context.Background(), "foo")
+	require.NoError(t, err)
+
+	require.Equal(t, "baz", secret.Data["bar"])
+}


### PR DESCRIPTION
### Changes proposed in this PR:

This adds an e2e testing framework + e2e tests for our binary entrypoints. Opening it just to get eyes on it, but it'll fail until I add Vault + Envoy installation into our github workflow setup, since the tests run them as external binaries.

### Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
