### PR TITLE
deps: update consul-server-connection-manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/consul-server-connection-manager v0.1.1-0.20221115222743-242744ae73fb
+	github.com/hashicorp/consul-server-connection-manager v0.1.1
 	github.com/hashicorp/consul/api v1.18.0
 	github.com/hashicorp/consul/proto-public v0.2.1
 	github.com/hashicorp/consul/sdk v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -687,6 +687,12 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul-server-connection-manager v0.1.1-0.20221115222743-242744ae73fb h1:bbbNb5f4PFoKLSRREYb/YKjrTtt7MHEqffGW+Tjx25o=
 github.com/hashicorp/consul-server-connection-manager v0.1.1-0.20221115222743-242744ae73fb/go.mod h1:XVVlO+Yk7aiRpspiHZkrrFVn9BJIiOPnQIzqytPxGaU=
+github.com/hashicorp/consul-server-connection-manager v0.1.1-0.20230118215633-3b2a49b39662 h1:rBNbZ2GUD62hUd0Xy8wNIAtyjHLzs8miuFELkSWyzJI=
+github.com/hashicorp/consul-server-connection-manager v0.1.1-0.20230118215633-3b2a49b39662/go.mod h1:pp2hlwmFacV4hMhD5iu9Hppfk+iaDlbMsIWLgWntchM=
+github.com/hashicorp/consul-server-connection-manager v0.1.1-0.20230120153659-f9b5452b527e h1:HX+AsjeFL84774gThBMYGRPqbp9ftzI8+sktIopo2sc=
+github.com/hashicorp/consul-server-connection-manager v0.1.1-0.20230120153659-f9b5452b527e/go.mod h1:0jIi+bPKHXBhJi3iF9vGihsxssXj+u1/8+hvql4iVkY=
+github.com/hashicorp/consul-server-connection-manager v0.1.1 h1:uLL+56/qMTU2cYbTqJqqJ02L1TIgNdQZMo7f6MHExUI=
+github.com/hashicorp/consul-server-connection-manager v0.1.1/go.mod h1:0jIi+bPKHXBhJi3iF9vGihsxssXj+u1/8+hvql4iVkY=
 github.com/hashicorp/consul/api v1.18.0 h1:R7PPNzTCeN6VuQNDwwhZWJvzCtGSrNpJqfb22h3yH9g=
 github.com/hashicorp/consul/api v1.18.0/go.mod h1:owRRGJ9M5xReDC5nfT8FTJrNAPbT4NM6p/k+d03q2v4=
 github.com/hashicorp/consul/proto-public v0.2.1 h1:9dZGW68IEuajEkaAAdXCUovVuKyccBOS0jub4Gee5II=

--- a/internal/consul/connection.go
+++ b/internal/consul/connection.go
@@ -54,7 +54,6 @@ type ClientConfig struct {
 }
 
 type client struct {
-	stop        func()
 	config      ClientConfig
 	client      *api.Client
 	token       string

--- a/internal/consul/connection.go
+++ b/internal/consul/connection.go
@@ -75,7 +75,6 @@ func (c *client) Wait(until time.Duration) error {
 	case err := <-c.initialized:
 		return err
 	case <-time.After(until):
-		c.stop()
 		return errors.New("did not get state within time limit")
 	}
 }
@@ -127,9 +126,6 @@ func (c *client) WatchServers(ctx context.Context) error {
 		<-ctx.Done()
 		return nil
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	c.stop = cancel
 
 	var static bool
 	serverName := c.config.Addresses


### PR DESCRIPTION
This resolves test flakiness issues caused by the un-threadsafety of registering a gRPC balancer in `NewWatcher` rather than an `init()` function. This didn't cause problems in actual deployments, but could happen when in our test suite when multiple calls to `NewWatcher` happened concurrently.

### Changes proposed in this PR:

- Updates to a new version of consul-server-connection-manager which removes the gRPC custom balancer implementation and switches to the default [`pick_first`](https://github.com/grpc/grpc/blob/master/doc/load-balancing.md#pick_first) balancer.
- Removes the now-unnecessary `globalWatcherMutex` (added in https://github.com/hashicorp/consul-api-gateway/pull/449)
- Removes an unneeded context cancellation call from the `client.WatchServers` method which was responsible for a race condition occurring infrequently on timeouts, particularly from the [discovery-error](https://github.com/hashicorp/consul-api-gateway/blob/874f3248ad6636d3d1cf995ed16d0706a0fd6c82/internal/commands/exec/command_test.go#L119-L128) unit test.
  - This context cancellation was already handled by the caller at https://github.com/hashicorp/consul-api-gateway/blob/874f3248ad6636d3d1cf995ed16d0706a0fd6c82/internal/commands/exec/exec.go#L85

### How I've tested this PR:

Research and discussion on upstream implementation with @kisunji and @pglass, testing https://github.com/hashicorp/consul-server-connection-manager/pull/28 as a dependency locally and in CI. Thanks for the help in tracking down these issues!

### How I expect reviewers to test this PR:

The CI unit tests should stop being flaky.

### Checklist:
- [ ] ~~Tests added~~
- [ ] ~~CHANGELOG entry added~~
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
