### PR TITLE
consul: set Envoy xDS address from discovery state

### DIFF
--- a/internal/commands/exec/command.go
+++ b/internal/commands/exec/command.go
@@ -220,7 +220,6 @@ func (c *Command) Run(args []string) (ret int) {
 		},
 		EnvoyConfig: EnvoyConfig{
 			CACertificateFile: cfg.TLSConfig.CAFile,
-			XDSAddress:        c.flagConsulHTTPAddress,
 			XDSPort:           c.flagConsulXDSPort,
 			SDSAddress:        c.flagSDSServerAddress,
 			SDSPort:           c.flagSDSServerPort,

--- a/internal/commands/exec/command.go
+++ b/internal/commands/exec/command.go
@@ -220,6 +220,7 @@ func (c *Command) Run(args []string) (ret int) {
 		},
 		EnvoyConfig: EnvoyConfig{
 			CACertificateFile: cfg.TLSConfig.CAFile,
+			XDSAddress:        c.flagConsulHTTPAddress,
 			XDSPort:           c.flagConsulXDSPort,
 			SDSAddress:        c.flagSDSServerAddress,
 			SDSPort:           c.flagSDSServerPort,

--- a/internal/commands/exec/exec.go
+++ b/internal/commands/exec/exec.go
@@ -130,7 +130,7 @@ func RunExec(config ExecConfig) (ret int) {
 			ID:                registry.ID(),
 			Namespace:         registry.Namespace(),
 			ConsulCA:          config.EnvoyConfig.CACertificateFile,
-			ConsulAddress:     config.EnvoyConfig.XDSAddress,
+			ConsulAddress:     client.ConsulAddress(),
 			ConsulXDSPort:     config.EnvoyConfig.XDSPort,
 			BootstrapFilePath: config.EnvoyConfig.BootstrapFile,
 			LogLevel:          config.LogLevel,

--- a/internal/commands/exec/exec.go
+++ b/internal/commands/exec/exec.go
@@ -5,6 +5,7 @@ package exec
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/signal"
@@ -123,6 +124,11 @@ func RunExec(config ExecConfig) (ret int) {
 		}
 		sessionCancel()
 	}()
+
+	fmt.Println("initializing Envoy manager")
+	fmt.Println("Consul HTTP address", config.EnvoyConfig.XDSAddress)
+	fmt.Println("Consul Server Connection Manager address", client.ConsulAddress())
+	// time.Sleep(60 * time.Minute)
 
 	envoyManager := envoy.NewManager(
 		config.Logger.Named("envoy-manager"),

--- a/internal/commands/server/k8s_e2e_test.go
+++ b/internal/commands/server/k8s_e2e_test.go
@@ -87,6 +87,9 @@ func TestGatewayWithClassConfigChange(t *testing.T) {
 			// Create a Gateway and wait for it to be ready
 			firstGatewayName := envconf.RandomName("gw", 16)
 			firstGateway := createGateway(ctx, t, resources, firstGatewayName, namespace, gc, []gwv1beta1.Listener{httpsListener})
+
+			time.Sleep(60 * time.Minute)
+
 			require.Eventually(t, gatewayStatusCheck(ctx, resources, firstGatewayName, namespace, conditionReady), checkTimeout, checkInterval, "no gateway found in the allotted time")
 			checkGatewayConfigAnnotation(ctx, t, resources, firstGatewayName, namespace, firstConfig)
 

--- a/internal/consul/connection.go
+++ b/internal/consul/connection.go
@@ -165,21 +165,23 @@ func (c *client) WatchServers(ctx context.Context) error {
 		return err
 	}
 	updateClient := func(s discovery.State) error {
-		var consulServerAddress string
+		var consulAddress string
+
+		fmt.Printf("DISCOVERY STATE %+v\n", s)
 
 		cfg := c.config.ApiClientConfig
 		if c.config.Namespace != "" {
 			cfg.Namespace = c.config.Namespace
 		}
 
-		consulServerAddress = s.Address.IP.String()
-		cfg.Address = fmt.Sprintf("%s:%d", consulServerAddress, c.config.HTTPPort)
+		consulAddress = s.Address.IP.String()
+		cfg.Address = fmt.Sprintf("%s:%d", consulAddress, c.config.HTTPPort)
 		if static {
 			// This is to fix the fact that s.Address always resolves to an IP, if
 			// we pass a DNS address without an IPSANS, regardless of setting cfg.TLSConfig.Address
 			// below, we have a connection error on cert validation.
-			consulServerAddress = c.config.Addresses
-			cfg.Address = fmt.Sprintf("%s:%d", consulServerAddress, c.config.HTTPPort)
+			consulAddress = c.config.Addresses
+			cfg.Address = fmt.Sprintf("%s:%d", c.config.Addresses, c.config.HTTPPort)
 		}
 		cfg.Token = s.Token
 		cfg.TLSConfig.Address = serverName
@@ -191,7 +193,7 @@ func (c *client) WatchServers(ctx context.Context) error {
 
 		c.mutex.Lock()
 		c.client = client
-		c.consulAddress = consulServerAddress
+		c.consulAddress = consulAddress
 		c.token = s.Token
 		c.mutex.Unlock()
 

--- a/internal/consul/test_client.go
+++ b/internal/consul/test_client.go
@@ -24,6 +24,10 @@ func NewTestClient(c *api.Client) *TestClient {
 	}
 }
 
+func (c *TestClient) ConsulAddress() string {
+	return ""
+}
+
 func (c *TestClient) WatchServers(ctx context.Context) error {
 	return nil
 }

--- a/internal/consul/test_client.go
+++ b/internal/consul/test_client.go
@@ -25,7 +25,7 @@ func NewTestClient(c *api.Client) *TestClient {
 }
 
 func (c *TestClient) ConsulAddress() string {
-	return ""
+	return "test"
 }
 
 func (c *TestClient) WatchServers(ctx context.Context) error {

--- a/internal/envoy/manager.go
+++ b/internal/envoy/manager.go
@@ -6,6 +6,7 @@ package envoy
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -126,6 +127,8 @@ func (m *Manager) RenderBootstrap(sdsConfig string) error {
 	}); err != nil {
 		return err
 	}
+
+	fmt.Printf("BOOTSTRAP CONFIG %+v\n", bootstrapConfig.String())
 
 	return os.WriteFile(m.BootstrapFilePath, bootstrapConfig.Bytes(), 0600)
 }


### PR DESCRIPTION
### Changes proposed in this PR:

Use the discovery state from consul-server-connection-manager to set the xDS address for Envoy gateway instances rather than passing through the `--consul-http-address` CLI argument.

This is intended to help mitigate an issue where Consul API Gateway will hit the Consul gRPC rate limiter when registering a gateway directly with a Consul server due to consul-k8s v1.0 or later running in "agentless" mode.

### How I've tested this PR:

It's failing e2e tests currently, as CSCM seems to not be resolving `host.docker.internal` to a Consul server IP successfully, despite the preceding call to `Wait()`.

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
