### PR TITLE
ci: switch to pr/conformance label

### DIFF
--- a/.github/workflows/conformance_with_build.yml
+++ b/.github/workflows/conformance_with_build.yml
@@ -25,8 +25,8 @@ env:
 
 jobs:
   run-on-kind:
-    # Run on PR only if there is a `pr/run-conformance` label
-    if: "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr/run-conformance')"
+    # Run on PR only if there is a `pr/conformance` label
+    if: "github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'pr/conformance')"
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
### Changes proposed in this PR:

I kept misreading the `pr/run-conformance` label as "un-conformance", this updates the CI check to look for a `pr/conformance` label instead. We can keep both labels around temporarily to avoid requiring PRs before this change to rebase to run conformance tests.

### How I've tested this PR:

Runs CI conformance tests with the `pr/conformance` label.

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
