### PR TITLE
Bump default envoy image

### DIFF
--- a/.changelog/521.txt
+++ b/.changelog/521.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Bump the default envoy image from `1.21` to `1.24` to be compatible with consul 1.15
+```

--- a/.changelog/521.txt
+++ b/.changelog/521.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-Bump the default envoy image from `1.21` to `1.24` to be compatible with consul 1.15
+```release-note:enhancement
+Bump the default envoy image for consul 1.15 compatability when the image is not specified in a GatewayClassConfig
 ```

--- a/internal/k8s/builder/builder.go
+++ b/internal/k8s/builder/builder.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 const (
-	defaultEnvoyImage           = "envoyproxy/envoy:v1.21-latest"
+	defaultEnvoyImage           = "envoyproxy/envoy:v1.24-latest"
 	defaultLogLevel             = "info"
 	defaultConsulAddress        = "$(HOST_IP)"
 	defaultConsulHTTPPort       = "8500"

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -80,7 +80,7 @@ spec:
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
-        image: envoyproxy/envoy:v1.21-latest
+        image: envoyproxy/envoy:v1.24-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -80,7 +80,7 @@ spec:
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
-        image: envoyproxy/envoy:v1.21-latest
+        image: envoyproxy/envoy:v1.24-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/max-instances.deployment.golden.yaml
@@ -80,7 +80,7 @@ spec:
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
-        image: envoyproxy/envoy:v1.21-latest
+        image: envoyproxy/envoy:v1.24-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/min-instances.deployment.golden.yaml
@@ -80,7 +80,7 @@ spec:
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
-        image: envoyproxy/envoy:v1.21-latest
+        image: envoyproxy/envoy:v1.24-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/multiple-instances.deployment.golden.yaml
@@ -80,7 +80,7 @@ spec:
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
-        image: envoyproxy/envoy:v1.21-latest
+        image: envoyproxy/envoy:v1.24-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -82,7 +82,7 @@ spec:
         - name: CONSUL_TLS_SERVER_NAME
         - name: PATH
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
-        image: envoyproxy/envoy:v1.21-latest
+        image: envoyproxy/envoy:v1.24-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -82,7 +82,7 @@ spec:
           value: /:/sbin:/bin:/usr/bin:/usr/local/bin:/bootstrap
         - name: CONSUL_CACERT
           value: /consul/tls/ca.pem
-        image: envoyproxy/envoy:v1.21-latest
+        image: envoyproxy/envoy:v1.24-latest
         name: consul-api-gateway
         ports:
         - containerPort: 20000


### PR DESCRIPTION
### Changes proposed in this PR:
The default envoy image (v1.21) is no longer compatible with consul 1.15, this PR bumps that to `1.24` to maintain compatability.

### How I've tested this PR:
Ran the tests.

### How I expect reviewers to test this PR:
Code review, run the tests

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
