### PR TITLE
Add TLS server name and partition CRD extensions

### DIFF
--- a/.changelog/450.txt
+++ b/.changelog/450.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add optional `consul.partition` and `consul.serverName` to GatewayClassConfig CRD. If set these will be used to initialize the partition and server name used in TLS verification for communicating with Consul in a deployment.
+```

--- a/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -78,6 +78,9 @@ spec:
                           to bind to the managed ServiceAccount if managed is true.
                         type: string
                     type: object
+                  partition:
+                    description: The partition in which the gateway is registered.
+                    type: string
                   ports:
                     description: The information about Consul's ports
                     properties:
@@ -93,6 +96,11 @@ spec:
                     enum:
                     - http
                     - https
+                    type: string
+                  serverName:
+                    description: The server name presented by the server's TLS certificate.
+                      This is useful when attempting to talk to a Consul server over
+                      TLS while referencing it via ip address.
                     type: string
                 type: object
               copyAnnotations:

--- a/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
+++ b/config/crd/bases/api-gateway.consul.hashicorp.com_gatewayclassconfigs.yaml
@@ -79,7 +79,8 @@ spec:
                         type: string
                     type: object
                   partition:
-                    description: The partition in which the gateway is registered.
+                    description: The Consul admin partition in which the gateway is
+                      registered. https://developer.hashicorp.com/consul/tutorials/enterprise/consul-admin-partitions
                     type: string
                   ports:
                     description: The information about Consul's ports

--- a/internal/k8s/builder/builder.go
+++ b/internal/k8s/builder/builder.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -38,6 +39,11 @@ const (
 	consulCAFilename  = "ca.pem"
 
 	k8sHostnameTopologyKey = "kubernetes.io/hostname"
+)
+
+var (
+	defaultPartition  = os.Getenv("CONSUL_PARTITION")
+	defaultServerName = os.Getenv("CONSUL_TLS_SERVER_NAME")
 )
 
 var consulCALocalFile = filepath.Join(consulCALocalPath, consulCAFilename)

--- a/internal/k8s/builder/gateway.go
+++ b/internal/k8s/builder/gateway.go
@@ -288,6 +288,14 @@ func (b *GatewayDeploymentBuilder) envVars() []corev1.EnvVar {
 			},
 		},
 		{
+			Name:  "CONSUL_PARTITION",
+			Value: orDefault(b.gwConfig.Spec.ConsulSpec.Partition, defaultPartition),
+		},
+		{
+			Name:  "CONSUL_TLS_SERVER_NAME",
+			Value: orDefault(b.gwConfig.Spec.ConsulSpec.ServerName, defaultServerName),
+		},
+		{
 			Name:  "PATH",
 			Value: "/:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap",
 		},

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: CONSUL_PARTITION
+        - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: CONSUL_PARTITION
+        - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest

--- a/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: CONSUL_PARTITION
+        - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest

--- a/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: CONSUL_PARTITION
+        - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest

--- a/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: CONSUL_PARTITION
+        - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -75,6 +75,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: CONSUL_PARTITION
+        - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         image: envoyproxy/envoy:v1.21-latest

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -73,6 +73,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: CONSUL_PARTITION
+        - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         - name: CONSUL_CACERT

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -95,7 +95,8 @@ type ConsulSpec struct {
 	// The scheme to use for connecting to Consul.
 	// +kubebuilder:validation:Enum=http;https
 	Scheme string `json:"scheme,omitempty"`
-	// The partition in which the gateway is registered.
+	// The Consul admin partition in which the gateway is registered.
+	// https://developer.hashicorp.com/consul/tutorials/enterprise/consul-admin-partitions
 	Partition string `json:"partition,omitempty"`
 	// The server name presented by the server's TLS certificate. This is
 	// useful when attempting to talk to a Consul server over TLS while

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -95,6 +95,12 @@ type ConsulSpec struct {
 	// The scheme to use for connecting to Consul.
 	// +kubebuilder:validation:Enum=http;https
 	Scheme string `json:"scheme,omitempty"`
+	// The partition in which the gateway is registered.
+	Partition string `json:"partition,omitempty"`
+	// The server name presented by the server's TLS certificate. This is
+	// useful when attempting to talk to a Consul server over TLS while
+	// referencing it via ip address.
+	ServerName string `json:"serverName,omitempty"`
 	// The address of the consul server to communicate with in the gateway
 	// pod. If not specified, the pod will attempt to use a local agent on
 	// the host on which it is running.


### PR DESCRIPTION
### Changes proposed in this PR:

This adds support for setting the `CONSUL_PARTITION` and `CONSUL_TLS_SERVER_NAME` environment variables to support some of our changes for agentless.

### How I've tested this PR:

Installed via helm and saw the values being set and the container starting up even when the values are empty.

### Checklist:
- [x] CHANGELOG entry added 
