### PR TITLE
Restore URL rewrite filter conversion logic lost to merge conflicts

### DIFF
--- a/internal/k8s/reconciler/converter/http.go
+++ b/internal/k8s/reconciler/converter/http.go
@@ -213,6 +213,21 @@ func convertHTTPRouteFilters(routeFilters []gwv1alpha2.HTTPRouteFilter) []core.H
 					Status:   statusCode,
 				},
 			})
+		case gwv1alpha2.HTTPRouteFilterURLRewrite:
+			// We currently only support prefix match replacement
+			if filter.URLRewrite.Path == nil ||
+				filter.URLRewrite.Path.Type != gwv1alpha2.PrefixMatchHTTPPathModifier ||
+				filter.URLRewrite.Path.ReplacePrefixMatch == nil {
+				continue
+			}
+
+			filters = append(filters, core.HTTPFilter{
+				Type: core.HTTPURLRewriteFilterType,
+				URLRewrite: core.HTTPURLRewriteFilter{
+					Type:               core.URLRewriteReplacePrefixMatchType,
+					ReplacePrefixMatch: *filter.URLRewrite.Path.ReplacePrefixMatch,
+				},
+			})
 		}
 	}
 	return filters

--- a/internal/k8s/reconciler/converter/http_test.go
+++ b/internal/k8s/reconciler/converter/http_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	gwv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/hashicorp/consul-api-gateway/internal/k8s/reconciler/state"
@@ -79,6 +80,14 @@ func TestConvertHTTPRoute(t *testing.T) {
 								Value: "b",
 							}},
 							Remove: []string{"x-c"},
+						},
+					}, {
+						Type: gwv1alpha2.HTTPRouteFilterURLRewrite,
+						URLRewrite: &gwv1alpha2.HTTPURLRewriteFilter{
+							Path: &gwv1alpha2.HTTPPathModifier{
+								Type:               gwv1alpha2.PrefixMatchHTTPPathModifier,
+								ReplacePrefixMatch: pointer.String("/v1/"),
+							},
 						},
 					}},
 				},
@@ -173,6 +182,24 @@ func TestConvertHTTPRoute(t *testing.T) {
 					"URLRewrite": {
 						"Type": "",
 						"ReplacePrefixMatch": ""
+					}
+				},
+				{
+					"Type": "HTTPURLRewriteFilter",
+					"Header": {
+						"Set": null,
+						"Add": null,
+						"Remove": null
+					},
+					"Redirect": {
+						"Scheme": "",
+						"Hostname": "",
+						"Port": 0,
+						"Status": 0
+					},
+					"URLRewrite": {
+						"Type": "URLRewriteReplacePrefixMatch",
+						"ReplacePrefixMatch": "/v1/"
 					}
 				}
 			],


### PR DESCRIPTION
### Changes proposed in this PR:
The URL rewrite portion of the route conversion logic was lost to merge conflicts during the refactor. This PR restores it and adds test coverage for it.

### How I've tested this PR:
- [x] 🤖 tests pass
- [x] Installed `HTTPRoute` with a URL rewrite filter and verified the Consul config entry reflects it

<details>
<summary>Details</summary>

HTTPRoute:
```yaml
# Derived from https://github.com/hashicorp/learn-consul-kubernetes/blob/main/api-gateway/local/api-gw/routes.yaml
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: echo-1
  namespace: consul
spec:
  parentRefs:
  - name: api-gateway
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
    backendRefs:
    - kind: Service
      name: echo-1
      namespace: default
      port: 8080
    filters:
    - type: URLRewrite
      urlRewrite:
        path:
          type: ReplacePrefixMatch
          replacePrefixMatch: /api/v1
```

Resulting config entry in Consul:
```json
{
    "Kind": "service-router",
    "Name": "api-gateway-9b9265b",
    "Routes": [
        {
            "Match": {
                "HTTP": {
                    "PathPrefix": "/"
                }
            },
            "Destination": {
                "Service": "echo-1",
                "PrefixRewrite": "/api/v1",
                "RequestHeaders": {}
            }
        }
    ],
    "Meta": {
        "consul-api-gateway/k8s/Gateway.Name": "api-gateway",
        "consul-api-gateway/k8s/Gateway.Namespace": "consul",
        "external-source": "consul-api-gateway"
    },
    "CreateIndex": 343,
    "ModifyIndex": 594
}
```
</details>

### How I expect reviewers to test this PR:

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
