### PR TITLE
Register via TTL check for nodes with no agents

### DIFF
--- a/.changelog/371.txt
+++ b/.changelog/371.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Switch deployed gateways to use TTL-based health checks to better support running with Consul servers that are not on the same network as a gateway
+```

--- a/internal/commands/exec/exec.go
+++ b/internal/commands/exec/exec.go
@@ -108,7 +108,7 @@ func RunExec(config ExecConfig) (ret int) {
 	}
 
 	config.Logger.Trace("registering service")
-	if err := registry.RegisterGateway(ctx, false); err != nil {
+	if err := registry.RegisterGateway(ctx, true); err != nil {
 		config.Logger.Error("error registering service", "error", err)
 		return 1
 	}


### PR DESCRIPTION
### Changes proposed in this PR:

This swaps the health check that's registered as part of the exec process to use TTL-based checks in Consul.

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
