### PR TITLE
Update `./dev/run` for Kubernetes 1.24

### DIFF
--- a/dev/config/helm/consul.yaml
+++ b/dev/config/helm/consul.yaml
@@ -1,6 +1,5 @@
 global:
   name: consul
-  image: "hashicorpdev/consul:581357c32"
   tls:
     enabled: true
     serverAdditionalDNSSANs:

--- a/dev/config/k8s/service-account-secret.yaml
+++ b/dev/config/k8s/service-account-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: consul-api-gateway
+  annotations:
+    kubernetes.io/service-account.name: consul-api-gateway
+type: kubernetes.io/service-account-token

--- a/dev/config/k8s/service-account.yaml
+++ b/dev/config/k8s/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: consul-api-gateway

--- a/dev/run
+++ b/dev/run
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+K8S_VERSION=1.24.7
+CONSUL_K8S_VERSION=0.49.0
+
 enableHelmRepo() {
   echo "Enabling Hashicorp Helm repo"
   (helm repo add hashicorp https://helm.releases.hashicorp.com && helm repo update) 2>&1 > /dev/null
@@ -20,7 +23,7 @@ createCluster() {
     echo "consul-api-gateway cluster already exists"
     exit 1
   fi
-  kind create cluster --name consul-api-gateway --config=dev/config/kind/cluster.yaml
+  kind create cluster --name consul-api-gateway --config=dev/config/kind/cluster.yaml --image kindest/node:v$K8S_VERSION
 }
 
 installGatewayCRDs() {
@@ -30,7 +33,8 @@ installGatewayCRDs() {
 
 createServiceAccountForRBAC() {
   echo "Creating consul-api-gateway Service Account"
-  kubectl create serviceaccount consul-api-gateway 2>&1 > /dev/null
+  kubectl apply -f dev/config/k8s/service-account.yaml 2>&1 > /dev/null
+  kubectl apply -f dev/config/k8s/service-account-secret.yaml 2>&1 > /dev/null
   kubectl apply -f dev/config/k8s/rbac.yaml 2>&1 > /dev/null
 }
 
@@ -44,7 +48,7 @@ createNginxIngress() {
 
 installConsul() {
   echo "Installing consul helm chart"
-  helm install consul hashicorp/consul --version 0.41.1 -f dev/config/helm/consul.yaml 2>&1 > /dev/null
+  helm install consul hashicorp/consul --version $CONSUL_K8S_VERSION -f dev/config/helm/consul.yaml 2>&1 > /dev/null
   echo "Waiting for consul to stabilize"
   sleep 10
   kubectl wait --for=condition=ready pod --selector=app=consul,component=server,release=consul --timeout=90s
@@ -53,7 +57,7 @@ installConsul() {
 
 setupAuthMethod() {
   echo "Importing Kubernetes Configuration"
-  export K8S_JWT=$(kubectl get secret $(kubectl get serviceaccounts consul-api-gateway -o json | jq '.secrets[0].name' -r) -o json | jq '.data.token' -r | base64 -d)
+  export K8S_JWT=$(kubectl get secret consul-api-gateway -o json | jq '.data.token' -r | base64 -d)
   export K8S_HOST=$(kind get kubeconfig --name consul-api-gateway --internal | grep server | tr -s ' '| cut -d' ' -f3)
   export K8S_CERT=$(kubectl config view -o jsonpath='{.clusters[].cluster.certificate-authority-data}' --raw | base64 -d)
 


### PR DESCRIPTION
### Changes proposed in this PR:

With Kubernetes 1.24, Service Accounts no longer get a secret with an access token by default.

- Added a step in the `./dev/run` demo that creates the secret. 
- Changed how the secret is accessed in accordance with 1.24's changes. 
- Removed the pinned Consul version from the Helm chart, now we can use what the Consul-k8s Helm chart uses by default.
- Set versions for K8s and Consul-k8s as constants at the top of the file so we can more easily update them in the future.

I chose 1.24 as the K8s version instead of 1.25 because I think Consul-k8s still has some gaps in supporting 1.25.

### How I've tested this PR:

- Ran through [this onboarding doc](https://github.com/hashicorp/consul-api-gateway/blob/main/dev/docs/getting-started.md)

### How I expect reviewers to test this PR:

You may also run through the onboarding if you so desire.

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
