### PR TITLE
Fix bug with cross namespace policy

### DIFF
--- a/.changelog/505.txt
+++ b/.changelog/505.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix `cross-namespace-policy` not being applied to namespaces created by the controller.
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## UNRELEASED
 
-BUG FIXES:
-
-* Fix `cross-namespace-policy` not being applied to namespaces created by the controller. [[GH-505](https://github.com/hashicorp/consul-api-gateway/pull/505)]
-
 ## 0.5.0 (November 17, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* Fix `cross-namespace-policy` not being applied to namespaces created by the controller. [[GH-](https://github.com/hashicorp/consul-api-gateway/pull/)]
+* Fix `cross-namespace-policy` not being applied to namespaces created by the controller. [[GH-505](https://github.com/hashicorp/consul-api-gateway/pull/505)]
 
 ## 0.5.0 (November 17, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+BUG FIXES:
+
+* Fix `cross-namespace-policy` not being applied to namespaces created by the controller. [[GH-](https://github.com/hashicorp/consul-api-gateway/pull/)]
+
 ## 0.5.0 (November 17, 2022)
 
 FEATURES:

--- a/internal/commands/server/command.go
+++ b/internal/commands/server/command.go
@@ -169,7 +169,7 @@ func (c *Command) Run(args []string) int {
 		consulCfg.Address = c.flagConsulAddress
 	}
 
-	partitionInfo := consul.NewPartitionInfo(os.Getenv("CONSUL_ENABLE_PARTITIONS") == "true", os.Getenv("CONSUL_PARTITION_NAME"))
+	partitionInfo := consul.NewPartitionInfo(os.Getenv("CONSUL_PARTITION"))
 
 	cfg.ConsulNamespaceConfig = k8s.ConsulNamespaceConfig{
 		ConsulDestinationNamespace:      c.flagConsulDestinationNamespace,

--- a/internal/commands/server/command.go
+++ b/internal/commands/server/command.go
@@ -60,7 +60,6 @@ type Command struct {
 	flagConsulDestinationNamespace string
 	flagMirrorK8SNamespaces        bool
 	flagMirrorK8SNamespacePrefix   string
-	flagPartitionInfo              consul.PartitionInfo
 
 	// Logging
 	flagLogLevel string
@@ -94,8 +93,6 @@ func (c *Command) init() {
 		c.flagSet.StringVar(&c.flagConsulDestinationNamespace, "consul-destination-namespace", "", "Consul namespace to register gateway services.")
 		c.flagSet.BoolVar(&c.flagMirrorK8SNamespaces, "mirroring-k8s", false, "Register Consul gateway services based on Kubernetes namespace.")
 		c.flagSet.StringVar(&c.flagMirrorK8SNamespacePrefix, "mirroring-k8s-prefix", "", "Namespace prefix for Consul services when mirroring Kubernetes namespaces.")
-		c.flagSet.BoolVar(&c.flagPartitionInfo.EnablePartitions, "enable-partitions", false, "[Enterprise Only] Enables Admin Partitions")
-		c.flagSet.StringVar(&c.flagPartitionInfo.PartitionName, "partition", "", "[Enterprise Only] Name of the Admin Partition")
 	}
 
 	{
@@ -172,11 +169,13 @@ func (c *Command) Run(args []string) int {
 		consulCfg.Address = c.flagConsulAddress
 	}
 
+	partitionInfo := consul.NewPartitionInfo(os.Getenv("CONSUL_ENABLE_PARTITIONS") == "true", os.Getenv("CONSUL_PARTITION_NAME"))
+
 	cfg.ConsulNamespaceConfig = k8s.ConsulNamespaceConfig{
 		ConsulDestinationNamespace:      c.flagConsulDestinationNamespace,
 		MirrorKubernetesNamespaces:      c.flagMirrorK8SNamespaces,
 		MirrorKubernetesNamespacePrefix: c.flagMirrorK8SNamespacePrefix,
-		PartitionInfo:                   c.flagPartitionInfo,
+		PartitionInfo:                   partitionInfo,
 	}
 
 	consulScheme, consulHTTPAddressOrCommand, port, err := parseConsulHTTPAddress()

--- a/internal/commands/server/command.go
+++ b/internal/commands/server/command.go
@@ -60,6 +60,7 @@ type Command struct {
 	flagConsulDestinationNamespace string
 	flagMirrorK8SNamespaces        bool
 	flagMirrorK8SNamespacePrefix   string
+	flagPartitionInfo              consul.PartitionInfo
 
 	// Logging
 	flagLogLevel string
@@ -93,6 +94,8 @@ func (c *Command) init() {
 		c.flagSet.StringVar(&c.flagConsulDestinationNamespace, "consul-destination-namespace", "", "Consul namespace to register gateway services.")
 		c.flagSet.BoolVar(&c.flagMirrorK8SNamespaces, "mirroring-k8s", false, "Register Consul gateway services based on Kubernetes namespace.")
 		c.flagSet.StringVar(&c.flagMirrorK8SNamespacePrefix, "mirroring-k8s-prefix", "", "Namespace prefix for Consul services when mirroring Kubernetes namespaces.")
+		c.flagSet.BoolVar(&c.flagPartitionInfo.EnablePartitions, "enable-partitions", false, "[Enterprise Only] Enables Admin Partitions")
+		c.flagSet.StringVar(&c.flagPartitionInfo.PartitionName, "partition", "", "[Enterprise Only] Name of the Admin Partition")
 	}
 
 	{
@@ -173,6 +176,7 @@ func (c *Command) Run(args []string) int {
 		ConsulDestinationNamespace:      c.flagConsulDestinationNamespace,
 		MirrorKubernetesNamespaces:      c.flagMirrorK8SNamespaces,
 		MirrorKubernetesNamespacePrefix: c.flagMirrorK8SNamespacePrefix,
+		PartitionInfo:                   c.flagPartitionInfo,
 	}
 
 	consulScheme, consulHTTPAddressOrCommand, port, err := parseConsulHTTPAddress()

--- a/internal/consul/connection.go
+++ b/internal/consul/connection.go
@@ -17,6 +17,14 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+// Calling discovery.NewWatcher registers a new gRPC load balancer
+// type tied to the consul:// scheme, which calls the global
+// google.golang.org/grpc/balancer.Register, which, as specified
+// in their docs is not threadsafe and should be called only in an
+// init function. This mutex makes it so we can boot up multiple watchers
+// particularly in our tests.
+var globalWatcherMutex sync.Mutex
+
 type PeeringClient interface {
 	Read(ctx context.Context, name string, q *api.QueryOptions) (*api.Peering, *api.QueryMeta, error)
 }
@@ -80,22 +88,22 @@ func (c *client) Wait(until time.Duration) error {
 
 func (c *client) WatchServers(ctx context.Context) error {
 	if !c.config.UseDynamic {
-		cfg := c.config.ApiClientConfig
-		cfg.Address = fmt.Sprintf("%s:%d", c.config.Addresses, c.config.HTTPPort)
+		c.config.ApiClientConfig.Address = fmt.Sprintf("%s:%d", c.config.Addresses, c.config.HTTPPort)
 
 		var err error
 		var client *api.Client
 		var token string
 		if c.config.Credentials.Type == discovery.CredentialsTypeLogin {
-			baseClient, err := api.NewClient(cfg)
+			c.config.Logger.Info("IN IF STATEMENT")
+			baseClient, err := api.NewClient(c.config.ApiClientConfig)
 			if err != nil {
 				c.initialized <- err
 				return err
 			}
 			if c.config.Namespace != "" {
-				cfg.Namespace = c.config.Namespace
+				c.config.ApiClientConfig.Namespace = c.config.Namespace
 			}
-			client, token, err = login(ctx, baseClient, cfg, c.config)
+			client, token, err = login(ctx, baseClient, c.config)
 			if err != nil {
 				c.initialized <- err
 				return err
@@ -104,11 +112,11 @@ func (c *client) WatchServers(ctx context.Context) error {
 
 		} else {
 			// this might be empty
-			cfg.Token = c.config.Credentials.Static.Token
+			c.config.ApiClientConfig.Token = c.config.Credentials.Static.Token
 			if c.config.Namespace != "" {
-				cfg.Namespace = c.config.Namespace
+				c.config.ApiClientConfig.Namespace = c.config.Namespace
 			}
-			client, err = api.NewClient(cfg)
+			client, err = api.NewClient(c.config.ApiClientConfig)
 			if err != nil {
 				c.initialized <- err
 				return err
@@ -117,7 +125,7 @@ func (c *client) WatchServers(ctx context.Context) error {
 
 		c.mutex.Lock()
 		c.client = client
-		c.token = cfg.Token
+		c.token = c.config.ApiClientConfig.Token
 		c.mutex.Unlock()
 
 		close(c.initialized)
@@ -148,7 +156,6 @@ func (c *client) WatchServers(ctx context.Context) error {
 	}
 
 	watcher, err := discovery.NewWatcher(ctx, config, c.config.Logger)
-
 	if err != nil {
 		c.initialized <- err
 		return err
@@ -271,13 +278,14 @@ func (c *client) Internal() *api.Client {
 	return c.client
 }
 
-func login(ctx context.Context, client *api.Client, cfg *api.Config, config ClientConfig) (*api.Client, string, error) {
+func login(ctx context.Context, client *api.Client, config ClientConfig) (*api.Client, string, error) {
 	authenticator := NewAuthenticator(
 		config.Logger.Named("authenticator"),
 		client,
 		config.Credentials.Login.AuthMethod,
 		config.Credentials.Login.Namespace,
 	)
+	config.Logger.Named("authenticator").Info(fmt.Sprintf("Cred Namespace: %s, Config Namespace: %s", config.Credentials.Login.Namespace, config.Namespace))
 
 	token, err := authenticator.Authenticate(ctx, config.Name, config.Credentials.Login.BearerToken)
 	if err != nil {
@@ -285,8 +293,10 @@ func login(ctx context.Context, client *api.Client, cfg *api.Config, config Clie
 	}
 
 	// Now update the client so that it will read the ACL token we just fetched.
-	cfg.Token = token
-	newClient, err := api.NewClient(cfg)
+	config.ApiClientConfig.Token = token
+	config.Logger.Named("authenticator").Info(fmt.Sprintf("ClientConfigToken in login: %s", config.ApiClientConfig.Token))
+	// config.ApiClientConfig.Namespace = config.Credentials.Login.Namespace
+	newClient, err := api.NewClient(config.ApiClientConfig)
 	if err != nil {
 		return nil, "", fmt.Errorf("error updating client connection with token: %w", err)
 	}

--- a/internal/consul/namespaces.go
+++ b/internal/consul/namespaces.go
@@ -24,6 +24,20 @@ type PartitionInfo struct {
 	PartitionName    string
 }
 
+func NewPartitionInfo(enablePartitions bool, partitionName string) PartitionInfo {
+	p := PartitionInfo{}
+	if !enablePartitions {
+		return p
+	}
+	if partitionName == "" {
+		partitionName = "default"
+	}
+
+	p.EnablePartitions = true
+	p.PartitionName = partitionName
+	return p
+}
+
 // EnsureNamespaceExists ensures a Consul namespace with name ns exists. If it doesn't,
 // it will create it and set crossNSACLPolicy as a policy default.
 // Boolean return value indicates if the namespace was created by this call.
@@ -135,6 +149,8 @@ partition "{{ .PartitionName }}" {
 
 // isPolicyExistsErr returns true if err is due to trying to call the
 // policy create API when the policy already exists.
+// this handles the case where ACL's aren't enabled, the only way to check this currently
+// is to make a request against Consul and check the error code/message
 func isPolicyExistsErr(err error, policyName string) bool {
 	return strings.Contains(err.Error(), "Unexpected response code: 500") &&
 		strings.Contains(err.Error(), fmt.Sprintf("Invalid Policy: A Policy with Name %q already exists", policyName))

--- a/internal/consul/namespaces.go
+++ b/internal/consul/namespaces.go
@@ -5,6 +5,7 @@ package consul
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html/template"
 	"strings"
@@ -92,6 +93,10 @@ func getOrCreateCrossNamespacePolicy(client Client, partitionInfo PartitionInfo)
 	createdPolicy, _, err = acl.PolicyReadByName(policy.Name, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if createdPolicy == nil {
+		return nil, errors.New("failed to read policy \"cross-namespace-policy\" from consul server")
 	}
 	return createdPolicy, nil
 }

--- a/internal/consul/namespaces.go
+++ b/internal/consul/namespaces.go
@@ -24,13 +24,10 @@ type PartitionInfo struct {
 	PartitionName    string
 }
 
-func NewPartitionInfo(enablePartitions bool, partitionName string) PartitionInfo {
+func NewPartitionInfo(partitionName string) PartitionInfo {
 	p := PartitionInfo{}
-	if !enablePartitions {
-		return p
-	}
 	if partitionName == "" {
-		partitionName = "default"
+		return p
 	}
 
 	p.EnablePartitions = true

--- a/internal/consul/namespaces.go
+++ b/internal/consul/namespaces.go
@@ -80,7 +80,7 @@ func getOrCreateCrossNamespacePolicy(client Client, partitionInfo PartitionInfo)
 		Rules:       rules,
 	}
 	createdPolicy, _, err := acl.PolicyCreate(policy, nil)
-	if !isPolicyExistsErr(err, policy.Name) {
+	if err != nil && !isPolicyExistsErr(err, policy.Name) {
 		return nil, err
 	}
 
@@ -136,7 +136,6 @@ partition "{{ .PartitionName }}" {
 // isPolicyExistsErr returns true if err is due to trying to call the
 // policy create API when the policy already exists.
 func isPolicyExistsErr(err error, policyName string) bool {
-	return err != nil &&
-		strings.Contains(err.Error(), "Unexpected response code: 500") &&
+	return strings.Contains(err.Error(), "Unexpected response code: 500") &&
 		strings.Contains(err.Error(), fmt.Sprintf("Invalid Policy: A Policy with Name %q already exists", policyName))
 }

--- a/internal/k8s/config.go
+++ b/internal/k8s/config.go
@@ -24,6 +24,7 @@ func StoreConfig(adapter core.SyncAdapter, client gatewayclient.Client, consulCl
 		Client:                   client,
 		Consul:                   consulClient,
 		ConsulNamespaceMirroring: config.ConsulNamespaceConfig.MirrorKubernetesNamespaces,
+		ConsulPartitionInfo:      config.ConsulNamespaceConfig.PartitionInfo,
 	})
 	updater := reconciler.NewStatusUpdater(logger, client, deployer, ControllerName)
 	backend := store.NewMemoryBackend()

--- a/internal/k8s/controller.go
+++ b/internal/k8s/controller.go
@@ -34,9 +34,7 @@ import (
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;get;list;update
 //+kubebuilder:rbac:groups=api-gateway.consul.hashicorp.com,resources=meshservices,verbs=get;list;watch
 
-var (
-	scheme = runtime.NewScheme()
-)
+var scheme = runtime.NewScheme()
 
 const (
 	ControllerName             = "hashicorp.com/consul-api-gateway-controller"
@@ -53,6 +51,7 @@ type ConsulNamespaceConfig struct {
 	ConsulDestinationNamespace      string
 	MirrorKubernetesNamespaces      bool
 	MirrorKubernetesNamespacePrefix string
+	PartitionInfo                   consul.PartitionInfo
 }
 
 func (c ConsulNamespaceConfig) Namespace(namespace string) string {
@@ -128,7 +127,6 @@ func New(logger hclog.Logger, config *Config) (*Kubernetes, error) {
 		opts.LeaderElectionNamespace = config.Namespace
 	}
 	mgr, err := ctrl.NewManager(config.RestConfig, opts)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to start k8s controller manager: %w", err)
 	}

--- a/internal/k8s/reconciler/deployer.go
+++ b/internal/k8s/reconciler/deployer.go
@@ -32,6 +32,7 @@ type GatewayDeployer struct {
 	sdsPort                  int
 	consul                   consul.Client
 	consulNamespaceMirroring bool
+	partitionInfo            consul.PartitionInfo
 
 	logger hclog.Logger
 }
@@ -45,6 +46,7 @@ type DeployerConfig struct {
 	Client                   gatewayclient.Client
 	Consul                   consul.Client
 	ConsulNamespaceMirroring bool
+	ConsulPartitionInfo      consul.PartitionInfo
 }
 
 func NewDeployer(config DeployerConfig) *GatewayDeployer {
@@ -57,12 +59,13 @@ func NewDeployer(config DeployerConfig) *GatewayDeployer {
 		logger:                   config.Logger,
 		consul:                   config.Consul,
 		consulNamespaceMirroring: config.ConsulNamespaceMirroring,
+		partitionInfo:            config.ConsulPartitionInfo,
 	}
 }
 
 func (d *GatewayDeployer) Deploy(ctx context.Context, gateway *K8sGateway) error {
 	if d.consulNamespaceMirroring {
-		_, err := consul.EnsureNamespaceExists(d.consul, gateway.Namespace)
+		_, err := consul.EnsureNamespaceExists(d.consul, gateway.Namespace, d.partitionInfo)
 		if err != nil {
 			return err
 		}

--- a/internal/k8s/reconciler/statuses.go
+++ b/internal/k8s/reconciler/statuses.go
@@ -68,7 +68,6 @@ func (s *StatusUpdater) UpdateGatewayStatusOnSync(ctx context.Context, gateway s
 
 func (s *StatusUpdater) UpdateRouteStatus(ctx context.Context, route store.Route) error {
 	r := route.(*K8sRoute)
-
 	if status, ok := r.RouteState.ParentStatuses.NeedsUpdate(r.routeStatus(), s.controllerName, r.GetGeneration()); ok {
 		r.setStatus(status)
 


### PR DESCRIPTION
### Changes proposed in this PR:
When new namespace is created we should automatically apply the `cross-namespace-policy` policy to the newly created namespace to ensure cross namespace communication is allowed. 

Fixes #510 

### How I've tested this PR:
* Clone the files from the following gist: https://gist.github.com/jm96441n/7e005c82fa918b7b73c11abb617b4998
* Replace the `<YOUR ENTERPRISE KEY>` with a key for enterprise consul in the `deploy.sh` file
* From the api-gw repo run `make docker/dev` on the main branch (without these changes)
* Run the `deploy.sh` script
* After that finishes from the terminal run `curl 0:30602 -vv --header 'Host: nginx.green.daskt.nsbug.it'` and you should see a `503` error along with `no healthy upstream`
* In the consul UI if you select `Manage Namespaces` from the `Namespaces` drop down you will see the `green` namespace does not have the `cross-namespace-policy` attached to it
* In the api-gateway repo checkout this branch and run `make docker/dev` again to build the image with the changes from this branch
* Run the `reload.sh` script from the gist
* After that finishes from the terminal run `curl 0:30602 -vv --header 'Host: nginx.green.daskt.nsbug.it'` and you should see a response with a bunch of html (you may see a "connection reset by peer" error, if so give things a few seconds to reconcile and try again)
* In the consul UI if you select `Manage Namespaces` from the `Namespaces` drop down you will see the `green` namespace now has the `cross-namespace-policy` attached to it


### How I expect reviewers to test this PR:
Code Review
Can run the above steps

### Checklist:
- [ ] Tests added
- [X] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
