### PR TITLE
Add tools.go to prevent mod from dropping tool-only dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
 	k8s.io/klog/v2 v2.80.1
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/e2e-framework v0.0.7
 	sigs.k8s.io/gateway-api v0.5.0
@@ -149,7 +150,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.25.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1224,7 +1224,6 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -1,0 +1,6 @@
+//go:build tools
+
+// following https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
+package internal
+
+import _ "github.com/golang/mock/mockgen"


### PR DESCRIPTION
### Changes proposed in this PR:
We don't actually import `mockgen` anywhere but depend on it as part of our toolchain. Since it isn't imported, `$ go mod tidy` will remove it from the modfile and causes failures in our unit test CI (examples [1](https://github.com/hashicorp/consul-api-gateway/actions/runs/3230554154/jobs/5289136204), [2](https://github.com/hashicorp/consul-api-gateway/pull/399), [3](https://github.com/hashicorp/consul-api-gateway/pull/415), etc.)

This fix is recommended by https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module, which I came across via https://github.com/google/wire/issues/299.

### How I've tested this PR:
:robot: tests pass

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
