### PR TITLE
Add fallback to no gRPC

### DIFF
--- a/.github/workflows/conformance_with_build.yml
+++ b/.github/workflows/conformance_with_build.yml
@@ -50,7 +50,7 @@ jobs:
             api-gateway-image: "hashicorppreview/consul-api-gateway:0.4-dev"
             consul-image: "hashicorppreview/consul:1.14-dev"
             envoy-image: "envoyproxy/envoy:v1.22-latest"
-            consul-k8s-version: "v0.49.0"
+            consul-k8s-version: "main"
       fail-fast: true
     name: "${{ matrix.config.name }}"
 

--- a/internal/commands/exec/command.go
+++ b/internal/commands/exec/command.go
@@ -169,12 +169,9 @@ func (c *Command) Run(args []string) (ret int) {
 		bearerToken = strings.TrimSpace(string(data))
 	}
 
-	if c.flagGatewayNamespace != "" {
-		cfg.Namespace = c.flagGatewayNamespace
-	}
-
 	consulClientConfig := consul.ClientConfig{
 		Name:            c.flagGatewayName,
+		Namespace:       c.flagGatewayNamespace,
 		ApiClientConfig: cfg,
 		UseDynamic:      os.Getenv("CONSUL_DYNAMIC_SERVER_DISCOVERY") == "true",
 		Addresses:       c.flagConsulHTTPAddress,

--- a/internal/commands/exec/command.go
+++ b/internal/commands/exec/command.go
@@ -174,7 +174,9 @@ func (c *Command) Run(args []string) (ret int) {
 	}
 
 	consulClientConfig := consul.ClientConfig{
+		Name:            c.flagGatewayName,
 		ApiClientConfig: cfg,
+		UseDynamic:      os.Getenv("CONSUL_DYNAMIC_SERVER_DISCOVERY") == "true",
 		Addresses:       c.flagConsulHTTPAddress,
 		HTTPPort:        c.flagConsulHTTPPort,
 		GRPCPort:        c.flagConsulXDSPort,

--- a/internal/commands/exec/command_test.go
+++ b/internal/commands/exec/command_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -124,6 +125,7 @@ func TestExec(t *testing.T) {
 		output: "did not get state within time limit",
 	}} {
 		t.Run(test.name, func(t *testing.T) {
+			os.Setenv("CONSUL_DYNAMIC_SERVER_DISCOVERY", "true")
 			ctx := context.Background()
 			ui := cli.NewMockUi()
 			var buffer gwTesting.Buffer

--- a/internal/commands/exec/exec_test.go
+++ b/internal/commands/exec/exec_test.go
@@ -468,6 +468,7 @@ func runMockConsulServer(t *testing.T, opts mockConsulOptions) *mockConsulServer
 	})
 
 	server.clientConfig = consul.ClientConfig{
+		UseDynamic:      true,
 		Addresses:       serverURL.Hostname(),
 		ApiClientConfig: clientConfig,
 		GRPCPort:        grpcPort,

--- a/internal/commands/server/server.go
+++ b/internal/commands/server/server.go
@@ -167,14 +167,21 @@ func registerSecretClients(config ServerConfig) (*envoy.MultiSecretClient, error
 	return secretClient, nil
 }
 
-func parseConsulHTTPAddress() (cmd string, port int, err error) {
+func parseConsulHTTPAddress() (scheme string, cmd string, port int, err error) {
 	consulhttpAddress := os.Getenv(consulHTTPAddressEnvName)
+	scheme = "http"
+	if os.Getenv("CONSUL_HTTP_SSL") == "true" || strings.HasPrefix(consulhttpAddress, "https://") {
+		scheme = "https"
+	}
 
+	// (?:http|https|ftp)://)
+	consulhttpAddress = strings.TrimPrefix(consulhttpAddress, "http://")
+	consulhttpAddress = strings.TrimPrefix(consulhttpAddress, "https://")
 	index := strings.LastIndex(consulhttpAddress, ":")
 	cmd, portString := consulhttpAddress[:index], consulhttpAddress[index+1:]
 	port, err = strconv.Atoi(portString)
 	if err != nil {
-		return "", 0, err
+		return "", "", 0, err
 	}
-	return cmd, port, nil
+	return scheme, cmd, port, nil
 }

--- a/internal/k8s/builder/gateway.go
+++ b/internal/k8s/builder/gateway.go
@@ -297,6 +297,10 @@ func (b *GatewayDeploymentBuilder) envVars() []corev1.EnvVar {
 			Value: os.Getenv("CONSUL_LOGIN_DATACENTER"),
 		},
 		{
+			Name:  "CONSUL_DYNAMIC_SERVER_DISCOVERY",
+			Value: os.Getenv("CONSUL_DYNAMIC_SERVER_DISCOVERY"),
+		},
+		{
 			Name:  "CONSUL_PARTITION",
 			Value: orDefault(b.gwConfig.Spec.ConsulSpec.Partition, defaultPartition),
 		},

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -75,6 +75,7 @@ spec:
               fieldPath: status.hostIP
         - name: CONSUL_LOGIN_PARTITION
         - name: CONSUL_LOGIN_DATACENTER
+        - name: CONSUL_DYNAMIC_SERVER_DISCOVERY
         - name: CONSUL_PARTITION
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -75,6 +75,7 @@ spec:
               fieldPath: status.hostIP
         - name: CONSUL_LOGIN_PARTITION
         - name: CONSUL_LOGIN_DATACENTER
+        - name: CONSUL_DYNAMIC_SERVER_DISCOVERY
         - name: CONSUL_PARTITION
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH

--- a/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
@@ -75,6 +75,7 @@ spec:
               fieldPath: status.hostIP
         - name: CONSUL_LOGIN_PARTITION
         - name: CONSUL_LOGIN_DATACENTER
+        - name: CONSUL_DYNAMIC_SERVER_DISCOVERY
         - name: CONSUL_PARTITION
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH

--- a/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
@@ -75,6 +75,7 @@ spec:
               fieldPath: status.hostIP
         - name: CONSUL_LOGIN_PARTITION
         - name: CONSUL_LOGIN_DATACENTER
+        - name: CONSUL_DYNAMIC_SERVER_DISCOVERY
         - name: CONSUL_PARTITION
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH

--- a/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
@@ -75,6 +75,7 @@ spec:
               fieldPath: status.hostIP
         - name: CONSUL_LOGIN_PARTITION
         - name: CONSUL_LOGIN_DATACENTER
+        - name: CONSUL_DYNAMIC_SERVER_DISCOVERY
         - name: CONSUL_PARTITION
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -77,6 +77,7 @@ spec:
               fieldPath: status.hostIP
         - name: CONSUL_LOGIN_PARTITION
         - name: CONSUL_LOGIN_DATACENTER
+        - name: CONSUL_DYNAMIC_SERVER_DISCOVERY
         - name: CONSUL_PARTITION
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -75,6 +75,7 @@ spec:
               fieldPath: status.hostIP
         - name: CONSUL_LOGIN_PARTITION
         - name: CONSUL_LOGIN_DATACENTER
+        - name: CONSUL_DYNAMIC_SERVER_DISCOVERY
         - name: CONSUL_PARTITION
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH


### PR DESCRIPTION
### Changes proposed in this PR:

Add an opt-in value for trying to use the new dynamic server discovery components. This is needed because agent (non-server) nodes don't have the requisite gRPC endpoints to actually use the connection manager library. When the `CONSUL_DYNAMIC_SERVER_DISCOVERY` is not set, then we do things in the "old way" without gRPC, otherwise if it's set we know we're talking to a server and can use gRPC.

### How I've tested this PR:

Manually w/ Consul 1.12 + 1.13 and consul-k8s 0.49.1 and consul-k8s main branch in both agent and agentless mode pending my PR that I'll link here.
