### PR TITLE
Prepare for release of v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## UNRELEASED
 
+## 0.5.2 (March 3, 2022)
+
+IMPROVEMENTS:
+
+* Add initial set of copyright headers to applicable files [[GH-470](https://github.com/hashicorp/consul-api-gateway/issues/470)]
+* Bump the default envoy image for consul 1.15 compatability when the image is not specified in a GatewayClassConfig [[GH-521](https://github.com/hashicorp/consul-api-gateway/issues/521)]
+* go: build with Go v1.19.4 [[GH-474](https://github.com/hashicorp/consul-api-gateway/issues/474)]
+
+BUG FIXES:
+
+* Fix `cross-namespace-policy` not being applied to namespaces created by the controller. [[GH-505](https://github.com/hashicorp/consul-api-gateway/issues/505)]
+* consul: fix Consul Enterprise gateway sync issue with Kubernetes namespace mirroring disabled and the Consul destination namespace set to "default" [[GH-483](https://github.com/hashicorp/consul-api-gateway/issues/483)]
+
 ## 0.5.1 (November 22, 2022)
 
 IMPROVEMENTS:

--- a/config/deployment/deployment.yaml
+++ b/config/deployment/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       serviceAccountName: consul-api-gateway-controller
       containers:
-      - image: hashicorp/consul-api-gateway:0.5.0
+      - image: hashicorp/consul-api-gateway:0.5.2
         command: ["consul-api-gateway", "server", "-consul-address", "$(HOST_IP):8501", "-ca-file", "/ca/tls.crt", "-sds-server-host", "$(IP)", "-k8s-namespace", "$(CONSUL_K8S_NAMESPACE)", "-log-level", "$(LOG_LEVEL)"]
         name: consul-api-gateway-controller
         ports:

--- a/dev/docs/example-setup.md
+++ b/dev/docs/example-setup.md
@@ -72,8 +72,8 @@ We have provided a set of `kustomize` manifests for installing the Consul API Ga
 Apply them to your cluster using the following commands.
 
 ```bash
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.5.0"
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.5.0"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.5.2"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.5.2"
 ```
 
 ## Installing the demo Gateway and Mesh Service
@@ -116,7 +116,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.5.0
+- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.5.2
 
 patches:
 - target:

--- a/dev/docs/supported-features.md
+++ b/dev/docs/supported-features.md
@@ -2,7 +2,7 @@
 Below is a list of the Kubernetes Gateway API features supported in the current release of the
 Consul API Gateway.
 
-Consul API Gateway version: **v0.5.0**
+Consul API Gateway version: **v0.5.2**
 Supported K8s Gateway API version: **v1beta1**
 
 Supported features are marked with a grey checkbox


### PR DESCRIPTION
> **Note**: Had to do this manually since our Actions workflow is hitting issues with new SSO enforcement for tokens ([logs](https://github.com/hashicorp/consul-api-gateway/actions/runs/4324872794/jobs/7550276588)). Compare to #457 

Consul API Gateway version being released: `0.5.2` Now requires:
- consul: `1.12.0`
- consul-k8s: `0.49.1`
