### PR TITLE
Update InvalidCertificateRef error to RefNotPermitted

### DIFF
--- a/.changelog/412.txt
+++ b/.changelog/412.txt
@@ -1,0 +1,3 @@
+```release-note:note
+RefNotPermitted error is now returned instead of InvalidCertificateRef in the case where a cross namespace certificate is not allowed by a ReferenceGrant
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
   e2e:
     name: e2e tests (consul-image=${{ matrix.consul-image }})
     strategy:
+      fail-fast: false
       matrix:
         consul-image:
         - 'hashicorp/consul:1.11.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,4 +132,4 @@ jobs:
         --format=short-verbose \
         --jsonfile $TEST_RESULTS_DIR/json/go-test-race.log \
         --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
-        -tags e2e ./internal/commands/server
+        -tags e2e ./internal/commands/server --failfast

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: "hashicorp/gateway-api"
-          ref: "conformance/v0.5.0-skipped-tests"
+          ref: "conformance/v0.5.1-skipped-tests"
           path: "gateway-api"
 
       - name: Generate Unique Cluster Name

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	k8s.io/klog/v2 v2.80.1
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/e2e-framework v0.0.7
-	sigs.k8s.io/gateway-api v0.5.0
+	sigs.k8s.io/gateway-api v0.5.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1510,8 +1510,8 @@ sigs.k8s.io/controller-runtime v0.13.0 h1:iqa5RNciy7ADWnIc8QxCbOX5FEKVR3uxVxKHRM
 sigs.k8s.io/controller-runtime v0.13.0/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/e2e-framework v0.0.7 h1:nMv2oSPBLWARse2aBoqX5Wq3ox67w8jrhTGWGpccWDQ=
 sigs.k8s.io/e2e-framework v0.0.7/go.mod h1:hdwYGVQg4bvDAah5eidNf2/qkG35qHjzuyMVr2A3oiY=
-sigs.k8s.io/gateway-api v0.5.0 h1:ze+k9fJqvmL8s1t3e4q1ST8RnN+f09dEv+gfacahlAE=
-sigs.k8s.io/gateway-api v0.5.0/go.mod h1:x0AP6gugkFV8fC/oTlnOMU0pnmuzIR8LfIPRVUjxSqA=
+sigs.k8s.io/gateway-api v0.5.1 h1:EqzgOKhChzyve9rmeXXbceBYB6xiM50vDfq0kK5qpdw=
+sigs.k8s.io/gateway-api v0.5.1/go.mod h1:x0AP6gugkFV8fC/oTlnOMU0pnmuzIR8LfIPRVUjxSqA=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -1770,7 +1770,7 @@ func TestReferenceGrantLifecycle(t *testing.T) {
 
 			// Expect that Gateway listener has expected error condition
 			// due to missing ReferenceGrant for CertificateRef in other namespace
-			listenerConditionCheck := createListenerStatusConditionsCheck([]meta.Condition{{Type: "ResolvedRefs", Status: "False", Reason: "InvalidCertificateRef"}})
+			listenerConditionCheck := createListenerStatusConditionsCheck([]meta.Condition{{Type: "ResolvedRefs", Status: "False", Reason: "RefNotPermitted"}})
 			listenerCheck := listenerStatusCheck(ctx, resources, gatewayName, gatewayNamespace, listenerConditionCheck)
 			require.Eventually(t, listenerCheck, checkTimeout, checkInterval, "Gateway listener status not set in allotted time")
 
@@ -1812,7 +1812,7 @@ func TestReferenceGrantLifecycle(t *testing.T) {
 			gatewayCheck = gatewayStatusCheck(ctx, resources, gatewayName, gatewayNamespace, gatewayConditionCheck)
 			require.Eventually(t, gatewayCheck, checkTimeout, checkInterval, "Gateway status not set in allotted time")
 
-			listenerConditionCheck = createListenerStatusConditionsCheck([]meta.Condition{{Type: "ResolvedRefs", Status: "False", Reason: "InvalidCertificateRef"}})
+			listenerConditionCheck = createListenerStatusConditionsCheck([]meta.Condition{{Type: "ResolvedRefs", Status: "False", Reason: "RefNotPermitted"}})
 			listenerCheck = listenerStatusCheck(ctx, resources, gatewayName, gatewayNamespace, listenerConditionCheck)
 			require.Eventually(t, listenerCheck, checkTimeout, checkInterval, "Gateway listener status not set in allotted time")
 
@@ -1854,7 +1854,7 @@ func TestReferenceGrantLifecycle(t *testing.T) {
 			gatewayCheck = gatewayStatusCheck(ctx, resources, gatewayName, gatewayNamespace, gatewayConditionCheck)
 			require.Eventually(t, gatewayCheck, checkTimeout, checkInterval, "Gateway status not set in allotted time")
 
-			listenerConditionCheck = createListenerStatusConditionsCheck([]meta.Condition{{Type: "ResolvedRefs", Status: "False", Reason: "InvalidCertificateRef"}})
+			listenerConditionCheck = createListenerStatusConditionsCheck([]meta.Condition{{Type: "ResolvedRefs", Status: "False", Reason: "RefNotPermitted"}})
 			listenerCheck = listenerStatusCheck(ctx, resources, gatewayName, gatewayNamespace, listenerConditionCheck)
 			require.Eventually(t, listenerCheck, checkTimeout, checkInterval, "Gateway listener status not set in allotted time")
 

--- a/internal/k8s/reconciler/validator/gateway.go
+++ b/internal/k8s/reconciler/validator/gateway.go
@@ -379,7 +379,6 @@ func (g *GatewayValidator) validateTLS(ctx context.Context, state *state.Listene
 		return err
 	} else if !allowed {
 		nsName := getNamespacedName(ref.Name, ref.Namespace, gateway.Namespace)
-		//g.logger.Warn("Cross-namespace listener certificate not allowed without matching ReferenceGrant", "refName", nsName.Name, "refNamespace", nsName.Namespace)
 		state.Status.ResolvedRefs.RefNotPermitted = rerrors.NewCertificateResolutionErrorNotPermitted(
 			fmt.Sprintf("Cross-namespace listener certificate not allowed without matching ReferenceGrant for Secret %q", nsName))
 		return nil

--- a/internal/k8s/reconciler/validator/gateway.go
+++ b/internal/k8s/reconciler/validator/gateway.go
@@ -380,7 +380,7 @@ func (g *GatewayValidator) validateTLS(ctx context.Context, state *state.Listene
 	} else if !allowed {
 		nsName := getNamespacedName(ref.Name, ref.Namespace, gateway.Namespace)
 		//g.logger.Warn("Cross-namespace listener certificate not allowed without matching ReferenceGrant", "refName", nsName.Name, "refNamespace", nsName.Namespace)
-		state.Status.ResolvedRefs.InvalidCertificateRef = rerrors.NewCertificateResolutionErrorNotPermitted(
+		state.Status.ResolvedRefs.RefNotPermitted = rerrors.NewCertificateResolutionErrorNotPermitted(
 			fmt.Sprintf("Cross-namespace listener certificate not allowed without matching ReferenceGrant for Secret %q", nsName))
 		return nil
 	}
@@ -391,7 +391,7 @@ func (g *GatewayValidator) validateTLS(ctx context.Context, state *state.Listene
 		if !errors.As(err, &certificateErr) {
 			return err
 		}
-		state.Status.ResolvedRefs.InvalidCertificateRef = certificateErr
+		state.Status.ResolvedRefs.RefNotPermitted = certificateErr
 		return nil
 	}
 

--- a/internal/k8s/reconciler/validator/gateway.go
+++ b/internal/k8s/reconciler/validator/gateway.go
@@ -391,7 +391,7 @@ func (g *GatewayValidator) validateTLS(ctx context.Context, state *state.Listene
 		if !errors.As(err, &certificateErr) {
 			return err
 		}
-		state.Status.ResolvedRefs.RefNotPermitted = certificateErr
+		state.Status.ResolvedRefs.InvalidCertificateRef = certificateErr
 		return nil
 	}
 

--- a/internal/k8s/reconciler/validator/gateway_test.go
+++ b/internal/k8s/reconciler/validator/gateway_test.go
@@ -423,7 +423,7 @@ func TestListenerValidate(t *testing.T) {
 		require.NoError(t, err)
 
 		condition := listenerState.Status.ResolvedRefs.Condition(0)
-		require.Equal(t, status.ListenerConditionReasonRefNotPermitted, condition.Reason)
+		require.Equal(t, status.ListenerConditionReasonInvalidCertificateRef, condition.Reason)
 	})
 
 	t.Run("Invalid cross-namespace secret ref with no ReferenceGrant", func(t *testing.T) {
@@ -531,7 +531,7 @@ func TestListenerValidate(t *testing.T) {
 		require.NoError(t, err)
 
 		condition := listenerState.Status.ResolvedRefs.Condition(0)
-		assert.Equal(t, status.ListenerConditionReasonRefNotPermitted, condition.Reason)
+		assert.Equal(t, status.ListenerConditionReasonInvalidCertificateRef, condition.Reason)
 	})
 
 	t.Run("Valid minimum TLS version", func(t *testing.T) {

--- a/internal/k8s/reconciler/validator/gateway_test.go
+++ b/internal/k8s/reconciler/validator/gateway_test.go
@@ -423,7 +423,7 @@ func TestListenerValidate(t *testing.T) {
 		require.NoError(t, err)
 
 		condition := listenerState.Status.ResolvedRefs.Condition(0)
-		require.Equal(t, status.ListenerConditionReasonInvalidCertificateRef, condition.Reason)
+		require.Equal(t, status.ListenerConditionReasonRefNotPermitted, condition.Reason)
 	})
 
 	t.Run("Invalid cross-namespace secret ref with no ReferenceGrant", func(t *testing.T) {
@@ -444,7 +444,7 @@ func TestListenerValidate(t *testing.T) {
 		require.NoError(t, err)
 
 		condition := listenerState.Status.ResolvedRefs.Condition(0)
-		assert.Equal(t, status.ListenerConditionReasonInvalidCertificateRef, condition.Reason)
+		assert.Equal(t, status.ListenerConditionReasonRefNotPermitted, condition.Reason)
 	})
 
 	t.Run("Valid cross-namespace secret ref with ReferenceGrant", func(t *testing.T) {
@@ -531,7 +531,7 @@ func TestListenerValidate(t *testing.T) {
 		require.NoError(t, err)
 
 		condition := listenerState.Status.ResolvedRefs.Condition(0)
-		assert.Equal(t, status.ListenerConditionReasonInvalidCertificateRef, condition.Reason)
+		assert.Equal(t, status.ListenerConditionReasonRefNotPermitted, condition.Reason)
 	})
 
 	t.Run("Valid minimum TLS version", func(t *testing.T) {


### PR DESCRIPTION
Closes #396 

### Changes proposed in this PR:
- Update InvalidCertificateRef error to RefNotPermitted to match the spec [#1351](https://github-redirect.dependabot.com/kubernetes-sigs/gateway-api/pull/1351)

### How I've tested this PR:
- Update conformance test pin to pull in updated tests

### How I expect reviewers to test this PR:
- PR Passes

### Checklist:
- [ X ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
