### PR TITLE
Update e2e tests to work on k8s 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        curl -L https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 -o ./kind
+        curl -L https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64 -o ./kind
         chmod +x ./kind
         mv ./kind /usr/local/bin/kind
         curl -L https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl -o ./kubectl

--- a/internal/testing/e2e/kind.go
+++ b/internal/testing/e2e/kind.go
@@ -33,7 +33,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+  image: kindest/node:v1.24.6@sha256:97e8d00bc37a7598a0b32d1fabd155a96355c49fa0d4d4790aab0f161bf31be1
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration

--- a/internal/testing/e2e/kubernetes.go
+++ b/internal/testing/e2e/kubernetes.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/cenkalti/backoff"
-	consulapigw "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 	core "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	api "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -25,6 +23,8 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	consulapigw "github.com/hashicorp/consul-api-gateway/pkg/apis/v1alpha1"
 )
 
 type k8sTokenContext struct{}
@@ -95,24 +95,22 @@ func CreateServiceAccount(namespace, accountName, clusterRolePath string) env.Fu
 			return nil, err
 		}
 
-		var secretName string
-		err = backoff.Retry(func() error {
-			account := &core.ServiceAccount{}
-			if err := cfg.Client().Resources().Get(ctx, accountName, namespace, account); err != nil {
-				return err
-			}
-			if len(account.Secrets) == 0 {
-				return errors.New("invalid account secrets")
-			}
-			secretName = account.Secrets[0].Name
-			return nil
-		}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 5), ctx))
-		if err != nil {
-			return nil, err
+		// As of K8s 1.24, ServiceAccounts no longer implicitly create a Secret w/ token,
+		// so we create the token Secret directly using the proper annotations.
+		// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#to-create-additional-api-tokens
+		if err := cfg.Client().Resources().Create(ctx, &core.Secret{
+			Type: core.SecretTypeServiceAccountToken,
+			ObjectMeta: meta.ObjectMeta{
+				Name:        accountName,
+				Namespace:   namespace,
+				Annotations: map[string]string{core.ServiceAccountNameKey: accountName},
+			},
+		}); err != nil {
+			return nil, errors.New("failed to create secret w/ service account token")
 		}
 
 		secret := &core.Secret{}
-		if err := cfg.Client().Resources().Get(ctx, secretName, namespace, secret); err != nil {
+		if err := cfg.Client().Resources().Get(ctx, accountName, namespace, secret); err != nil {
 			return nil, err
 		}
 
@@ -257,28 +255,11 @@ func readCRDs(data []byte) ([]*api.CustomResourceDefinition, error) {
 }
 
 func serviceAccountClient(ctx context.Context, client klient.Client, account, namespace string) (klient.Client, error) {
-	serviceAccount := core.ServiceAccount{}
-	if err := client.Resources().Get(ctx, account, namespace, &serviceAccount); err != nil {
-		return nil, err
-	}
-	if len(serviceAccount.Secrets) == 0 {
-		return nil, errors.New("can't find secret")
-	}
-	secretName := serviceAccount.Secrets[0].Name
-	token := core.Secret{}
-	if err := client.Resources().Get(ctx, secretName, namespace, &token); err != nil {
-		return nil, err
-	}
-	tokenData, found := token.Data["token"]
-	if !found {
-		return nil, errors.New("token not found")
-	}
-
 	config := rest.CopyConfig(client.RESTConfig())
-	tlsConfig := client.RESTConfig().TLSClientConfig
+	config.BearerToken = K8sServiceToken(ctx)
 
-	config.BearerToken = string(tokenData)
 	// overwrite the TLS config so we're not using cert-based auth
+	tlsConfig := client.RESTConfig().TLSClientConfig
 	config.TLSClientConfig = rest.TLSClientConfig{
 		ServerName: tlsConfig.ServerName,
 		CAFile:     tlsConfig.CAFile,


### PR DESCRIPTION
### Changes proposed in this PR:
Kubernetes 1.24 no longer implicitly creates a `Secret` w/ a token in it when a `ServiceAccount` is created. This PR modifies our e2e tests to create the `Secret` explicitly which is the [documented solution](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#to-create-additional-api-tokens).

I found [this](https://itnext.io/big-change-in-k8s-1-24-about-serviceaccounts-and-their-secrets-4b909a4af4e0) to be a helpful explanation of what's happening.

> **Note** A pod running w/ the `ServiceAccount` still has a token mounted inside even though the `Secret` that previously contained this token is no longer created. This is why Consul API Gateway works on K8s 1.24 in a standard deployment; however, our e2e test deployment does not run inside a pod and so requires the changes in this PR.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
