### PR TITLE
k8s/controller: always map "default" Consul namespace to empty string

### DIFF
--- a/.changelog/483.txt
+++ b/.changelog/483.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: fix Consul Enterprise gateway sync issue with Kubernetes namespace mirroring disabled and the Consul destination namespace set to "default"
+```

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -169,6 +169,10 @@ func TestGatewayWithoutNamespaceMirroring(t *testing.T) {
 			assert.NoError(t, resources.Delete(ctx, secondGateway))
 			assert.NoError(t, resources.Delete(ctx, thirdGateway))
 
+			// Re-enable namespace mirroring
+			ctx, err := e2e.SetNamespaceMirroring(true)(ctx, nil)
+			require.NoError(t, err)
+
 			return ctx
 		})
 
@@ -344,6 +348,10 @@ func TestGatewayBasic(t *testing.T) {
 
 			// check for the service being registered
 			client := e2e.ConsulClient(ctx)
+            t.Log("k8s namespace:", e2e.Namespace(ctx)
+            t.Log("consul namespace:", e2e.ConsulNamespace(ctx)
+            t.Log("mirroring:", e2e.NamespaceMirroring(ctx)
+
 			require.Eventually(t, func() bool {
 				services, _, err := client.Catalog().Service(gatewayName, "", &api.QueryOptions{
 					Namespace: e2e.ConsulNamespace(ctx),

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -116,6 +116,65 @@ func TestGatewayWithClassConfigChange(t *testing.T) {
 	testenv.Test(t, feature.Feature())
 }
 
+func TestGatewayWithoutNamespaceMirroring(t *testing.T) {
+	feature := features.New("gateway admission").
+		Assess("gateway sync without namespace mirroring", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			namespace := e2e.Namespace(ctx)
+			resources := cfg.Client().Resources(namespace)
+
+			// Disable namespace mirroring
+			ctx, err := e2e.SetNamespaceMirroring(false)(ctx, nil)
+			require.NoError(t, err)
+
+			useHostPorts := false
+			gcc, gc := createGatewayClassWithParams(ctx, t, resources, GatewayClassConfigParams{
+				UseHostPorts: &useHostPorts,
+			})
+			require.Eventually(t, gatewayClassStatusCheck(ctx, resources, gc.Name, namespace, conditionAccepted), checkTimeout, checkInterval, "gatewayclass not accepted in the allotted time")
+
+			// Create an HTTPS Gateway Listener to pass when creating gateways
+			httpsListener := createHTTPSListener(ctx, t, 443)
+
+			// Create a Gateway and wait for it to be ready
+			// This will attempt to sync to a randomly generated Consul desintation namespace
+			firstGatewayName := envconf.RandomName("gw", 16)
+			firstGateway := createGateway(ctx, t, resources, firstGatewayName, namespace, gc, []gwv1beta1.Listener{httpsListener})
+			require.Eventually(t, gatewayStatusCheck(ctx, resources, firstGatewayName, namespace, conditionReady), checkTimeout, checkInterval, "no gateway found in the allotted time")
+			checkGatewayConfigAnnotation(ctx, t, resources, firstGatewayName, namespace, gcc)
+
+			// Set a different Consul destination namespace
+			defaultNamespace := ""
+			ctx, err = e2e.SetConsulNamespace(&defaultNamespace)(ctx, nil)
+			require.NoError(t, err)
+
+			// Create a second Gateway and wait for it to be ready
+			secondGatewayName := envconf.RandomName("gw", 16)
+			secondGateway := createGateway(ctx, t, resources, secondGatewayName, namespace, gc, []gwv1beta1.Listener{httpsListener})
+			require.Eventually(t, gatewayStatusCheck(ctx, resources, secondGatewayName, namespace, conditionReady), checkTimeout, checkInterval, "no gateway found in the allotted time")
+			checkGatewayConfigAnnotation(ctx, t, resources, secondGatewayName, namespace, gcc)
+
+			// Set a different Consul destination namespace
+			defaultEnterpriseNamespace := "default"
+			ctx, err = e2e.SetConsulNamespace(&defaultEnterpriseNamespace)(ctx, nil)
+			require.NoError(t, err)
+
+			// Create a third Gateway and wait for it to be ready
+			thirdGatewayName := envconf.RandomName("gw", 16)
+			thirdGateway := createGateway(ctx, t, resources, thirdGatewayName, namespace, gc, []gwv1beta1.Listener{httpsListener})
+			require.Eventually(t, gatewayStatusCheck(ctx, resources, thirdGatewayName, namespace, conditionReady), checkTimeout, checkInterval, "no gateway found in the allotted time")
+			checkGatewayConfigAnnotation(ctx, t, resources, thirdGatewayName, namespace, gcc)
+
+			// Cleanup
+			assert.NoError(t, resources.Delete(ctx, firstGateway))
+			assert.NoError(t, resources.Delete(ctx, secondGateway))
+			assert.NoError(t, resources.Delete(ctx, thirdGateway))
+
+			return ctx
+		})
+
+	testenv.Test(t, feature.Feature())
+}
+
 func TestGatewayWithReplicas(t *testing.T) {
 	feature := features.New("gateway class config configure instances").
 		Assess("gateway is created with appropriate number of replicas set", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -348,9 +348,9 @@ func TestGatewayBasic(t *testing.T) {
 
 			// check for the service being registered
 			client := e2e.ConsulClient(ctx)
-            t.Log("k8s namespace:", e2e.Namespace(ctx)
-            t.Log("consul namespace:", e2e.ConsulNamespace(ctx)
-            t.Log("mirroring:", e2e.NamespaceMirroring(ctx)
+			t.Log("k8s namespace:", e2e.Namespace(ctx))
+			t.Log("consul namespace:", e2e.ConsulNamespace(ctx))
+			t.Log("mirroring:", e2e.NamespaceMirroring(ctx))
 
 			require.Eventually(t, func() bool {
 				services, _, err := client.Catalog().Service(gatewayName, "", &api.QueryOptions{

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -170,7 +170,7 @@ func TestGatewayWithoutNamespaceMirroring(t *testing.T) {
 			assert.NoError(t, resources.Delete(ctx, thirdGateway))
 
 			// Re-enable namespace mirroring
-			ctx, err := e2e.SetNamespaceMirroring(true)(ctx, nil)
+			ctx, err = e2e.SetNamespaceMirroring(true)(ctx, nil)
 			require.NoError(t, err)
 
 			return ctx

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -66,7 +66,7 @@ func (c ConsulNamespaceConfig) Namespace(namespace string) string {
 
 	// Always map the default namespace to "" for compatibility with Consul OSS
 	if consulNamespace == "default" {
-		consulNamespace = ""
+		return ""
 	}
 
 	return consulNamespace

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -56,10 +56,20 @@ type ConsulNamespaceConfig struct {
 }
 
 func (c ConsulNamespaceConfig) Namespace(namespace string) string {
+	var consulNamespace string
+
 	if c.MirrorKubernetesNamespaces {
-		return c.MirrorKubernetesNamespacePrefix + namespace
+		consulNamespace = c.MirrorKubernetesNamespacePrefix + namespace
+	} else {
+		consulNamespace = c.ConsulDestinationNamespace
 	}
-	return c.ConsulDestinationNamespace
+
+	// Always map the default namespace to "" for compatibility with Consul OSS
+	if consulNamespace == "default" {
+		consulNamespace = ""
+	}
+
+	return consulNamespace
 }
 
 type Kubernetes struct {

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -602,15 +602,19 @@ func SetConsulNamespace(namespace *string) env.Func {
 			if consulEnvironment == nil {
 				return ctx, nil
 			}
-			env := consulEnvironment.(*consulTestEnvironment)
-			_, _, err := env.consulClient.Namespaces().Create(&api.Namespace{
-				Name: *namespace,
-			}, &api.WriteOptions{
-				Token: env.token,
-			})
-			// TODO: ignore error if namespace already exists
-			if err != nil {
-				return nil, err
+			// Passing an empty string for namespace name returns a Consul API error,
+			// and the default namespace should always exist
+			if *namespace != "" {
+				env := consulEnvironment.(*consulTestEnvironment)
+				_, _, err := env.consulClient.Namespaces().Create(&api.Namespace{
+					Name: *namespace,
+				}, &api.WriteOptions{
+					Token: env.token,
+				})
+				// TODO: ignore error if namespace already exists
+				if err != nil {
+					return nil, err
+				}
 			}
 			env.namespace = *namespace
 		}

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -612,7 +612,6 @@ func SetConsulNamespace(namespace *string) env.Func {
 				}, &api.WriteOptions{
 					Token: env.token,
 				})
-				// TODO: ignore error if namespace already exists
 				if err != nil {
 					return nil, err
 				}

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -602,10 +602,11 @@ func SetConsulNamespace(namespace *string) env.Func {
 			if consulEnvironment == nil {
 				return ctx, nil
 			}
+			env := consulEnvironment.(*consulTestEnvironment)
+
 			// Passing an empty string for namespace name returns a Consul API error,
 			// and the default namespace should always exist
 			if *namespace != "" {
-				env := consulEnvironment.(*consulTestEnvironment)
 				_, _, err := env.consulClient.Namespaces().Create(&api.Namespace{
 					Name: *namespace,
 				}, &api.WriteOptions{
@@ -616,6 +617,7 @@ func SetConsulNamespace(namespace *string) env.Func {
 					return nil, err
 				}
 			}
+
 			env.namespace = *namespace
 		}
 		return ctx, nil

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -594,7 +594,8 @@ func SetConsulNamespace(namespace *string) env.Func {
 		if IsEnterprise() {
 			log.Print("Creating Consul Namespace")
 			if namespace == nil {
-				*namespace = envconf.RandomName("consul", 16)
+				name := envconf.RandomName("consul", 16)
+				namespace = &name
 			}
 
 			consulEnvironment := ctx.Value(consulTestContextKey)

--- a/internal/testing/e2e/environment.go
+++ b/internal/testing/e2e/environment.go
@@ -11,14 +11,22 @@ import (
 )
 
 type namespaceContext struct{}
+type namespaceMirroringContext struct{}
 type clusterNameContext struct{}
 
 var namespaceContextKey = namespaceContext{}
+var namespaceMirroringContextKey = namespaceMirroringContext{}
 var clusterNameContextKey = clusterNameContext{}
 
 func SetNamespace(namespace string) env.Func {
 	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 		return context.WithValue(ctx, namespaceContextKey, namespace), nil
+	}
+}
+
+func SetNamespaceMirroring(namespaceMirroring bool) env.Func {
+	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		return context.WithValue(ctx, namespaceMirroringContextKey, namespaceMirroring), nil
 	}
 }
 
@@ -28,6 +36,11 @@ func Namespace(ctx context.Context) string {
 		panic("must run this with an integration test that has called SetNamespace")
 	}
 	return namespace.(string)
+}
+
+func NamespaceMirroring(ctx context.Context) bool {
+	namespaceMirroring := ctx.Value(namespaceMirroringContextKey)
+	return namespaceMirroring.(bool)
 }
 
 func SetClusterName(name string) env.Func {

--- a/internal/testing/e2e/gateway.go
+++ b/internal/testing/e2e/gateway.go
@@ -64,7 +64,7 @@ func (p *gatewayTestEnvironment) run(ctx context.Context, namespace string, cfg 
 		CACert:        ConsulCA(ctx),
 		ConsulNamespaceConfig: k8s.ConsulNamespaceConfig{
 			ConsulDestinationNamespace: ConsulNamespace(ctx),
-			MirrorKubernetesNamespaces: isConsulNamespaceMirroringOn(),
+			MirrorKubernetesNamespaces: isConsulNamespaceMirroringOn(ctx),
 		},
 	}
 

--- a/internal/testing/e2e/stack.go
+++ b/internal/testing/e2e/stack.go
@@ -23,6 +23,8 @@ func SetUpStack(hostRoute string) env.Func {
 		kindClusterName := envconf.RandomName("consul-api-gateway-test", 30)
 		namespace := envconf.RandomName("test", 16)
 
+		// TODO: should this instead create a new context?
+
 		ctx = SetHostRoute(ctx, hostRoute)
 
 		for _, f := range []env.Func{

--- a/internal/testing/e2e/stack.go
+++ b/internal/testing/e2e/stack.go
@@ -28,6 +28,7 @@ func SetUpStack(hostRoute string) env.Func {
 		for _, f := range []env.Func{
 			SetClusterName(kindClusterName),
 			SetNamespace(namespace),
+			SetNamespaceMirroring(true),
 			CrossCompileProject,
 			BuildDockerImage,
 			CreateKindCluster(kindClusterName),
@@ -38,7 +39,7 @@ func SetUpStack(hostRoute string) env.Func {
 			CreateTestConsulContainer(kindClusterName, namespace),
 			CreateConsulACLPolicy,
 			CreateConsulAuthMethod(),
-			CreateConsulNamespace,
+			SetConsulNamespace(nil),
 			CreateTestGatewayServer(namespace),
 		} {
 			ctx, err = f(ctx, cfg)


### PR DESCRIPTION
### Changes proposed in this PR:

Always map the `"default"` Consul namespace to the empty string in the memory backend store, for compatibility with Consul OSS and the logic to [parse the namespace of a Gateway from the SPIFFE URI](https://github.com/hashicorp/consul-api-gateway/blob/v0.5.1/internal/envoy/middleware.go#L112-L114), used when [reading a Gateway from a store backend](https://github.com/hashicorp/consul-api-gateway/blob/v0.5.1/internal/envoy/middleware.go#L79-L85).

This Consul namespace mapper function is already called when [reconciling a Gateway to a backend store](https://github.com/hashicorp/consul-api-gateway/blob/v0.5.1/internal/k8s/reconciler/manager.go#L180-L192), but the corresponding lookup fails with Consul Enterprise when `--consul-destination-namespace` is set to `"default"` because of the special case handling in the `parseURI` helper.

No migration handling should be needed because this is all within the ephemeral memory store for now, but this does need an e2e test for a service in the `"default"` namespace on Consul Enterprise.

As a temporary workaround, this edge case can be avoided by configuring `consulNamespaces.mirroringK8S: true` or specfiying `""` or _any_ value other than `"default"` for `consulNamespaces.consulDestinationNamespace` in the Helm chart.

### How I've tested this PR:

### How I expect reviewers to test this PR:

### Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
