### PR TITLE
Prepare for release of v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ## UNRELEASED
 
+## 0.5.0 (November 17, 2022)
+
+FEATURES:
+
+* Switch deployed gateways to use TTL-based health checks to better support running with Consul servers that are not on the same network as a gateway [[GH-371](https://github.com/hashicorp/consul-api-gateway/issues/371)]
+
+IMPROVEMENTS:
+
+* Add optional `consul.partition` and `consul.serverName` to GatewayClassConfig CRD. If set these will be used to initialize the partition and server name used in TLS verification for communicating with Consul in a deployment. [[GH-450](https://github.com/hashicorp/consul-api-gateway/issues/450)]
+* Add optional `podSecurityPolicy` to GatewayClassConfig CRD. If set and "managed" ServiceAccounts are being used, a Role and RoleBinding are created to attach the named `PodSecurityPolicy` to the managed ServiceAccount. [[GH-433](https://github.com/hashicorp/consul-api-gateway/issues/433)]
+* Add optional configuration for maximum upstream connections to GatewayClassConfig CRD. If unset, behavior is unchanged and Envoy's default will be used. [[GH-405](https://github.com/hashicorp/consul-api-gateway/issues/405)]
+* Add support for tolerations to Consul API Gateway Controller and GatewayClassConfig. [[GH-426](https://github.com/hashicorp/consul-api-gateway/issues/426)]
+* Integrate consul-server-connection-manager to support Agentless consul server discovery [[GH-449](https://github.com/hashicorp/consul-api-gateway/issues/449)]
+* Support distroless Envoy images (with continued support for distroful images) [[GH-391](https://github.com/hashicorp/consul-api-gateway/issues/391)]
+* api: add OpenAPI schema and stubs for bootstrap token CRUD [[GH-384](https://github.com/hashicorp/consul-api-gateway/issues/384)]
+* go: update to Go v1.19 [[GH-424](https://github.com/hashicorp/consul-api-gateway/issues/424)]
+* makefile: switch back to upstream go-changelog repo [[GH-385](https://github.com/hashicorp/consul-api-gateway/issues/385)]
+
+BUG FIXES:
+
+* Delete gateway ACL tokens on shutdown so they are not orphaned after being provisioned at startup. [[GH-377](https://github.com/hashicorp/consul-api-gateway/issues/377)]
+* Fix failing root certificate watch for controller when deployed in secondary federated datacenter. [[GH-368](https://github.com/hashicorp/consul-api-gateway/issues/368)]
+* When a gateway is created in a namespace that doesn't exist in Consul and namespace mirroring is enabled, create the namespace in Consul. [[GH-397](https://github.com/hashicorp/consul-api-gateway/issues/397)]
+
+NOTES:
+
+* RefNotPermitted error is now returned instead of InvalidCertificateRef in the case where a cross namespace certificate is not allowed by a ReferenceGrant [[GH-412](https://github.com/hashicorp/consul-api-gateway/issues/412)]
+
 ## 0.4.0 (August 16, 2022)
 DEPRECATIONS:
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Consul API Gateway implements the Kubernetes [Gateway API Specification](https:/
 ## Prerequisites
 
 The Consul API Gateway must be installed on a Kubernetes cluster with the [Consul K8s](https://github.com/hashicorp/consul-k8s) service
-mesh deployed on it. The installed version of Consul must be `v1.11.2` or greater.
+mesh deployed on it. The installed version of Consul must be `v1.12` or greater.
 
 The Consul Helm chart must be used, with specific settings, to install Consul on the Kubernetes
-cluster. The Consul Helm chart must be version `0.47.1` or greater. See the Consul API Gateway documentation for the required settings.
+cluster. The Consul Helm chart must be version `0.49.1` or greater. See the Consul API Gateway documentation for the required settings.
 
 # Documentation
 

--- a/config/deployment/deployment.yaml
+++ b/config/deployment/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: consul-api-gateway-controller
       containers:
-      - image: hashicorp/consul-api-gateway:0.4.0
+      - image: hashicorp/consul-api-gateway:0.5.0
         command: ["consul-api-gateway", "server", "-consul-address", "$(HOST_IP):8501", "-ca-file", "/ca/tls.crt", "-sds-server-host", "$(IP)", "-k8s-namespace", "$(CONSUL_K8S_NAMESPACE)", "-log-level", "$(LOG_LEVEL)"]
         name: consul-api-gateway-controller
         ports:

--- a/dev/docs/example-setup.md
+++ b/dev/docs/example-setup.md
@@ -72,8 +72,8 @@ We have provided a set of `kustomize` manifests for installing the Consul API Ga
 Apply them to your cluster using the following commands.
 
 ```bash
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.4.0"
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.4.0"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.5.0"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.5.0"
 ```
 
 ## Installing the demo Gateway and Mesh Service
@@ -116,7 +116,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.4.0
+- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.5.0
 
 patches:
 - target:

--- a/dev/docs/supported-features.md
+++ b/dev/docs/supported-features.md
@@ -2,7 +2,7 @@
 Below is a list of the Kubernetes Gateway API features supported in the current release of the
 Consul API Gateway.
 
-Consul API Gateway version: **v0.4.0**
+Consul API Gateway version: **v0.5.0**
 Supported K8s Gateway API version: **v1beta1**
 
 Supported features are marked with a grey checkbox


### PR DESCRIPTION
Consul API Gateway version being released: `0.5.0`
Now requires:
- consul: `1.12`
- consul-k8s: `0.49.1`