### PR TITLE
Prep release 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
-## UNRELEASED
+## 0.5.4 (May 16, 2023)
 
-## 0.5.3 (March 29, 2022)
+IMPROVEMENTS:
+
+* go: build with Go v1.19.9 [[GH-570](https://github.com/hashicorp/consul-api-gateway/issues/570)]
+
+BUG FIXES:
+
+* add support for parsing SPIFFE paths for non-default partitions in Consul Enterprise [[GH-547](https://github.com/hashicorp/consul-api-gateway/issues/547)]
+
+## 0.5.3 (March 29, 2023)
 
 BUG FIXES:
 
 * Fix envoy deployments not properly identifying themselves when deployed to non-default partitions. [[GH-537](https://github.com/hashicorp/consul-api-gateway/issues/537)]
 
-## 0.5.2 (March 3, 2022)
+## 0.5.2 (March 3, 2023)
 
 IMPROVEMENTS:
 

--- a/config/deployment/deployment.yaml
+++ b/config/deployment/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       serviceAccountName: consul-api-gateway-controller
       containers:
-      - image: hashicorp/consul-api-gateway:0.5.3
+      - image: hashicorp/consul-api-gateway:0.5.4
         command: ["consul-api-gateway", "server", "-consul-address", "$(HOST_IP):8501", "-ca-file", "/ca/tls.crt", "-sds-server-host", "$(IP)", "-k8s-namespace", "$(CONSUL_K8S_NAMESPACE)", "-log-level", "$(LOG_LEVEL)"]
         name: consul-api-gateway-controller
         ports:

--- a/dev/docs/example-setup.md
+++ b/dev/docs/example-setup.md
@@ -72,8 +72,8 @@ We have provided a set of `kustomize` manifests for installing the Consul API Ga
 Apply them to your cluster using the following commands.
 
 ```bash
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.5.3"
-kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.5.3"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.5.4"
+kubectl apply -k "github.com/hashicorp/consul-api-gateway/config?ref=v0.5.4"
 ```
 
 ## Installing the demo Gateway and Mesh Service
@@ -116,7 +116,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.5.3
+- github.com/hashicorp/consul-api-gateway/config/example?ref=v0.5.4
 
 patches:
 - target:

--- a/dev/docs/supported-features.md
+++ b/dev/docs/supported-features.md
@@ -2,7 +2,7 @@
 Below is a list of the Kubernetes Gateway API features supported in the current release of the
 Consul API Gateway.
 
-Consul API Gateway version: **v0.5.3**
+Consul API Gateway version: **v0.5.4**
 Supported K8s Gateway API version: **v1beta1**
 
 Supported features are marked with a grey checkbox

--- a/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/clusterip.deployment.golden.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/discover
         - /bin/consul-api-gateway
         - /bootstrap/
-        image: hashicorp/consul-api-gateway:0.5.3
+        image: hashicorp/consul-api-gateway:0.5.4
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/loadbalancer.deployment.golden.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/discover
         - /bin/consul-api-gateway
         - /bootstrap/
-        image: hashicorp/consul-api-gateway:0.5.3
+        image: hashicorp/consul-api-gateway:0.5.4
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/static-mapping.deployment.golden.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/discover
         - /bin/consul-api-gateway
         - /bootstrap/
-        image: hashicorp/consul-api-gateway:0.5.3
+        image: hashicorp/consul-api-gateway:0.5.4
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
+++ b/internal/k8s/builder/testdata/tls-cert.deployment.golden.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/discover
         - /bin/consul-api-gateway
         - /bootstrap/
-        image: hashicorp/consul-api-gateway:0.5.3
+        image: hashicorp/consul-api-gateway:0.5.4
         name: consul-api-gateway-init
         resources: {}
         volumeMounts:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -17,7 +17,7 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.5.3"
+	Version = "0.5.4"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
> **Note**: Had to do this manually since our Actions workflow is hitting issues with new SSO enforcement for tokens. Compare to #544

Consul API Gateway version being released: `0.5.4` Now requires:
- consul: `1.12.0`
- consul-k8s: `0.49.1`