### PR TITLE
Accept PodSecurityPolicy name, bind to managed ServiceAccount if provided

### DIFF
--- a/.changelog/433.txt
+++ b/.changelog/433.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add optional `podSecurityPolicy` to GatewayClassConfig CRD. If set and "managed" ServiceAccounts are being used, a Role and RoleBinding are created to attach the named `PodSecurityPolicy` to the managed ServiceAccount.
+```

--- a/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -60,7 +60,7 @@ spec:
                     properties:
                       account:
                         description: The name of an existing Kubernetes ServiceAccount
-                          to authenticate as. Ignored if !managed.
+                          to authenticate as. Ignored if managed is true.
                         type: string
                       managed:
                         description: Whether deployments should be run with "managed"
@@ -75,7 +75,7 @@ spec:
                         type: string
                       podSecurityPolicy:
                         description: The name of an existing Kubernetes PodSecurityPolicy
-                          to bind to the ServiceAccount if managed.
+                          to bind to the ServiceAccount if managed is true.
                         type: string
                     type: object
                   ports:

--- a/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -60,11 +60,11 @@ spec:
                     properties:
                       account:
                         description: The name of an existing Kubernetes ServiceAccount
-                          to authenticate as. Ignored if !Managed.
+                          to authenticate as. Ignored if !managed.
                         type: string
                       managed:
                         description: Whether deployments should be run with "managed"
-                          service accounts created by the gateway controller.
+                          Kubernetes ServiceAccounts created by the gateway controller.
                         type: boolean
                       method:
                         description: The Consul auth method used for initial authentication
@@ -75,7 +75,7 @@ spec:
                         type: string
                       podSecurityPolicy:
                         description: The name of an existing Kubernetes PodSecurityPolicy
-                          to bind to the ServiceAccount if Managed
+                          to bind to the ServiceAccount if managed.
                         type: string
                     type: object
                   ports:

--- a/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -75,7 +75,7 @@ spec:
                         type: string
                       podSecurityPolicy:
                         description: The name of an existing Kubernetes PodSecurityPolicy
-                          to bind to the ServiceAccount if managed is true.
+                          to bind to the managed ServiceAccount if managed is true.
                         type: string
                     type: object
                   ports:

--- a/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -59,8 +59,8 @@ spec:
                     description: Consul authentication information
                     properties:
                       account:
-                        description: The Kubernetes service account to authenticate
-                          as.
+                        description: The name of an existing Kubernetes ServiceAccount
+                          to authenticate as. Ignored if !Managed.
                         type: string
                       managed:
                         description: Whether deployments should be run with "managed"
@@ -72,6 +72,10 @@ spec:
                         type: string
                       namespace:
                         description: The Consul namespace to use for authentication.
+                        type: string
+                      podSecurityPolicy:
+                        description: The name of an existing Kubernetes PodSecurityPolicy
+                          to bind to the ServiceAccount if Managed
                         type: string
                     type: object
                   ports:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -239,6 +239,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -238,3 +238,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/internal/k8s/controllers/gateway_controller.go
+++ b/internal/k8s/controllers/gateway_controller.go
@@ -47,6 +47,7 @@ type GatewayReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=services,verbs=list;get;create;update;watch
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;get;create;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=create;update;get;list;watch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=list;get;create;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/k8s/controllers/gateway_controller.go
+++ b/internal/k8s/controllers/gateway_controller.go
@@ -48,6 +48,7 @@ type GatewayReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=list;get;create;watch
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=create;update;get;list;watch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=list;get;create;watch
+//+kubebuilder:rbac:groups=policy,resources=podsecuritypolicies,verbs=use
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/k8s/gatewayclient/mocks/gatewayclient.go
+++ b/internal/k8s/gatewayclient/mocks/gatewayclient.go
@@ -130,6 +130,26 @@ func (mr *MockClientMockRecorder) DeploymentForGateway(ctx, gw interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentForGateway", reflect.TypeOf((*MockClient)(nil).DeploymentForGateway), ctx, gw)
 }
 
+// EnsureExists mocks base method.
+func (m *MockClient) EnsureExists(ctx context.Context, obj client.Object, mutators ...func() error) (bool, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, obj}
+	for _, a := range mutators {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EnsureExists", varargs...)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EnsureExists indicates an expected call of EnsureExists.
+func (mr *MockClientMockRecorder) EnsureExists(ctx, obj interface{}, mutators ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, obj}, mutators...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureExists", reflect.TypeOf((*MockClient)(nil).EnsureExists), varargs...)
+}
+
 // EnsureFinalizer mocks base method.
 func (m *MockClient) EnsureFinalizer(ctx context.Context, object client.Object, finalizer string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -125,15 +125,15 @@ type CopyAnnotationsSpec struct {
 }
 
 type AuthSpec struct {
-	// Whether deployments should be run with "managed" service accounts created by the gateway controller.
+	// Whether deployments should be run with "managed" Kubernetes ServiceAccounts created by the gateway controller.
 	Managed bool `json:"managed,omitempty"`
 	// The Consul auth method used for initial authentication by consul-api-gateway.
 	Method string `json:"method,omitempty"`
-	// The name of an existing Kubernetes ServiceAccount to authenticate as. Ignored if !Managed.
+	// The name of an existing Kubernetes ServiceAccount to authenticate as. Ignored if !managed.
 	Account string `json:"account,omitempty"`
 	// The Consul namespace to use for authentication.
 	Namespace string `json:"namespace,omitempty"`
-	// The name of an existing Kubernetes PodSecurityPolicy to bind to the ServiceAccount if Managed
+	// The name of an existing Kubernetes PodSecurityPolicy to bind to the ServiceAccount if managed.
 	PodSecurityPolicy string `json:"podSecurityPolicy,omitempty"`
 }
 

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -129,7 +129,7 @@ type AuthSpec struct {
 	Managed bool `json:"managed,omitempty"`
 	// The Consul auth method used for initial authentication by consul-api-gateway.
 	Method string `json:"method,omitempty"`
-	// The name of an existing Kubernetes ServiceAccount to authenticate as. Ignored if !managed.
+	// The name of an existing Kubernetes ServiceAccount to authenticate as. Ignored if managed.
 	Account string `json:"account,omitempty"`
 	// The Consul namespace to use for authentication.
 	Namespace string `json:"namespace,omitempty"`

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -147,6 +147,9 @@ type GatewayClassConfigList struct {
 	Items []GatewayClassConfig `json:"items"`
 }
 
+// RoleFor constructs a Kubernetes Role for the specified Gateway based
+// on the GatewayClassConfig. If the GatewayClassConfig is configured in
+// such a way that does not require a Role, nil is returned.
 func (c *GatewayClassConfig) RoleFor(gw *gwv1beta1.Gateway) *rbac.Role {
 	if !c.Spec.ConsulSpec.AuthSpec.Managed || c.Spec.ConsulSpec.AuthSpec.PodSecurityPolicy == "" {
 		return nil
@@ -167,6 +170,9 @@ func (c *GatewayClassConfig) RoleFor(gw *gwv1beta1.Gateway) *rbac.Role {
 	}
 }
 
+// RoleBindingFor constructs a Kubernetes RoleBinding for the specified Gateway
+// based on the GatewayClassConfig. If the GatewayClassConfig is configured in
+// such a way that does not require a RoleBinding, nil is returned.
 func (c *GatewayClassConfig) RoleBindingFor(gw *gwv1beta1.Gateway) *rbac.RoleBinding {
 	serviceAccount := c.ServiceAccountFor(gw)
 	if serviceAccount == nil {
@@ -199,7 +205,9 @@ func (c *GatewayClassConfig) RoleBindingFor(gw *gwv1beta1.Gateway) *rbac.RoleBin
 	}
 }
 
-// ServiceAccountFor returns the service account to be created for the given gateway.
+// ServiceAccountFor constructs a Kubernetes ServiceAccount for the specified
+// Gateway based on the GatewayClassConfig. If the GatewayClassConfig is configured
+// in such a way that does not require a ServiceAccount, nil is returned.
 func (c *GatewayClassConfig) ServiceAccountFor(gw *gwv1beta1.Gateway) *corev1.ServiceAccount {
 	if !c.Spec.ConsulSpec.AuthSpec.Managed {
 		return nil

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -129,11 +129,11 @@ type AuthSpec struct {
 	Managed bool `json:"managed,omitempty"`
 	// The Consul auth method used for initial authentication by consul-api-gateway.
 	Method string `json:"method,omitempty"`
-	// The name of an existing Kubernetes ServiceAccount to authenticate as. Ignored if managed.
+	// The name of an existing Kubernetes ServiceAccount to authenticate as. Ignored if managed is true.
 	Account string `json:"account,omitempty"`
 	// The Consul namespace to use for authentication.
 	Namespace string `json:"namespace,omitempty"`
-	// The name of an existing Kubernetes PodSecurityPolicy to bind to the ServiceAccount if managed.
+	// The name of an existing Kubernetes PodSecurityPolicy to bind to the ServiceAccount if managed is true.
 	PodSecurityPolicy string `json:"podSecurityPolicy,omitempty"`
 }
 

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -133,7 +133,7 @@ type AuthSpec struct {
 	Account string `json:"account,omitempty"`
 	// The Consul namespace to use for authentication.
 	Namespace string `json:"namespace,omitempty"`
-	// The name of an existing Kubernetes PodSecurityPolicy to bind to the ServiceAccount if managed is true.
+	// The name of an existing Kubernetes PodSecurityPolicy to bind to the managed ServiceAccount if managed is true.
 	PodSecurityPolicy string `json:"podSecurityPolicy,omitempty"`
 }
 

--- a/pkg/apis/v1alpha1/types_test.go
+++ b/pkg/apis/v1alpha1/types_test.go
@@ -3,9 +3,13 @@ package v1alpha1
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/hashicorp/consul-api-gateway/internal/k8s/utils"
 )
 
 func TestGatewayClassConfigDeepCopy(t *testing.T) {
@@ -42,4 +46,149 @@ func TestGatewayClassConfigDeepCopy(t *testing.T) {
 	copyConfigList := configList.DeepCopy()
 	copyConfigListObject := configList.DeepCopyObject()
 	require.Equal(t, copyConfigList, copyConfigListObject)
+}
+
+func TestGatewayClassConfig_RoleFor(t *testing.T) {
+	t.Run("unmanaged auth", func(t *testing.T) {
+		gcc := &GatewayClassConfig{
+			Spec: GatewayClassConfigSpec{
+				ConsulSpec: ConsulSpec{
+					AuthSpec: AuthSpec{Managed: false},
+				},
+			},
+		}
+
+		assert.Nil(t, gcc.RoleFor(&gwv1beta1.Gateway{}))
+	})
+
+	t.Run("managed auth with no podSecurityPolicy", func(t *testing.T) {
+		gcc := &GatewayClassConfig{
+			Spec: GatewayClassConfigSpec{
+				ConsulSpec: ConsulSpec{
+					AuthSpec: AuthSpec{
+						Managed:           true,
+						PodSecurityPolicy: "",
+					},
+				},
+			},
+		}
+		assert.Nil(t, gcc.RoleFor(&gwv1beta1.Gateway{}))
+	})
+
+	t.Run("managed auth with podSecurityPolicy", func(t *testing.T) {
+		gcc := &GatewayClassConfig{
+			Spec: GatewayClassConfigSpec{
+				ConsulSpec: ConsulSpec{
+					AuthSpec: AuthSpec{
+						Managed:           true,
+						PodSecurityPolicy: "myPodSecurityPolicy",
+					},
+				},
+			},
+		}
+
+		gw := &gwv1beta1.Gateway{ObjectMeta: meta.ObjectMeta{Name: t.Name(), Namespace: t.Name()}}
+
+		role := gcc.RoleFor(gw)
+		require.NotNil(t, role)
+		assert.Equal(t, t.Name(), role.Name)
+		assert.Equal(t, t.Name(), role.Namespace)
+		assert.Equal(t, utils.LabelsForGateway(gw), role.Labels)
+
+		require.Len(t, role.Rules, 1)
+		assert.ElementsMatch(t, []string{"policy"}, role.Rules[0].APIGroups)
+		assert.ElementsMatch(t, []string{"podsecuritypolicies"}, role.Rules[0].Resources)
+		assert.ElementsMatch(t, []string{"myPodSecurityPolicy"}, role.Rules[0].ResourceNames)
+		assert.ElementsMatch(t, []string{"use"}, role.Rules[0].Verbs)
+	})
+}
+
+func TestGatewayClassConfig_RoleBindingFor(t *testing.T) {
+	t.Run("unmanaged auth", func(t *testing.T) {
+		gcc := &GatewayClassConfig{
+			Spec: GatewayClassConfigSpec{
+				ConsulSpec: ConsulSpec{
+					AuthSpec: AuthSpec{Managed: false},
+				},
+			},
+		}
+
+		assert.Nil(t, gcc.ServiceAccountFor(&gwv1beta1.Gateway{}))
+	})
+
+	t.Run("managed auth with no podSecurityPolicy", func(t *testing.T) {
+		gcc := &GatewayClassConfig{
+			Spec: GatewayClassConfigSpec{
+				ConsulSpec: ConsulSpec{
+					AuthSpec: AuthSpec{
+						Managed:           true,
+						PodSecurityPolicy: "",
+					},
+				},
+			},
+		}
+		assert.Nil(t, gcc.RoleFor(&gwv1beta1.Gateway{}))
+	})
+
+	t.Run("managed auth with podSecurityPolicy", func(t *testing.T) {
+		gcc := &GatewayClassConfig{
+			Spec: GatewayClassConfigSpec{
+				ConsulSpec: ConsulSpec{
+					AuthSpec: AuthSpec{
+						Managed:           true,
+						PodSecurityPolicy: "myPodSecurityPolicy",
+					},
+				},
+			},
+		}
+
+		gw := &gwv1beta1.Gateway{ObjectMeta: meta.ObjectMeta{Name: t.Name(), Namespace: t.Name()}}
+
+		binding := gcc.RoleBindingFor(gw)
+		require.NotNil(t, binding)
+		assert.Equal(t, gw.Name, binding.Name)
+		assert.Equal(t, gw.Namespace, binding.Namespace)
+		assert.Equal(t, utils.LabelsForGateway(gw), binding.Labels)
+
+		assert.Equal(t, "rbac.authorization.k8s.io", binding.RoleRef.APIGroup)
+		assert.Equal(t, "Role", binding.RoleRef.Kind)
+		assert.Equal(t, gw.Name, binding.RoleRef.Name)
+
+		require.Len(t, binding.Subjects, 1)
+		assert.Equal(t, "ServiceAccount", binding.Subjects[0].Kind)
+		assert.Equal(t, gw.Name, binding.Subjects[0].Name)
+		assert.Equal(t, gw.Namespace, binding.Subjects[0].Namespace)
+	})
+}
+
+func TestGatewayClassConfig_ServiceAccountFor(t *testing.T) {
+	t.Run("unmanaged auth", func(t *testing.T) {
+		gcc := &GatewayClassConfig{
+			Spec: GatewayClassConfigSpec{
+				ConsulSpec: ConsulSpec{
+					AuthSpec: AuthSpec{Managed: false},
+				},
+			},
+		}
+
+		assert.Nil(t, gcc.ServiceAccountFor(&gwv1beta1.Gateway{}))
+	})
+
+	t.Run("managed auth", func(t *testing.T) {
+		gcc := &GatewayClassConfig{
+			Spec: GatewayClassConfigSpec{
+				ConsulSpec: ConsulSpec{
+					AuthSpec: AuthSpec{Managed: true},
+				},
+			},
+		}
+
+		gw := &gwv1beta1.Gateway{ObjectMeta: meta.ObjectMeta{Name: t.Name(), Namespace: t.Name()}}
+
+		sa := gcc.ServiceAccountFor(gw)
+		require.NotNil(t, sa)
+		assert.Equal(t, t.Name(), sa.Name)
+		assert.Equal(t, t.Name(), sa.Namespace)
+		assert.Equal(t, utils.LabelsForGateway(gw), sa.Labels)
+	})
 }


### PR DESCRIPTION
> **Note** Depends on the changes proposed in https://github.com/hashicorp/consul-k8s/pull/1672 which was recently merged.

### Changes proposed in this PR:
When creating a `Deployment` for a given `Gateway`, we create a "managed" `ServiceAccount` if the `GatewayClassConfig` indicates that we should.

With the changes in this PR, we will also create a `Role` and `RoleBinding` attaching the named `podSecurityPolicy` from the `GatewayClassConfig` if one has been provided.

> **Note** For convenience, the Helm chart changes merged in https://github.com/hashicorp/consul-k8s/pull/1672 will create a `PodSecurityPolicy` that is reasonable for these deployments when `.Values.global.enablePodSecurityPolicies`; however, users may also create their own `PodSecurityPolicy` and reference that in the `GatewayClassConfig` if they wish.

### How I've tested this PR:
Create a K8s cluster that requires `PodSecurityPolicies`. In GKE, this is:

```shell
$ gcloud beta container clusters create cluster-1 --region us-east1 --enable-pod-security-policy
```

Install the Consul Helm chart from https://github.com/hashicorp/consul-k8s/pull/1672 and exercise Consul API Gateway functionality.

### How I expect reviewers to test this PR:
See above

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
