### PR TITLE
Add partition identity to envoy deployment

### DIFF
--- a/.changelog/537.txt
+++ b/.changelog/537.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix envoy deployments not properly identifying themselves when deployed to non-default partitions.
+```

--- a/internal/commands/exec/command.go
+++ b/internal/commands/exec/command.go
@@ -217,6 +217,7 @@ func (c *Command) Run(args []string) (ret int) {
 			Host:      c.flagGatewayHost,
 			Name:      c.flagGatewayName,
 			Namespace: c.flagGatewayNamespace,
+			Partition: getPartition(),
 		},
 		EnvoyConfig: EnvoyConfig{
 			CACertificateFile: cfg.TLSConfig.CAFile,
@@ -285,4 +286,8 @@ func init() {
 			}
 		}
 	}
+}
+
+func getPartition() string {
+	return os.Getenv("CONSUL_PARTITION")
 }

--- a/internal/commands/exec/exec.go
+++ b/internal/commands/exec/exec.go
@@ -30,6 +30,7 @@ type GatewayConfig struct {
 	Host      string
 	Name      string
 	Namespace string
+	Partition string
 }
 
 type EnvoyConfig struct {
@@ -101,6 +102,7 @@ func RunExec(config ExecConfig) (ret int) {
 		client,
 		config.GatewayConfig.Name,
 		config.GatewayConfig.Namespace,
+		config.GatewayConfig.Partition,
 		config.GatewayConfig.Host,
 	)
 	if config.isTest {
@@ -129,6 +131,7 @@ func RunExec(config ExecConfig) (ret int) {
 		envoy.ManagerConfig{
 			ID:                registry.ID(),
 			Namespace:         registry.Namespace(),
+			Partition:         registry.Partition(),
 			ConsulCA:          config.EnvoyConfig.CACertificateFile,
 			ConsulAddress:     config.EnvoyConfig.XDSAddress,
 			ConsulXDSPort:     config.EnvoyConfig.XDSPort,

--- a/internal/consul/registration.go
+++ b/internal/consul/registration.go
@@ -34,6 +34,7 @@ type ServiceRegistry struct {
 	id        string
 	name      string
 	namespace string
+	partition string
 	host      string
 	tags      []string
 
@@ -45,13 +46,14 @@ type ServiceRegistry struct {
 }
 
 // NewServiceRegistry creates a new service registry instance
-func NewServiceRegistry(logger hclog.Logger, client Client, service, namespace, host string) *ServiceRegistry {
+func NewServiceRegistry(logger hclog.Logger, client Client, service, namespace, partition, host string) *ServiceRegistry {
 	return &ServiceRegistry{
 		logger:                 logger,
 		client:                 client,
 		id:                     uuid.New().String(),
 		name:                   service,
 		namespace:              namespace,
+		partition:              partition,
 		host:                   host,
 		tries:                  defaultMaxAttempts,
 		backoffInterval:        defaultBackoffInterval,
@@ -94,6 +96,7 @@ func (s *ServiceRegistry) RegisterGateway(ctx context.Context, ttl bool) error {
 		ID:        s.id,
 		Name:      s.name,
 		Namespace: s.namespace,
+		Partition: s.partition,
 		Address:   s.host,
 		Tags:      s.tags,
 		Meta: map[string]string{
@@ -110,6 +113,7 @@ func (s *ServiceRegistry) Register(ctx context.Context) error {
 		ID:        s.id,
 		Name:      s.name,
 		Namespace: s.namespace,
+		Partition: s.partition,
 		Address:   s.host,
 		Tags:      s.tags,
 		Checks: api.AgentServiceChecks{{
@@ -230,4 +234,8 @@ func (s *ServiceRegistry) ID() string {
 
 func (s *ServiceRegistry) Namespace() string {
 	return s.namespace
+}
+
+func (s *ServiceRegistry) Partition() string {
+	return s.partition
 }

--- a/internal/consul/registration_test.go
+++ b/internal/consul/registration_test.go
@@ -58,7 +58,7 @@ func TestRegister(t *testing.T) {
 			}
 
 			server := runRegistryServer(t, test.failures, id)
-			registry := NewServiceRegistry(hclog.NewNullLogger(), NewTestClient(server.consul), service, namespace, test.host).WithTries(maxAttempts)
+			registry := NewServiceRegistry(hclog.NewNullLogger(), NewTestClient(server.consul), service, namespace, "", test.host).WithTries(maxAttempts)
 
 			registry.backoffInterval = 0
 			registry.id = id
@@ -111,7 +111,7 @@ func TestDeregister(t *testing.T) {
 			}
 
 			server := runRegistryServer(t, test.failures, id)
-			registry := NewServiceRegistry(hclog.NewNullLogger(), NewTestClient(server.consul), service, "", "").WithTries(maxAttempts)
+			registry := NewServiceRegistry(hclog.NewNullLogger(), NewTestClient(server.consul), service, "", "", "").WithTries(maxAttempts)
 			registry.backoffInterval = 0
 			registry.id = id
 			err := registry.Deregister(context.Background())

--- a/internal/envoy/manager.go
+++ b/internal/envoy/manager.go
@@ -28,6 +28,7 @@ var (
 type bootstrapArgs struct {
 	ID            string
 	Namespace     string
+	Partition     string
 	ConsulCA      string
 	ConsulAddress string
 	ConsulXDSPort int
@@ -48,6 +49,7 @@ func init() {
 type ManagerConfig struct {
 	ID                string
 	Namespace         string
+	Partition         string
 	ConsulCA          string
 	ConsulAddress     string
 	ConsulXDSPort     int
@@ -117,6 +119,7 @@ func (m *Manager) RenderBootstrap(sdsConfig string) error {
 		SDSCluster:    sdsConfig,
 		ID:            m.ID,
 		Namespace:     m.Namespace,
+		Partition:     m.Partition,
 		ConsulCA:      m.ConsulCA,
 		ConsulAddress: m.ConsulAddress,
 		ConsulXDSPort: m.ConsulXDSPort,
@@ -144,7 +147,8 @@ const bootstrapJSONTemplate = `{
     "cluster": "{{ .ID }}",
     "id": "{{ .ID }}",
     "metadata": {
-      "namespace": "{{if ne .Namespace ""}}{{ .Namespace }}{{else}}default{{end}}"
+      "namespace": "{{if ne .Namespace ""}}{{ .Namespace }}{{else}}default{{end}}",
+      "partition": "{{if ne .Partition ""}}{{ .Partition }}{{else}}default{{end}}"
     }
   },
   "static_resources": {

--- a/internal/envoy/testdata/basic.golden.json
+++ b/internal/envoy/testdata/basic.golden.json
@@ -12,7 +12,8 @@
     "cluster": "6f164d52-7846-45d1-97b1-fc984795572b",
     "id": "6f164d52-7846-45d1-97b1-fc984795572b",
     "metadata": {
-      "namespace": "default"
+      "namespace": "default",
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/internal/envoy/testdata/empty.golden.json
+++ b/internal/envoy/testdata/empty.golden.json
@@ -12,7 +12,8 @@
     "cluster": "",
     "id": "",
     "metadata": {
-      "namespace": "default"
+      "namespace": "default",
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/internal/envoy/testdata/sds.golden.json
+++ b/internal/envoy/testdata/sds.golden.json
@@ -12,7 +12,8 @@
     "cluster": "",
     "id": "",
     "metadata": {
-      "namespace": "default"
+      "namespace": "default",
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/internal/envoy/testdata/tls.golden.json
+++ b/internal/envoy/testdata/tls.golden.json
@@ -12,7 +12,8 @@
     "cluster": "feaf6c11-f46f-4869-ba53-b0cc07f09659",
     "id": "feaf6c11-f46f-4869-ba53-b0cc07f09659",
     "metadata": {
-      "namespace": "default"
+      "namespace": "default",
+      "partition": "default"
     }
   },
   "static_resources": {


### PR DESCRIPTION
### Changes proposed in this PR:

Gateways deployed in non-default partitions weren't properly identifying themselves to xDS servers. This adds the required metadata into the envoy bootstrapping file to make sure that the envoy instance identifies itself properly.

### How I've tested this PR:

Unit tests + verified manually.

### Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
