### PR TITLE
Prepare for release of v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UNRELEASED
 
-## 0.5.0 (November 18, 2022)
+## 0.5.1 (November 21, 2022)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## UNRELEASED
 
+## 0.5.0 (November 18, 2022)
+
+BUG FIXES:
+
+* Fix being able to use system-wide root certificates in deployments. [[GH-459](https://github.com/hashicorp/consul-api-gateway/issues/459)]
+
 ## 0.5.0 (November 17, 2022)
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Consul API Gateway implements the Kubernetes [Gateway API Specification](https:/
 ## Prerequisites
 
 The Consul API Gateway must be installed on a Kubernetes cluster with the [Consul K8s](https://github.com/hashicorp/consul-k8s) service
-mesh deployed on it. The installed version of Consul must be `v1.12` or greater.
+mesh deployed on it. The installed version of Consul must be `v1.12.0` or greater.
 
 The Consul Helm chart must be used, with specific settings, to install Consul on the Kubernetes
 cluster. The Consul Helm chart must be version `0.49.1` or greater. See the Consul API Gateway documentation for the required settings.

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/discover
         - /bin/consul-api-gateway
         - /bootstrap/
-        image: hashicorp/consul-api-gateway:0.5.0
+        image: hashicorp/consul-api-gateway:0.5.1
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/discover
         - /bin/consul-api-gateway
         - /bootstrap/
-        image: hashicorp/consul-api-gateway:0.5.0
+        image: hashicorp/consul-api-gateway:0.5.1
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/discover
         - /bin/consul-api-gateway
         - /bootstrap/
-        image: hashicorp/consul-api-gateway:0.5.0
+        image: hashicorp/consul-api-gateway:0.5.1
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/discover
         - /bin/consul-api-gateway
         - /bootstrap/
-        image: hashicorp/consul-api-gateway:0.5.0
+        image: hashicorp/consul-api-gateway:0.5.1
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.5.0"
+	Version = "0.5.1"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Consul API Gateway version being released: `0.5.1`
Now requires:
- consul: `1.12.0`
- consul-k8s: `0.49.1`