### PR TITLE
Specify primary datacenter for root cert watch

### DIFF
--- a/.changelog/368.txt
+++ b/.changelog/368.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix failing root certificate watch for controller when deployed in secondary federated datacenter.
+```

--- a/internal/commands/exec/command.go
+++ b/internal/commands/exec/command.go
@@ -14,9 +14,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/mitchellh/cli"
 
-	"github.com/hashicorp/consul-api-gateway/internal/common"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul-api-gateway/internal/common"
 )
 
 // https://github.com/hashicorp/consul-k8s/blob/24be51c58461e71365ca39f113dae0379f7a1b7c/control-plane/connect-inject/container_init.go#L272-L306
@@ -39,10 +40,11 @@ type Command struct {
 	isTest bool
 
 	// Consul params
-	flagConsulHTTPAddress string // Address for Consul HTTP API.
-	flagConsulHTTPPort    int    // Port for Consul HTTP communication
-	flagConsulCACertFile  string // Root CA file for Consul
-	flagConsulXDSPort     int    // Port for Consul xDS communication
+	flagConsulHTTPAddress       string // Address for Consul HTTP API.
+	flagConsulHTTPPort          int    // Port for Consul HTTP communication
+	flagConsulCACertFile        string // Root CA file for Consul
+	flagConsulXDSPort           int    // Port for Consul xDS communication
+	flagConsulPrimaryDatacenter string // Name of the primary datacenter if deploying into a secondary datacenter
 
 	// Gateway params
 	flagGatewayID        string // Gateway iD.
@@ -86,6 +88,7 @@ func (c *Command) init() {
 		c.flagSet.IntVar(&c.flagConsulHTTPPort, "consul-http-port", 8500, "Port of Consul HTTP server.")
 		c.flagSet.IntVar(&c.flagConsulXDSPort, "consul-xds-port", 8502, "Port of Consul xDS server.")
 		c.flagSet.StringVar(&c.flagConsulCACertFile, "consul-ca-cert-file", "", "CA Root file for Consul.")
+		c.flagSet.StringVar(&c.flagConsulPrimaryDatacenter, "consul-primary-datacenter", "", "Primary datacenter if deploying into a secondary datacenter.")
 	}
 	{
 		// Envoy
@@ -163,11 +166,12 @@ func (c *Command) Run(args []string) (ret int) {
 	}
 
 	return RunExec(ExecConfig{
-		Context:      c.ctx,
-		Logger:       logger,
-		LogLevel:     c.flagLogLevel,
-		ConsulClient: consulClient,
-		ConsulConfig: *cfg,
+		Context:           c.ctx,
+		Logger:            logger,
+		LogLevel:          c.flagLogLevel,
+		ConsulClient:      consulClient,
+		ConsulConfig:      *cfg,
+		PrimaryDatacenter: c.flagConsulPrimaryDatacenter,
 		AuthConfig: AuthConfig{
 			Method:    c.flagACLAuthMethod,
 			Namespace: c.flagAuthMethodNamespace,

--- a/internal/commands/exec/exec.go
+++ b/internal/commands/exec/exec.go
@@ -11,10 +11,11 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/hashicorp/consul-api-gateway/internal/consul"
-	"github.com/hashicorp/consul-api-gateway/internal/envoy"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul-api-gateway/internal/consul"
+	"github.com/hashicorp/consul-api-gateway/internal/envoy"
 )
 
 type AuthConfig struct {
@@ -43,14 +44,15 @@ type EnvoyConfig struct {
 }
 
 type ExecConfig struct {
-	Context       context.Context
-	Logger        hclog.Logger
-	LogLevel      string
-	ConsulClient  *api.Client
-	ConsulConfig  api.Config
-	AuthConfig    AuthConfig
-	GatewayConfig GatewayConfig
-	EnvoyConfig   EnvoyConfig
+	Context           context.Context
+	Logger            hclog.Logger
+	LogLevel          string
+	ConsulClient      *api.Client
+	ConsulConfig      api.Config
+	AuthConfig        AuthConfig
+	GatewayConfig     GatewayConfig
+	EnvoyConfig       EnvoyConfig
+	PrimaryDatacenter string
 
 	// for testing only
 	isTest bool
@@ -140,6 +142,7 @@ func RunExec(config ExecConfig) (ret int) {
 		},
 	)
 	options := consul.DefaultCertManagerOptions()
+	options.PrimaryDatacenter = config.PrimaryDatacenter
 	options.SDSAddress = config.EnvoyConfig.SDSAddress
 	options.SDSPort = config.EnvoyConfig.SDSPort
 	options.Directory = "/certs"

--- a/internal/commands/server/command.go
+++ b/internal/commands/server/command.go
@@ -39,6 +39,8 @@ type Command struct {
 
 	flagConsulAddress string // Consul server address
 
+	flagPrimaryDatacenter string // Primary datacenter, may or may not be the datacenter this controller is running in
+
 	flagSDSServerHost string // SDS server host
 	flagSDSServerPort int    // SDS server port
 	flagMetricsPort   int    // Port for prometheus metrics
@@ -70,6 +72,7 @@ func (c *Command) init() {
 	c.flagSet.StringVar(&c.flagCASecret, "ca-secret", "", "CA Secret for Consul server.")
 	c.flagSet.StringVar(&c.flagCASecretNamespace, "ca-secret-namespace", "default", "CA Secret namespace for Consul server.")
 	c.flagSet.StringVar(&c.flagConsulAddress, "consul-address", "", "Consul Address.")
+	c.flagSet.StringVar(&c.flagPrimaryDatacenter, "primary-datacenter", "", "Name of the primary Consul datacenter")
 	c.flagSet.StringVar(&c.flagSDSServerHost, "sds-server-host", defaultSDSServerHost, "SDS Server Host.")
 	c.flagSet.StringVar(&c.flagK8sContext, "k8s-context", "", "Kubernetes context to use.")
 	c.flagSet.StringVar(&c.flagK8sNamespace, "k8s-namespace", "", "Kubernetes namespace to use.")
@@ -164,13 +167,14 @@ func (c *Command) Run(args []string) int {
 	}
 
 	return RunServer(ServerConfig{
-		Context:       context.Background(),
-		Logger:        logger,
-		ConsulConfig:  consulCfg,
-		K8sConfig:     cfg,
-		ProfilingPort: c.flagPprofPort,
-		MetricsPort:   c.flagMetricsPort,
-		isTest:        c.isTest,
+		Context:           context.Background(),
+		Logger:            logger,
+		ConsulConfig:      consulCfg,
+		K8sConfig:         cfg,
+		ProfilingPort:     c.flagPprofPort,
+		MetricsPort:       c.flagMetricsPort,
+		PrimaryDatacenter: c.flagPrimaryDatacenter,
+		isTest:            c.isTest,
 	})
 }
 

--- a/internal/commands/server/command.go
+++ b/internal/commands/server/command.go
@@ -122,6 +122,7 @@ func (c *Command) Run(args []string) int {
 	cfg.SDSServerHost = c.flagSDSServerHost
 	cfg.SDSServerPort = c.flagSDSServerPort
 	cfg.Namespace = c.flagK8sNamespace
+	cfg.PrimaryDatacenter = c.flagPrimaryDatacenter
 
 	consulCfg := api.DefaultConfig()
 	if c.flagCAFile != "" {

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -24,12 +24,13 @@ import (
 )
 
 type ServerConfig struct {
-	Context       context.Context
-	Logger        hclog.Logger
-	ConsulConfig  *api.Config
-	K8sConfig     *k8s.Config
-	ProfilingPort int
-	MetricsPort   int
+	Context           context.Context
+	Logger            hclog.Logger
+	ConsulConfig      *api.Config
+	K8sConfig         *k8s.Config
+	ProfilingPort     int
+	MetricsPort       int
+	PrimaryDatacenter string
 
 	// for testing only
 	isTest bool
@@ -72,6 +73,8 @@ func RunServer(config ServerConfig) int {
 	controller.SetStore(store)
 
 	options := consul.DefaultCertManagerOptions()
+	options.PrimaryDatacenter = config.PrimaryDatacenter
+
 	certManager := consul.NewCertManager(
 		config.Logger.Named("cert-manager"),
 		consulClient,

--- a/internal/k8s/builder/gateway.go
+++ b/internal/k8s/builder/gateway.go
@@ -394,7 +394,7 @@ exec /bootstrap/consul-api-gateway exec -log-json \
   -acl-auth-method {{ .ACLAuthMethod }} \
 {{- end }}
 {{- if .PrimaryDatacenter }}
-  -primary-datacenter {{ .PrimaryDatacenter }}
+  -consul-primary-datacenter {{ .PrimaryDatacenter }} \
 {{- end }}
   -envoy-bootstrap-path /bootstrap/envoy.json \
   -envoy-sds-address {{ .SDSHost }} \

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -69,6 +69,7 @@ type Kubernetes struct {
 
 type Config struct {
 	CACert              string
+	PrimaryDatacenter   string
 	SDSServerHost       string
 	SDSServerPort       int
 	MetricsBindAddr     string
@@ -154,6 +155,7 @@ func (k *Kubernetes) Start(ctx context.Context) error {
 		Client:                gwClient,
 		Consul:                k.consul,
 		ConsulCA:              k.config.CACert,
+		PrimaryDatacenter:     k.config.PrimaryDatacenter,
 		SDSHost:               k.config.SDSServerHost,
 		SDSPort:               k.config.SDSServerPort,
 		Logger:                k.logger.Named("Reconciler"),

--- a/internal/k8s/reconciler/deployer.go
+++ b/internal/k8s/reconciler/deployer.go
@@ -18,29 +18,32 @@ import (
 
 // GatewayDeployer creates gateway deployments and services and ensures that they exist
 type GatewayDeployer struct {
-	client   gatewayclient.Client
-	consulCA string
-	sdsHost  string
-	sdsPort  int
+	client            gatewayclient.Client
+	consulCA          string
+	primaryDatacenter string
+	sdsHost           string
+	sdsPort           int
 
 	logger hclog.Logger
 }
 
 type DeployerConfig struct {
-	ConsulCA string
-	SDSHost  string
-	SDSPort  int
-	Logger   hclog.Logger
-	Client   gatewayclient.Client
+	ConsulCA          string
+	PrimaryDatacenter string
+	SDSHost           string
+	SDSPort           int
+	Logger            hclog.Logger
+	Client            gatewayclient.Client
 }
 
 func NewDeployer(config DeployerConfig) *GatewayDeployer {
 	return &GatewayDeployer{
-		client:   config.Client,
-		consulCA: config.ConsulCA,
-		sdsHost:  config.SDSHost,
-		sdsPort:  config.SDSPort,
-		logger:   config.Logger,
+		client:            config.Client,
+		consulCA:          config.ConsulCA,
+		primaryDatacenter: config.PrimaryDatacenter,
+		sdsHost:           config.SDSHost,
+		sdsPort:           config.SDSPort,
+		logger:            config.Logger,
 	}
 }
 
@@ -129,6 +132,7 @@ func (d *GatewayDeployer) Deployment(namespace string, config apigwv1alpha1.Gate
 	deploymentBuilder.WithClassConfig(config)
 	deploymentBuilder.WithConsulCA(d.consulCA)
 	deploymentBuilder.WithConsulGatewayNamespace(namespace)
+	deploymentBuilder.WithPrimaryConsulDatacenter(d.primaryDatacenter)
 	return deploymentBuilder.Build(currentReplicas)
 }
 

--- a/internal/k8s/reconciler/manager.go
+++ b/internal/k8s/reconciler/manager.go
@@ -68,6 +68,7 @@ type ManagerConfig struct {
 	Client                gatewayclient.Client
 	Consul                *api.Client
 	ConsulCA              string
+	PrimaryDatacenter     string
 	SDSHost               string
 	SDSPort               int
 	Store                 store.Store
@@ -78,11 +79,12 @@ type ManagerConfig struct {
 func NewReconcileManager(config ManagerConfig) *GatewayReconcileManager {
 	resolver := service.NewBackendResolver(config.Logger, config.ConsulNamespaceMapper, config.Client, config.Consul)
 	deployer := NewDeployer(DeployerConfig{
-		ConsulCA: config.ConsulCA,
-		SDSHost:  config.SDSHost,
-		SDSPort:  config.SDSPort,
-		Logger:   config.Logger,
-		Client:   config.Client,
+		ConsulCA:          config.ConsulCA,
+		PrimaryDatacenter: config.PrimaryDatacenter,
+		SDSHost:           config.SDSHost,
+		SDSPort:           config.SDSPort,
+		Logger:            config.Logger,
+		Client:            config.Client,
 	})
 
 	return &GatewayReconcileManager{


### PR DESCRIPTION
Fixes #361 

### Changes proposed in this PR:
In order to successfully watch root certs from a secondary datacenter, we must specify the name of the primary datacenter when setting up the watch. This requires that we accept the primary datacenter name as a flag when starting the controller. The other changes in this PR are just to plumb that value down into the watch initialization.

### How I've tested this PR:
1. Federate between 2 Kubernetes clusters as described in [this guide](https://www.consul.io/docs/k8s/deployment-configurations/multi-cluster/kubernetes), making sure to enable API gateway in both the primary and secondary clusters
    1. `apiGateway.enabled: true`
    2. `apiGateway.image: hashicorp/consul-api-gateway:0.4.0`
    3. `global.imageK8S: hashicorpdev/consul-k8s-control-plane:f1a9304a` (build from https://github.com/hashicorp/consul-k8s/pull/1481)
2. Create a `Gateway` in the secondary cluster and apply routes targeting services in the same cluster (I use the stack from [this Learn guide](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway))
3. Verify that you can reach these services. For the Learn guide, grab the IP from the `Gateway` status and visit `https://<ip>:8443`

