### PR TITLE
remove acl tokens on shutdown in exec

### DIFF
--- a/.changelog/376.txt
+++ b/.changelog/376.txt
@@ -1,0 +1,3 @@
+```release-note:bug-fix
+Delete gateway ACL tokens on shutdown so they are not orphaned after being provisioned at startup.
+```

--- a/.changelog/376.txt
+++ b/.changelog/376.txt
@@ -1,3 +1,3 @@
-```release-note:bug-fix
+```release-note:bug
 Delete gateway ACL tokens on shutdown so they are not orphaned after being provisioned at startup.
 ```


### PR DESCRIPTION
### Changes proposed in this PR:
We currently provision ACL tokens for each gateway on startup but do not clean them up this leads to abandoned ACL tokens for each gateway that restarts, every time the pod restarts.

### How I've tested this PR:
Manually deployed consul with ACLs enabled and api-gateway based on this branch, deployed a sample api-gw instance and checked the ACL tokens in Consul in the UI while deleting the gateway pod repeatedly.
Added a unit test.

### How I expect reviewers to test this PR:
- I can add a happy-path unit test but didnt see that as a pattern yet, happy to do this.
- Unit + manual test
- 👀 

### Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
