### PR TITLE
Add forgotten COPY command in default release docker target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN addgroup $PRODUCT_NAME && \
     adduser -S -G $PRODUCT_NAME 100
 
 COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+COPY --from=go-discover /go/bin/discover /bin/
 
 USER 100
 ENTRYPOINT /bin/$BIN_NAME


### PR DESCRIPTION
### Changes proposed in this PR:

https://github.com/hashicorp/consul-api-gateway/pull/446 Added `go-discover` to our containers and slightly changed our init container process. I forgot to add the `COPY` command to 1 of the 3 docker targets in our Dockerfile. This fixes that.