### PR TITLE
Update testing matrix for 1.15 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         - 'hashicorp/consul:1.14.0'
         - 'hashicorp/consul-enterprise:1.14.0-ent'
         - 'hashicorp/consul:1.15.0'
-        - 'hashicorp/consul-enterprise:1.15-ent'
+        - 'hashicorp/consul-enterprise:1.15.0-ent'
         - 'hashicorppreview/consul:1.16-dev'
         - 'hashicorppreview/consul-enterprise:1.16-dev'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.13.6
-        - 1.13.6+ent
+        - 1.13.7
+        - 1.13.7+ent
         - 1.14.5
         - 1.14.5+ent
         - 1.15.1
@@ -91,8 +91,8 @@ jobs:
       fail-fast: false
       matrix:
         consul-image:
-        - 'hashicorp/consul:1.13.6'
-        - 'hashicorp/consul-enterprise:1.13.6-ent'
+        - 'hashicorp/consul:1.13.7'
+        - 'hashicorp/consul-enterprise:1.13.7-ent'
         - 'hashicorp/consul:1.14.5'
         - 'hashicorp/consul-enterprise:1.14.5-ent'
         - 'hashicorp/consul:1.15.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         - 1.13.3+ent
         - 1.14.0
         - 1.14.0+ent
+        - 1.15.0
+        - 1.15.0+ent
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/consul@${{ matrix.consul-version }}
@@ -97,8 +99,18 @@ jobs:
         - 'hashicorp/consul-enterprise:1.13.3-ent'
         - 'hashicorp/consul:1.14.0'
         - 'hashicorp/consul-enterprise:1.14.0-ent'
-        - 'hashicorppreview/consul:1.15-dev'
-        - 'hashicorppreview/consul-enterprise:1.15-dev'
+        - 'hashicorp/consul:1.15.0'
+        - 'hashicorp/consul-enterprise:1.15-ent'
+        - 'hashicorppreview/consul:1.16-dev'
+        - 'hashicorppreview/consul-enterprise:1.16-dev'
+    runs-on: ubuntu-latest
+    env:
+      TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.12.6
-        - 1.12.6+ent
         - 1.13.6
         - 1.13.6+ent
         - 1.14.5
@@ -93,8 +91,6 @@ jobs:
       fail-fast: false
       matrix:
         consul-image:
-        - 'hashicorp/consul:1.12.6'
-        - 'hashicorp/consul-enterprise:1.12.6-ent'
         - 'hashicorp/consul:1.13.6'
         - 'hashicorp/consul-enterprise:1.13.6-ent'
         - 'hashicorp/consul:1.14.5'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-
-    runs-on: ubuntu-latest
-    env:
-      TEST_RESULTS_DIR: /tmp/test-results/e2e@${{ matrix.consul-image }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
     - name: Install Dependencies
       run: |
         curl -L https://kind.sigs.k8s.io/dl/v0.16.0/kind-linux-amd64 -o ./kind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
         consul-version:
         - 1.12.6
         - 1.12.6+ent
-        - 1.13.3
-        - 1.13.3+ent
-        - 1.14.0
-        - 1.14.0+ent
-        - 1.15.0
-        - 1.15.0+ent
+        - 1.13.6
+        - 1.13.6+ent
+        - 1.14.5
+        - 1.14.5+ent
+        - 1.15.1
+        - 1.15.1+ent
     runs-on: ubuntu-latest
     env:
       TEST_RESULTS_DIR: /tmp/test-results/consul@${{ matrix.consul-version }}
@@ -95,12 +95,12 @@ jobs:
         consul-image:
         - 'hashicorp/consul:1.12.6'
         - 'hashicorp/consul-enterprise:1.12.6-ent'
-        - 'hashicorp/consul:1.13.3'
-        - 'hashicorp/consul-enterprise:1.13.3-ent'
-        - 'hashicorp/consul:1.14.0'
-        - 'hashicorp/consul-enterprise:1.14.0-ent'
-        - 'hashicorp/consul:1.15.0'
-        - 'hashicorp/consul-enterprise:1.15.0-ent'
+        - 'hashicorp/consul:1.13.6'
+        - 'hashicorp/consul-enterprise:1.13.6-ent'
+        - 'hashicorp/consul:1.14.5'
+        - 'hashicorp/consul-enterprise:1.14.5-ent'
+        - 'hashicorp/consul:1.15.1'
+        - 'hashicorp/consul-enterprise:1.15.1-ent'
         - 'hashicorppreview/consul:1.16-dev'
         - 'hashicorppreview/consul-enterprise:1.16-dev'
     runs-on: ubuntu-latest

--- a/internal/testing/e2e/consul.go
+++ b/internal/testing/e2e/consul.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	grpcConsulIncompatibleNameVersion = "1.14"
-	defaultConsulImage                = "hashicorppreview/consul:1.14-dev"
+	defaultConsulImage                = "hashicorppreview/consul:1.16-dev"
 	envvarConsulImage                 = envvarPrefix + "CONSUL_IMAGE"
 	envvarConsulEnterpriseLicense     = "CONSUL_LICENSE"
 	envvarConsulEnterpriseLicensePath = "CONSUL_LICENSE_PATH"
@@ -513,6 +513,7 @@ func ConsulHTTPPort(ctx context.Context) int {
 func isConsulNamespaceMirroringOn(ctx context.Context) bool {
 	return IsEnterprise() && NamespaceMirroring(ctx)
 }
+
 func ConsulNamespace(ctx context.Context) string {
 	if isConsulNamespaceMirroringOn(ctx) {
 		return Namespace(ctx)


### PR DESCRIPTION
### Changes proposed in this PR:
* Update CI matrix to use official 1.15 images
* Add 1.16-dev images to CI matrix
* Update e2e tests to use the 1.16-dev images by default 

### How I've tested this PR:
Ran e2e tests locally

### How I expect reviewers to test this PR:
Code Review

### Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
