### PR TITLE
Add go-discover binary for exec-based discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+FROM golang:1.19.1-alpine as go-discover
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@49f60c093101c9c5f6b04d5b1c80164251a761a6
+
 # ===================================
 #
 #   Non-release images.
@@ -24,6 +27,8 @@ ARG BIN_NAME
 # Export BIN_NAME for the CMD below, it can't see ARGs directly.
 ENV BIN_NAME=$BIN_NAME
 COPY --from=devbuild /build/$BIN_NAME /bin/
+COPY --from=go-discover /go/bin/discover /bin/
+
 ENTRYPOINT /bin/$BIN_NAME
 CMD ["version"]
 
@@ -84,6 +89,7 @@ RUN addgroup $PRODUCT_NAME && \
     adduser --system --uid 101 --group $PRODUCT_NAME
 
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+COPY --from=go-discover /go/bin/discover /bin/
 
 USER 101
 ENTRYPOINT /bin/$BIN_NAME

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,9 @@
+FROM golang:1.19.1-alpine as go-discover
+RUN CGO_ENABLED=0 go install github.com/hashicorp/go-discover/cmd/discover@49f60c093101c9c5f6b04d5b1c80164251a761a6
+
 FROM alpine:latest
 
+COPY --from=go-discover /go/bin/discover /bin/
 COPY ./consul-api-gateway /bin/consul-api-gateway
 ENTRYPOINT ["/bin/consul-api-gateway"]
 CMD ["version"]

--- a/internal/k8s/builder/gateway.go
+++ b/internal/k8s/builder/gateway.go
@@ -289,7 +289,7 @@ func (b *GatewayDeploymentBuilder) envVars() []corev1.EnvVar {
 		},
 		{
 			Name:  "PATH",
-			Value: "/bin:/usr/bin:/usr/bin/local:/bootstrap",
+			Value: "/:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap",
 		},
 	}
 

--- a/internal/k8s/builder/gateway.go
+++ b/internal/k8s/builder/gateway.go
@@ -210,8 +210,7 @@ func (b *GatewayDeploymentBuilder) podSpec() corev1.PodSpec {
 			Name:         "consul-api-gateway-init",
 			VolumeMounts: mounts,
 			Command: []string{
-				"cp", "/bin/consul-api-gateway", "/bootstrap/consul-api-gateway",
-				"cp", "/bin/discover", "/bootstrap/discover",
+				"cp", "/bin/discover", "/bin/consul-api-gateway", "/bootstrap/",
 			},
 		}},
 		Containers: []corev1.Container{{

--- a/internal/k8s/builder/gateway.go
+++ b/internal/k8s/builder/gateway.go
@@ -211,6 +211,7 @@ func (b *GatewayDeploymentBuilder) podSpec() corev1.PodSpec {
 			VolumeMounts: mounts,
 			Command: []string{
 				"cp", "/bin/consul-api-gateway", "/bootstrap/consul-api-gateway",
+				"cp", "/bin/discover", "/bootstrap/discover",
 			},
 		}},
 		Containers: []corev1.Container{{
@@ -286,6 +287,10 @@ func (b *GatewayDeploymentBuilder) envVars() []corev1.EnvVar {
 					FieldPath: "status.hostIP",
 				},
 			},
+		},
+		{
+			Name:  "PATH",
+			Value: "/bin:/usr/bin:/usr/bin/local:/bootstrap",
 		},
 	}
 

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: PATH
+          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:
@@ -98,8 +100,9 @@ spec:
       initContainers:
       - command:
         - cp
+        - /bin/discover
         - /bin/consul-api-gateway
-        - /bootstrap/consul-api-gateway
+        - /bootstrap/
         image: hashicorp/consul-api-gateway:0.5.0
         name: consul-api-gateway-init
         resources: {}

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PATH
-          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
+          value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: PATH
+          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:
@@ -98,8 +100,9 @@ spec:
       initContainers:
       - command:
         - cp
+        - /bin/discover
         - /bin/consul-api-gateway
-        - /bootstrap/consul-api-gateway
+        - /bootstrap/
         image: hashicorp/consul-api-gateway:0.5.0
         name: consul-api-gateway-init
         resources: {}

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PATH
-          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
+          value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:

--- a/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PATH
-          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
+          value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:

--- a/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: PATH
+          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:
@@ -98,8 +100,9 @@ spec:
       initContainers:
       - command:
         - cp
+        - /bin/discover
         - /bin/consul-api-gateway
