### PR TITLE
envoy: fix parse SPIFFE path parsing for non-default partitions

### DIFF
--- a/.changelog/547.txt
+++ b/.changelog/547.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+add support for parsing SPIFFE paths for non-default partitions in Consul Enterprise
+```


### PR DESCRIPTION
### Changes proposed in this PR:

Adds SPIFFE parsing logic to handle paths for non-default partitions in Consul Enterprise.

### How I've tested this PR:

- [x] Manual verification
  - Configuring a Kubernetes cluster in a non-default partition requires external Consul servers, which our existing e2e framework does not support. Followup work will be adding a test deploying Consul API Gateway in a non-default partition to the github.com/hashicorp/consul-k8s/ repo, similar to the basic [`TestPartitions_Connect`](https://github.com/hashicorp/consul-k8s/blob/main/acceptance/tests/partitions/partitions_connect_test.go#L30) example.

### How I expect reviewers to test this PR:
- Confirm that deploying a Consul API Gateway in a Kubernetes cluster mapped to a non-default partition in Consul Enterprise succeeds with this patch applied.
- Check whether existing tweaked logic is reasonable, or whether we may want to switch to RegEx parsing here.

### Checklist:
- [ ] ~~Tests added~~
- [ ] CHANGELOG entry added 
  > Run `make changelog-entry` for guidance in authoring a changelog entry, and
  > commit the resulting file, which should have a name matching your PR number.
  > Entries should use imperative present tense (e.g. Add support for...)
