### PR TITLE
Support method chaining in gateway builders

### DIFF
--- a/internal/k8s/builder/gateway.go
+++ b/internal/k8s/builder/gateway.go
@@ -2,7 +2,6 @@ package builder
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"text/template"
 
@@ -30,13 +29,6 @@ func (b *GatewayServiceBuilder) WithClassConfig(cfg v1alpha1.GatewayClassConfig)
 	return b
 }
 
-func (b *GatewayServiceBuilder) Validate() error {
-	if b.gwConfig == nil {
-		return fmt.Errorf("GatewayClassConfig must be set")
-	}
-
-	return nil
-}
 func (b *GatewayServiceBuilder) Build() *corev1.Service {
 	if b.gwConfig.Spec.ServiceType == nil {
 		return nil
@@ -118,21 +110,6 @@ func (b *GatewayDeploymentBuilder) WithConsulGatewayNamespace(namespace string) 
 func (b *GatewayDeploymentBuilder) WithPrimaryConsulDatacenter(datacenter string) *GatewayDeploymentBuilder {
 	b.consulPrimaryDatacenter = datacenter
 	return b
-}
-
-func (b *GatewayDeploymentBuilder) Validate() error {
-	if b.gwConfig == nil {
-		return fmt.Errorf("GatewayClassConfig must be set")
-	}
-
-	if b.sdsHost == "" || b.sdsPort == 0 {
-		return fmt.Errorf("SDS must be set")
-	}
-
-	if b.requiresCA() && b.consulCAData == "" {
-		return fmt.Errorf("ConsulCA must be set")
-	}
-	return nil
 }
 
 func (b *GatewayDeploymentBuilder) Build(currentReplicas *int32) *v1.Deployment {

--- a/internal/k8s/builder/gateway.go
+++ b/internal/k8s/builder/gateway.go
@@ -25,8 +25,9 @@ func NewGatewayService(gw *gwv1beta1.Gateway) *GatewayServiceBuilder {
 	return &GatewayServiceBuilder{gateway: gw}
 }
 
-func (b *GatewayServiceBuilder) WithClassConfig(cfg v1alpha1.GatewayClassConfig) {
+func (b *GatewayServiceBuilder) WithClassConfig(cfg v1alpha1.GatewayClassConfig) *GatewayServiceBuilder {
 	b.gwConfig = &cfg
+	return b
 }
 
 func (b *GatewayServiceBuilder) Validate() error {
@@ -93,25 +94,30 @@ func NewGatewayDeployment(gw *gwv1beta1.Gateway) *GatewayDeploymentBuilder {
 	return &GatewayDeploymentBuilder{gateway: gw}
 }
 
-func (b *GatewayDeploymentBuilder) WithClassConfig(cfg v1alpha1.GatewayClassConfig) {
+func (b *GatewayDeploymentBuilder) WithClassConfig(cfg v1alpha1.GatewayClassConfig) *GatewayDeploymentBuilder {
 	b.gwConfig = &cfg
+	return b
 }
 
-func (b *GatewayDeploymentBuilder) WithSDS(host string, port int) {
+func (b *GatewayDeploymentBuilder) WithSDS(host string, port int) *GatewayDeploymentBuilder {
 	b.sdsHost = host
 	b.sdsPort = port
+	return b
 }
 
-func (b *GatewayDeploymentBuilder) WithConsulCA(caData string) {
+func (b *GatewayDeploymentBuilder) WithConsulCA(caData string) *GatewayDeploymentBuilder {
 	b.consulCAData = caData
+	return b
 }
 
-func (b *GatewayDeploymentBuilder) WithConsulGatewayNamespace(namespace string) {
+func (b *GatewayDeploymentBuilder) WithConsulGatewayNamespace(namespace string) *GatewayDeploymentBuilder {
 	b.consulGatewayNamespace = namespace
+	return b
 }
 
-func (b *GatewayDeploymentBuilder) WithPrimaryConsulDatacenter(datacenter string) {
+func (b *GatewayDeploymentBuilder) WithPrimaryConsulDatacenter(datacenter string) *GatewayDeploymentBuilder {
 	b.consulPrimaryDatacenter = datacenter
+	return b
 }
 
 func (b *GatewayDeploymentBuilder) Validate() error {

--- a/internal/k8s/builder/gateway_test.go
+++ b/internal/k8s/builder/gateway_test.go
@@ -50,18 +50,18 @@ func newGatewayTestConfig() *gatewayTestConfig {
 }
 
 func (g *gatewayTestConfig) EncodeDeployment() runtime.Object {
-	b := NewGatewayDeployment(g.gateway)
-	b.WithSDS("consul-api-gateway-controller.default.svc.cluster.local", 9090)
-	b.WithClassConfig(*g.gatewayClassConfig)
-	b.WithConsulCA("CONSUL_CA_MOCKED")
-	b.WithConsulGatewayNamespace("test")
-	return b.Build(nil)
+	return NewGatewayDeployment(g.gateway).
+		WithSDS("consul-api-gateway-controller.default.svc.cluster.local", 9090).
+		WithClassConfig(*g.gatewayClassConfig).
+		WithConsulCA("CONSUL_CA_MOCKED").
+		WithConsulGatewayNamespace("test").
+		Build(nil)
 }
 
 func (g *gatewayTestConfig) EncodeService() runtime.Object {
-	b := NewGatewayService(g.gateway)
-	b.WithClassConfig(*g.gatewayClassConfig)
-	return b.Build()
+	return NewGatewayService(g.gateway).
+		WithClassConfig(*g.gatewayClassConfig).
+		Build()
 }
 
 func TestGatewayDeploymentBuilder(t *testing.T) {

--- a/internal/k8s/reconciler/deployer.go
+++ b/internal/k8s/reconciler/deployer.go
@@ -127,17 +127,17 @@ func (d *GatewayDeployer) ensureService(ctx context.Context, config apigwv1alpha
 }
 
 func (d *GatewayDeployer) Deployment(namespace string, config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway, currentReplicas *int32) *apps.Deployment {
-	deploymentBuilder := builder.NewGatewayDeployment(gateway)
-	deploymentBuilder.WithSDS(d.sdsHost, d.sdsPort)
-	deploymentBuilder.WithClassConfig(config)
-	deploymentBuilder.WithConsulCA(d.consulCA)
-	deploymentBuilder.WithConsulGatewayNamespace(namespace)
-	deploymentBuilder.WithPrimaryConsulDatacenter(d.primaryDatacenter)
-	return deploymentBuilder.Build(currentReplicas)
+	return builder.NewGatewayDeployment(gateway).
+		WithSDS(d.sdsHost, d.sdsPort).
+		WithClassConfig(config).
+		WithConsulCA(d.consulCA).
+		WithConsulGatewayNamespace(namespace).
+		WithPrimaryConsulDatacenter(d.primaryDatacenter).
+		Build(currentReplicas)
 }
 
 func (d *GatewayDeployer) Service(config apigwv1alpha1.GatewayClassConfig, gateway *gwv1beta1.Gateway) *core.Service {
-	serviceBuilder := builder.NewGatewayService(gateway)
-	serviceBuilder.WithClassConfig(config)
-	return serviceBuilder.Build()
+	return builder.NewGatewayService(gateway).
+		WithClassConfig(config).
+		Build()
 }


### PR DESCRIPTION
### Changes proposed in this PR:
We have builder patterns that don't support method chaining which makes them feel awkward to use. This PR adds the parts needed for method chaining and removes some unused funcs on the builders. No functional impact.

### How I've tested this PR:
🤖 tests pass

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