-        - /bootstrap/consul-api-gateway
+        - /bootstrap/
         image: hashicorp/consul-api-gateway:0.2.1
         name: consul-api-gateway-init
         resources: {}

--- a/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PATH
-          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
+          value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:

--- a/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: PATH
+          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:
@@ -98,8 +100,9 @@ spec:
       initContainers:
       - command:
         - cp
+        - /bin/discover
         - /bin/consul-api-gateway
-        - /bootstrap/consul-api-gateway
+        - /bootstrap/
         image: hashicorp/consul-api-gateway:0.2.1
         name: consul-api-gateway-init
         resources: {}

--- a/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PATH
-          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
+          value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:

--- a/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: PATH
+          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:
@@ -98,8 +100,9 @@ spec:
       initContainers:
       - command:
         - cp
+        - /bin/discover
         - /bin/consul-api-gateway
-        - /bootstrap/consul-api-gateway
+        - /bootstrap/
         image: hashicorp/consul-api-gateway:0.2.1
         name: consul-api-gateway-init
         resources: {}

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -75,6 +75,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: PATH
+          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:
@@ -102,8 +104,9 @@ spec:
       initContainers:
       - command:
         - cp
+        - /bin/discover
         - /bin/consul-api-gateway
-        - /bootstrap/consul-api-gateway
+        - /bootstrap/
         image: hashicorp/consul-api-gateway:0.5.0
         name: consul-api-gateway-init
         resources: {}

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -76,7 +76,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PATH
-          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
+          value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest
         name: consul-api-gateway
         ports:

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -74,7 +74,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PATH
-          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
+          value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         - name: CONSUL_CACERT
           value: /consul/tls/ca.pem
         image: envoyproxy/envoy:v1.21-latest

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: PATH
+          value: /bin:/usr/bin:/usr/bin/local:/bootstrap
         - name: CONSUL_CACERT
           value: /consul/tls/ca.pem
         image: envoyproxy/envoy:v1.21-latest
@@ -99,8 +101,9 @@ spec:
       initContainers:
       - command:
         - cp
+        - /bin/discover
         - /bin/consul-api-gateway
-        - /bootstrap/consul-api-gateway
+        - /bootstrap/
         image: hashicorp/consul-api-gateway:0.5.0
         name: consul-api-gateway-init
         resources: {}

--- a/internal/testing/e2e/docker.go
+++ b/internal/testing/e2e/docker.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -35,7 +36,7 @@ func BuildDockerImage(ctx context.Context, cfg *envconf.Config) (context.Context
 	if err != nil {
 		return nil, err
 	}
-	_, err = dockerClient.ImageBuild(ctx, tar, types.ImageBuildOptions{
+	r, err := dockerClient.ImageBuild(ctx, tar, types.ImageBuildOptions{
 		Dockerfile: "Dockerfile.local",
 		Tags:       []string{tag},
 		Remove:     true,
@@ -43,6 +44,13 @@ func BuildDockerImage(ctx context.Context, cfg *envconf.Config) (context.Context
 	if err != nil {
 		return nil, err
 	}
+	defer r.Body.Close()
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	log.Print(string(b))
+
 	return context.WithValue(ctx, dockerImageContextKey, tag), nil
 }
 


### PR DESCRIPTION
### Changes proposed in this PR:

To go along with the movement towards the use of `consul-server-connection-manager`, I noticed that to make the "exec" mode actually useful, `consul-dataplane` vendors the [`hashicorp/go-discover` binary](https://github.com/hashicorp/consul-dataplane/blob/23748fbd2bb740b1a2fecaf58bc5b5a38d67d1d0/Dockerfile#L82). This does the same to make sure we actually have useful "discovery" binaries on disk for any `exec=...` host strings passed to `consul-server-connection-manager`.

Additionally, since we execute in the context of the envoy container rather than our own envoy vendored container (a deliberate decision early on to avoid having to rev our own containers if envoy CVEs dropped), I added a `PATH` environment variable that I believe should be sufficient for executing both `discover` and whatever other binaries someone is likely to package in a custom `envoy` container (in any official release, `envoy` is at `/usr/local/bin/envoy`).

I'll verify this all when we merge the connection-manager work.

Since I think this can be part of a changelog entry regarding `consul-server-connection-manager` incorporation, marking this as `pr/no-changelog`.

### How I've tested this PR:

Unit tests, will verify e2e with actual `exec=...` before merge.