### PR TITLE
Designate required permissions for release prep workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -19,6 +19,10 @@ jobs:
       NEW_CONSUL_REQ: ${{ github.event.inputs.new-min-consul-version }}
       NEW_CONSUL_K8S_REQ: ${{ github.event.inputs.new-min-consul-k8s-version }}
 
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+
     steps:
 
       - name: Checkout consul-api-gateway
@@ -122,7 +126,6 @@ jobs:
           delete-branch: true
           labels: 'pr/no-changelog'
           title: 'Prepare for release of v${{ env.NEW_API_GATEWAY_VERSION }}'
-          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
 
       - name: Output link to PR
         run: echo '[Resulting PR](${{ steps.create-pr.outputs.pull-request-url }})' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Changes proposed in this PR:
The `ELEVATED_GITHUB_TOKEN` that we were previously using no longer works for branch + PR creation due to new enforcement of SSO requirement.

This change enables the specific permissions required on the default token handed to the workflow job and uses that default token instead of the elevated token. This mimics what we do over in [terraform-cdk](https://github.com/hashicorp/terraform-cdk/blob/57b1d12fe5fb3fcc3b89de8449c20ee13c62f9ac/.github/workflows/update-snapshots.yml#L148-L150).

### How I've tested this PR:

### How I expect reviewers to test this PR:

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
