### PR TITLE
e2e: increase RegEx max program size in Envoy mesh service bootstrap template

### DIFF
--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -632,13 +632,14 @@ func TestHTTPRouteFlattening(t *testing.T) {
 				Body:       serviceTwo.Name,
 			}, map[string]string{
 				"Host": "test.foo",
+				"x-v2": "v2",
 			}, "service two not routable in allotted time")
-			checkRoute(t, checkPort, "/", httpResponse{
+			checkRoute(t, checkPort, "/v2/test", httpResponse{
 				StatusCode: http.StatusOK,
-				Body:       serviceOne.Name,
+				Body:       serviceTwo.Name,
 			}, map[string]string{
 				"Host": "test.foo",
-			}, "service one not routable in allotted time")
+			}, "service two not routable in allotted time")
 			checkRoute(t, checkPort, "/", httpResponse{
 				StatusCode: http.StatusOK,
 				Body:       serviceTwo.Name,
@@ -646,6 +647,18 @@ func TestHTTPRouteFlattening(t *testing.T) {
 				"Host": "test.foo",
 				"x-v2": "v2",
 			}, "service two with headers is not routable in allotted time")
+			checkRoute(t, checkPort, "/", httpResponse{
+				StatusCode: http.StatusOK,
+				Body:       serviceOne.Name,
+			}, map[string]string{
+				"Host": "test.foo",
+			}, "service one not routable in allotted time")
+			checkRoute(t, checkPort, "/v2/test", httpResponse{
+				StatusCode: http.StatusOK,
+				Body:       serviceOne.Name,
+			}, map[string]string{
+				"Host": "test.example",
+			}, "service one not routable in allotted time")
 
 			err = resources.Delete(ctx, gw)
 			require.NoError(t, err)

--- a/internal/testing/e2e/service.go
+++ b/internal/testing/e2e/service.go
@@ -40,6 +40,14 @@ const (
 				"namespace": "{{if ne .Namespace ""}}{{ .Namespace }}{{else}}default{{end}}"
 			}
 		},
+		"layered_runtime": {
+			"layers": [{
+				"name": "base",
+				"static_layer": {
+					"re2.max_program_size.error_level": 1048576
+				}
+			}]
+		},
 		"static_resources": {
 			"listeners": [{
 				"name": "static",


### PR DESCRIPTION
### Changes proposed in this PR:

This change is needed when running our e2e tests against Consul v1.15-dev, to accommodate the additional XForwardedClientCert (XFCC) logic added in https://github.com/hashicorp/consul/pull/15906

Thanks to @hashi-derek and @erichaberkorn for helping track this down and find the necessary fix!

### How I've tested this PR:

CI e2e tests with Consul v1.15-dev should be passing once again with this change applied.

The consul-server-connection-manager bump should be removed before merging and handled separately in #484, I just wanted to minimize flakiness for initial review.

### How I expect reviewers to test this PR:

Confirm Consul v1.15-dev e2e tests are passing.

### Checklist:
- [x] Tests added
- [ ] ~~CHANGELOG entry added~~
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
