### PR TITLE
makefile: switch back from fork to main go-changelog repo

### DIFF
--- a/.changelog/385.txt
+++ b/.changelog/385.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+makefile: switch back to upstream go-changelog repo
+```

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,7 @@ endif
 .PHONY: changelog-check
 changelog-check:
 ifeq (, $(shell which changelog-check))
-	@rm -rf go-changelog
-	@git clone -b changelog-check https://github.com/mikemorris/go-changelog
-	@cd go-changelog && go install ./cmd/changelog-check
+	@go install github.com/hashicorp/go-changelog/cmd/changelog-check@latest
 endif
 	@changelog-check
 


### PR DESCRIPTION
### Changes proposed in this PR:

Switch from my personal fork back to the upstream go-changelog repo now that https://github.com/hashicorp/go-changelog/pull/22 has been merged.

### How I've tested this PR:

Every CI run with a changelog entry will exercise this make task to validate it.

### How I expect reviewers to test this PR:

### Checklist:
- [ ] ~~Tests added~~
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
