### PR TITLE
Add fix for when we need to use the system-wide trusted CAs

### DIFF
--- a/.changelog/459.txt
+++ b/.changelog/459.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix being able to use system-wide root certificates in deployments.
+```

--- a/internal/commands/exec/exec.go
+++ b/internal/commands/exec/exec.go
@@ -135,6 +135,7 @@ func RunExec(config ExecConfig) (ret int) {
 			EnvoyBinary:       config.EnvoyConfig.Binary,
 			ExtraArgs:         config.EnvoyConfig.ExtraArgs,
 			Output:            config.EnvoyConfig.Output,
+			ForceTLS:          os.Getenv(api.HTTPSSLEnvName) == "true",
 		},
 	)
 	options := consul.DefaultCertManagerOptions()

--- a/internal/envoy/manager.go
+++ b/internal/envoy/manager.go
@@ -31,6 +31,7 @@ type bootstrapArgs struct {
 	SDSCluster    string
 	Token         string
 	AddressType   string
+	ForceTLS      bool
 }
 
 func init() {
@@ -53,6 +54,7 @@ type ManagerConfig struct {
 	EnvoyBinary       string
 	ExtraArgs         []string
 	Output            io.Writer
+	ForceTLS          bool
 }
 
 // Manager wraps and manages an envoy process and its bootstrap configuration
@@ -115,6 +117,7 @@ func (m *Manager) RenderBootstrap(sdsConfig string) error {
 		ConsulCA:      m.ConsulCA,
 		ConsulAddress: m.ConsulAddress,
 		ConsulXDSPort: m.ConsulXDSPort,
+		ForceTLS:      m.ForceTLS,
 		AddressType:   common.AddressTypeForAddress(m.ConsulAddress),
 		Token:         m.Token,
 	}); err != nil {
@@ -183,6 +186,20 @@ const bootstrapJSONTemplate = `{
               "validation_context": {
                 "trusted_ca": {
                   "filename": "{{ .ConsulCA }}"
+                }
+              }
+            }
+          }
+        },
+        {{- else if .ForceTLS }}
+        "transport_socket": {
+          "name": "tls",
+          "typed_config": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "common_tls_context": {
+              "validation_context": {
+                "trusted_ca": {
+                  "filename": "/etc/ssl/certs/ca-certificates.crt"
                 }
               }
             }


### PR DESCRIPTION
### Changes proposed in this PR:

This adds the simplest path for supporting the helm option `externalServer.useSystemRoots`. Since the controller always passes in a value to the deployment via `CONSUL_CACERT` when the controller knows that the Consul connections are served over TLS, we leverage the fact that it's going to write an empty file to disk that the deployment will then try and use as a file.

Rather than doing a larger re-write of the deployment code to handle cases in which TLS is configured but no certs are passed in (when you want to validate with system-wide certs), I added some code that handles the invalid certificates being passed in, in which case we just fallback to using the system-wide certs. What this entails is:

1. Ensuring that the file passed in `CONSUL_CACERT` is valid.
2. If it isn't, unsetting it but flagging that `CONSUL_USE_SSL` is set to mark that this still needs to talk over SSL
3. Passing this info down to our envoy process manager so that it knows to bootstrap envoy with the proper paths for verifying the Consul SSL connection (i.e. the path to the envoy container's system roots)

### How I've tested this PR:

Verified this on HCP with `useSystemRoots`, with a local consul server node and the self-signed certs that go with it, and with a local node and TLS disabled. These were validated with the changes in https://github.com/hashicorp/consul-k8s/pull/1743. 

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
