### PR TITLE
Fix copyright year attribute

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -2,7 +2,7 @@ schema_version = 1
 
 project {
   license        = "MPL-2.0"
-  copyright_year = 2022
+  copyright_year = 2021
 
   # (OPTIONAL) A list of globs that should not have copyright or license headers .
   # Supports doublestar glob patterns for more flexibility in defining which


### PR DESCRIPTION
### Changes proposed in this PR:
During work on #470, I mistakenly gave a `copyright_year` date of 2022 instead of 2021, when this project was originally created. This has the potential to cause license audits to fail, as `copywrite` will expect the attribution header on the `LICENSE` file to match whatever is in this `.copywrite.hcl` config.