<details>
<summary>Results from completing the above</summary>

```shell
➜  local git:(main) ✗ # In the secondary federated cluster
➜  local git:(main) ✗ kubectl config current-context
dc2
➜  local git:(main) ✗
➜  local git:(main) ✗ # Successfully deployed gateway
➜  local git:(main) ✗ k get gateway api-gateway -o yaml | yq .status
addresses:
  - type: IPAddress
    value: 34.66.212.71
conditions:
  - lastTransitionTime: "2022-09-15T19:36:12Z"
    message: Ready
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: Ready
  - lastTransitionTime: "2022-09-15T19:36:12Z"
    message: Scheduled
    observedGeneration: 1
    reason: Scheduled
    status: "True"
    type: Scheduled
  - lastTransitionTime: "2022-09-15T19:36:12Z"
    message: InSync
    observedGeneration: 1
    reason: InSync
    status: "True"
    type: InSync
listeners:
  - attachedRoutes: 2
    conditions:
      - lastTransitionTime: "2022-09-15T19:44:01Z"
        message: NoConflicts
        observedGeneration: 1
        reason: NoConflicts
        status: "False"
        type: Conflicted
      - lastTransitionTime: "2022-09-15T19:44:01Z"
        message: Attached
        observedGeneration: 1
        reason: Attached
        status: "False"
        type: Detached
      - lastTransitionTime: "2022-09-15T19:44:01Z"
        message: Ready
        observedGeneration: 1
        reason: Ready
        status: "True"
        type: Ready
      - lastTransitionTime: "2022-09-15T19:44:01Z"
        message: ResolvedRefs
        observedGeneration: 1
        reason: ResolvedRefs
        status: "True"
        type: ResolvedRefs
    name: https
    supportedKinds:
      - group: gateway.networking.k8s.io
        kind: HTTPRoute
➜  local git:(main) ✗
➜  local git:(main) ✗ # Can reach hashicups through the gateway
➜  local git:(main) ✗ curl https://34.66.212.71:8443 --insecure
<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width"/><meta charSet="utf-8"/><script>!function(){try {var d=document.documentElement.classList;d.remove('dark','light','dark','light');var e=localStorage.getItem('theme');if("system"===e||(!e&&true)){var t="(prefers-color-scheme: dark)",m=window.matchMedia(t);m.media!==t||m.matches?d.add('dark'):d.add('light')}else if(e) var x={"dark":"dark","light":"light","autoDark":"dark","autoLight":"light"};d.add(x[e])}catch(e){}}()</script><title>HashiCups - Demo App</title>...
```

</details>

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
